### PR TITLE
Issue 84 - Erroneous references to RFC 3986

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ DMARC                                                 E. Gustafsson (ed)
 Internet-Draft                                                    Google
 Obsoletes: 7489 (if approved)                               T. Herr (ed)
 Intended status: Standards Track                                Valimail
-Expires: 29 July 2021                                     J. Levine (ed)
+Expires: 14 August 2021                                   J. Levine (ed)
                                                            Standcore LLC
-                                                         25 January 2021
+                                                        10 February 2021
 
 
 Domain-based Message Authentication, Reporting, and Conformance (DMARC)
@@ -43,7 +43,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 29 July 2021.
+   This Internet-Draft will expire on 14 August 2021.
 
 Copyright Notice
 
@@ -54,9 +54,9 @@ Copyright Notice
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                  [Page 1]
+Gustafsson (ed), et al.  Expires 14 August 2021                 [Page 1]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -110,9 +110,9 @@ Table of Contents
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                  [Page 2]
+Gustafsson (ed), et al.  Expires 14 August 2021                 [Page 2]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
      9.5.  Interoperability Issues . . . . . . . . . . . . . . . . .  30
@@ -166,9 +166,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                  [Page 3]
+Gustafsson (ed), et al.  Expires 14 August 2021                 [Page 3]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
 1.  Introduction
@@ -222,9 +222,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                  [Page 4]
+Gustafsson (ed), et al.  Expires 14 August 2021                 [Page 4]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Experience with DMARC has revealed some issues of interoperability
@@ -278,9 +278,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                  [Page 5]
+Gustafsson (ed), et al.  Expires 14 August 2021                 [Page 5]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    *  authentication of entities other than domains, since DMARC is
@@ -334,9 +334,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                  [Page 6]
+Gustafsson (ed), et al.  Expires 14 August 2021                 [Page 6]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Readers are encouraged to be familiar with the contents of [RFC5598].
@@ -390,9 +390,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                  [Page 7]
+Gustafsson (ed), et al.  Expires 14 August 2021                 [Page 7]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Report Receiver:  An operator that receives reports from another
@@ -446,9 +446,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                  [Page 8]
+Gustafsson (ed), et al.  Expires 14 August 2021                 [Page 8]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Each of the underlying authentication technologies that DMARC takes
@@ -502,12 +502,12 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                  [Page 9]
+Gustafsson (ed), et al.  Expires 14 August 2021                 [Page 9]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
-   In relaxed mode, the [RFC3986]-authenticated domain and RFC5322.From
+   In relaxed mode, the [RFC7208]-authenticated domain and RFC5322.From
    domain must have the same Organizational Domain.  In strict mode,
    only an exact DNS domain match is considered to produce Identifier
    Alignment.
@@ -558,9 +558,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 10]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 10]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    4.  Construct a new DNS domain name using the name that matched from
@@ -594,7 +594,7 @@ Internet-Draft                  DMARCbis                    January 2021
    *  [RFC6376], which provides a domain-level identifier in the content
       of the "d=" tag of a validated DKIM-Signature header field.
 
-   *  [RFC3986], which can authenticate both the domain found in an
+   *  [RFC7208], which can authenticate both the domain found in an
       [RFC5322] HELO/EHLO command (the HELO identity) and the domain
       found in an SMTP MAIL command (the MAIL FROM identity).  DMARC
       uses the result of SPF authentication of the MAIL FROM identity.
@@ -614,9 +614,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 11]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 11]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    DMARC's filtering function is based on whether the RFC5322.From field
@@ -670,9 +670,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 12]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 12]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
     +---------------+
@@ -726,9 +726,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 13]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 13]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    3.   Submission service passes relevant details to the DKIM signing
@@ -782,9 +782,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 14]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 14]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    *  It seems the best choice of an identifier on which to focus, as
@@ -838,9 +838,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 15]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 15]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
 6.1.  DMARC Policy Record
@@ -894,9 +894,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 16]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 16]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Thus, a DMARC URI is a URI within which any commas or exclamation
@@ -950,9 +950,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 17]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 17]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
       0:  Generate a DMARC failure report if all underlying
@@ -1006,9 +1006,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 18]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 18]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
       Section 6.6.4 for details.  Note that random selection based on
@@ -1021,7 +1021,7 @@ Internet-Draft                  DMARCbis                    January 2021
       separated plain-text list of values; OPTIONAL; default is "afrf").
       The value of this tag is a list of one or more report formats as
       requested by the Domain Owner to be used when a message fails both
-      [RFC3986] and [RFC6376] tests to report details of the individual
+      [RFC7208] and [RFC6376] tests to report details of the individual
       failure.  The values MUST be present in the registry of reporting
       formats defined in Section 10; a Mail Receiver observing a
       different value SHOULD ignore it or MAY ignore the entire DMARC
@@ -1062,9 +1062,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 19]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 19]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
       above).  The format of the message to be generated MUST follow the
@@ -1118,9 +1118,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 20]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 20]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
      dmarc-uri       = URI [ "!" 1*DIGIT [ "k" / "m" / "g" / "t" ] ]
@@ -1174,9 +1174,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 21]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 21]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
      dmarc-rfmt      = "rf"  *WSP "=" *WSP Keyword *(*WSP ":" Keyword)
@@ -1230,9 +1230,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 22]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 22]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    In order to be processed by DMARC, a message typically needs to
@@ -1286,9 +1286,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 23]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 23]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    4.  Perform SPF validation checks.  The results of this step are
@@ -1342,9 +1342,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 24]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 24]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    1.  Mail Receivers MUST query the DNS for a DMARC TXT record at the
@@ -1398,9 +1398,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 25]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 25]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
 6.6.4.  Message Sampling
@@ -1454,9 +1454,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 26]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 26]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Mail Receivers MAY choose to accept email that fails the DMARC
@@ -1510,9 +1510,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 27]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 27]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
 7.  DMARC Feedback
@@ -1566,9 +1566,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 28]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 28]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
 9.2.  DNS Load and Caching
@@ -1622,9 +1622,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 29]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 29]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Similarly, the text portion of the SMTP reply may be important to
@@ -1678,9 +1678,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 30]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 30]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Additional DMARC constraints occur when a message is processed by
@@ -1734,9 +1734,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 31]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 31]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Meaning:  No DMARC policy record was published for the aligned
@@ -1790,9 +1790,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 32]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 32]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Defined: [RFC8601]
@@ -1846,9 +1846,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 33]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 33]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    To avoid version compatibility issues, tags added to the DMARC
@@ -1902,9 +1902,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 34]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 34]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    its status, which must be one of "current", "experimental", or
@@ -1958,9 +1958,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 35]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 35]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
 11.2.  Attacks on Reporting URIs
@@ -2014,9 +2014,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 36]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 36]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Generally, display name attacks are out of scope for DMARC, as
@@ -2070,9 +2070,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 37]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 37]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Note that the addresses shown in the "ruf" tag receive more
@@ -2126,9 +2126,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 38]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 38]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    [RFC5234]  Crocker, D., Ed. and P. Overell, "Augmented BNF for Syntax
@@ -2182,9 +2182,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 39]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 39]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    [RFC2142]  Crocker, D., "Mailbox Names for Common Services, Roles and
@@ -2238,9 +2238,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 40]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 40]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    [RFC8601]  Kucherawy, M., "Message Header Field for Indicating
@@ -2294,9 +2294,9 @@ A.2.  Method Exclusion
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 41]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 41]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Specifically, consider a Domain Owner that has deployed one of the
@@ -2350,9 +2350,9 @@ A.3.  Sender Header Field
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 42]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 42]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    3.  Allowing multiple ways to discover policy introduces unacceptable
@@ -2406,9 +2406,9 @@ A.5.  Issues with ADSP in Operation
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 43]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 43]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    5.  ADSP has no support for a slow rollout, i.e., no way to configure
@@ -2462,9 +2462,9 @@ A.6.  Organizational Domain Discovery Issues
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 44]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 44]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
 A.6.1.  Public Suffix Lists
@@ -2518,9 +2518,9 @@ B.1.1.  SPF
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 45]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 45]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    In this case, the RFC5322.From parameter includes a DNS domain that
@@ -2574,9 +2574,9 @@ B.1.2.  DKIM
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 46]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 46]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
         DKIM-Signature: v=1; ...; d=sample.net; ...
@@ -2630,9 +2630,9 @@ B.2.1.  Entire Domain, Monitoring Only
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 47]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 47]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    The DMARC policy record might look like this when retrieved using a
@@ -2686,9 +2686,9 @@ B.2.2.  Entire Domain, Monitoring Only, Per-Message Reports
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 48]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 48]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
      ; DMARC record for the domain example.com
@@ -2742,9 +2742,9 @@ B.2.3.  Per-Message Failure Reports Directed to Third Party
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 49]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 49]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    *  Given the DMARC record published by the Domain Owner at
@@ -2798,9 +2798,9 @@ B.2.4.  Subdomain, Sampling, and Multiple Aggregate Report URIs
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 50]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 50]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    *  Receivers should quarantine messages from this Organizational
@@ -2854,9 +2854,9 @@ B.4.  Processing of SMTP Time
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 51]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 51]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    2.  DKIM checks that yield one or more DKIM-authenticated
@@ -2910,9 +2910,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 52]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 52]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    The Mail Receiver is now ready to reply to the DATA command.  If the
@@ -2966,9 +2966,9 @@ B.5.  Utilization of Aggregate Feedback: Example
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 53]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 53]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Domain Owner can begin deployment of authentication technologies
@@ -3022,9 +3022,9 @@ B.6.  mailto Transport Example
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 54]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 54]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
 Acknowledgements
@@ -3078,5 +3078,5 @@ Authors' Addresses
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 55]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 55]
 ```

--- a/draft-ietf-dmarc-dmarcbis-01.html
+++ b/draft-ietf-dmarc-dmarcbis-01.html
@@ -1109,11 +1109,11 @@ dd.break {
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">DMARCbis</td>
-<td class="right">January 2021</td>
+<td class="right">February 2021</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Gustafsson (ed), et al.</td>
-<td class="center">Expires 29 July 2021</td>
+<td class="center">Expires 14 August 2021</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1129,12 +1129,12 @@ dd.break {
 <a href="https://www.rfc-editor.org/rfc/rfc7489" class="eref">7489</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-01-25" class="published">25 January 2021</time>
+<time datetime="2021-02-10" class="published">10 February 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2021-07-29">29 July 2021</time></dd>
+<dd class="expires"><time datetime="2021-08-14">14 August 2021</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1183,7 +1183,7 @@ choices for incoming mail.<a href="#section-abstract-2" class="pilcrow">¶</a></
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 29 July 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 14 August 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1802,7 +1802,7 @@ and verifies.<a href="#section-3.1.1-6" class="pilcrow">¶</a></p>
           </h4>
 <p id="section-3.1.2-1">DMARC permits Identifier Alignment, based on the result of an SPF
 authentication, to be strict or relaxed.<a href="#section-3.1.2-1" class="pilcrow">¶</a></p>
-<p id="section-3.1.2-2">In relaxed mode, the <span>[<a href="#RFC3986" class="xref">RFC3986</a>]</span>-authenticated domain and RFC5322.From
+<p id="section-3.1.2-2">In relaxed mode, the <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span>-authenticated domain and RFC5322.From
 domain must have the same Organizational Domain.  In strict mode,
 only an exact DNS domain match is considered to produce Identifier
 Alignment.<a href="#section-3.1.2-2" class="pilcrow">¶</a></p>
@@ -1902,7 +1902,7 @@ are supported in this version of DMARC:<a href="#section-4.1-1" class="pilcrow">
 the "d=" tag of a validated DKIM-Signature header field.<a href="#section-4.1-2.1.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-4.1-2.2">
-            <p id="section-4.1-2.2.1"><span>[<a href="#RFC3986" class="xref">RFC3986</a>]</span>, which can authenticate both the domain found in an <span>[<a href="#RFC5322" class="xref">RFC5322</a>]</span>
+            <p id="section-4.1-2.2.1"><span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span>, which can authenticate both the domain found in an <span>[<a href="#RFC5322" class="xref">RFC5322</a>]</span>
 HELO/EHLO command (the HELO identity) and the domain found in an
 SMTP MAIL command (the MAIL FROM identity).  DMARC uses the result
 of SPF authentication of the MAIL FROM identity.  Section 2.4 of
@@ -2311,7 +2311,7 @@ else
 separated plain-text list of values; OPTIONAL; default is "afrf").
 The value of this tag is a list of one or more report formats as
 requested by the Domain Owner to be used when a message fails both
-<span>[<a href="#RFC3986" class="xref">RFC3986</a>]</span> and <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span> tests to report details of the individual
+<span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span> and <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span> tests to report details of the individual
 failure.  The values MUST be present in the registry of reporting
 formats defined in <a href="#iana-considerations" class="xref">Section 10</a>; a Mail Receiver observing a
 different value SHOULD ignore it or MAY ignore the entire DMARC

--- a/draft-ietf-dmarc-dmarcbis-01.txt
+++ b/draft-ietf-dmarc-dmarcbis-01.txt
@@ -6,9 +6,9 @@ DMARC                                                 E. Gustafsson (ed)
 Internet-Draft                                                    Google
 Obsoletes: 7489 (if approved)                               T. Herr (ed)
 Intended status: Standards Track                                Valimail
-Expires: 29 July 2021                                     J. Levine (ed)
+Expires: 14 August 2021                                   J. Levine (ed)
                                                            Standcore LLC
-                                                         25 January 2021
+                                                        10 February 2021
 
 
 Domain-based Message Authentication, Reporting, and Conformance (DMARC)
@@ -42,7 +42,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 29 July 2021.
+   This Internet-Draft will expire on 14 August 2021.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                  [Page 1]
+Gustafsson (ed), et al.  Expires 14 August 2021                 [Page 1]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                  [Page 2]
+Gustafsson (ed), et al.  Expires 14 August 2021                 [Page 2]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
      9.5.  Interoperability Issues . . . . . . . . . . . . . . . . .  30
@@ -165,9 +165,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                  [Page 3]
+Gustafsson (ed), et al.  Expires 14 August 2021                 [Page 3]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
 1.  Introduction
@@ -221,9 +221,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                  [Page 4]
+Gustafsson (ed), et al.  Expires 14 August 2021                 [Page 4]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Experience with DMARC has revealed some issues of interoperability
@@ -277,9 +277,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                  [Page 5]
+Gustafsson (ed), et al.  Expires 14 August 2021                 [Page 5]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    *  authentication of entities other than domains, since DMARC is
@@ -333,9 +333,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                  [Page 6]
+Gustafsson (ed), et al.  Expires 14 August 2021                 [Page 6]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Readers are encouraged to be familiar with the contents of [RFC5598].
@@ -389,9 +389,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                  [Page 7]
+Gustafsson (ed), et al.  Expires 14 August 2021                 [Page 7]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Report Receiver:  An operator that receives reports from another
@@ -445,9 +445,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                  [Page 8]
+Gustafsson (ed), et al.  Expires 14 August 2021                 [Page 8]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Each of the underlying authentication technologies that DMARC takes
@@ -501,12 +501,12 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                  [Page 9]
+Gustafsson (ed), et al.  Expires 14 August 2021                 [Page 9]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
-   In relaxed mode, the [RFC3986]-authenticated domain and RFC5322.From
+   In relaxed mode, the [RFC7208]-authenticated domain and RFC5322.From
    domain must have the same Organizational Domain.  In strict mode,
    only an exact DNS domain match is considered to produce Identifier
    Alignment.
@@ -557,9 +557,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 10]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 10]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    4.  Construct a new DNS domain name using the name that matched from
@@ -593,7 +593,7 @@ Internet-Draft                  DMARCbis                    January 2021
    *  [RFC6376], which provides a domain-level identifier in the content
       of the "d=" tag of a validated DKIM-Signature header field.
 
-   *  [RFC3986], which can authenticate both the domain found in an
+   *  [RFC7208], which can authenticate both the domain found in an
       [RFC5322] HELO/EHLO command (the HELO identity) and the domain
       found in an SMTP MAIL command (the MAIL FROM identity).  DMARC
       uses the result of SPF authentication of the MAIL FROM identity.
@@ -613,9 +613,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 11]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 11]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    DMARC's filtering function is based on whether the RFC5322.From field
@@ -669,9 +669,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 12]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 12]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
     +---------------+
@@ -725,9 +725,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 13]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 13]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    3.   Submission service passes relevant details to the DKIM signing
@@ -781,9 +781,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 14]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 14]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    *  It seems the best choice of an identifier on which to focus, as
@@ -837,9 +837,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 15]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 15]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
 6.1.  DMARC Policy Record
@@ -893,9 +893,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 16]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 16]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Thus, a DMARC URI is a URI within which any commas or exclamation
@@ -949,9 +949,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 17]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 17]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
       0:  Generate a DMARC failure report if all underlying
@@ -1005,9 +1005,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 18]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 18]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
       Section 6.6.4 for details.  Note that random selection based on
@@ -1020,7 +1020,7 @@ Internet-Draft                  DMARCbis                    January 2021
       separated plain-text list of values; OPTIONAL; default is "afrf").
       The value of this tag is a list of one or more report formats as
       requested by the Domain Owner to be used when a message fails both
-      [RFC3986] and [RFC6376] tests to report details of the individual
+      [RFC7208] and [RFC6376] tests to report details of the individual
       failure.  The values MUST be present in the registry of reporting
       formats defined in Section 10; a Mail Receiver observing a
       different value SHOULD ignore it or MAY ignore the entire DMARC
@@ -1061,9 +1061,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 19]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 19]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
       above).  The format of the message to be generated MUST follow the
@@ -1117,9 +1117,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 20]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 20]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
      dmarc-uri       = URI [ "!" 1*DIGIT [ "k" / "m" / "g" / "t" ] ]
@@ -1173,9 +1173,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 21]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 21]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
      dmarc-rfmt      = "rf"  *WSP "=" *WSP Keyword *(*WSP ":" Keyword)
@@ -1229,9 +1229,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 22]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 22]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    In order to be processed by DMARC, a message typically needs to
@@ -1285,9 +1285,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 23]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 23]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    4.  Perform SPF validation checks.  The results of this step are
@@ -1341,9 +1341,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 24]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 24]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    1.  Mail Receivers MUST query the DNS for a DMARC TXT record at the
@@ -1397,9 +1397,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 25]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 25]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
 6.6.4.  Message Sampling
@@ -1453,9 +1453,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 26]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 26]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Mail Receivers MAY choose to accept email that fails the DMARC
@@ -1509,9 +1509,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 27]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 27]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
 7.  DMARC Feedback
@@ -1565,9 +1565,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 28]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 28]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
 9.2.  DNS Load and Caching
@@ -1621,9 +1621,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 29]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 29]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Similarly, the text portion of the SMTP reply may be important to
@@ -1677,9 +1677,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 30]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 30]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Additional DMARC constraints occur when a message is processed by
@@ -1733,9 +1733,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 31]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 31]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Meaning:  No DMARC policy record was published for the aligned
@@ -1789,9 +1789,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 32]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 32]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Defined: [RFC8601]
@@ -1845,9 +1845,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 33]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 33]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    To avoid version compatibility issues, tags added to the DMARC
@@ -1901,9 +1901,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 34]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 34]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    its status, which must be one of "current", "experimental", or
@@ -1957,9 +1957,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 35]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 35]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
 11.2.  Attacks on Reporting URIs
@@ -2013,9 +2013,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 36]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 36]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Generally, display name attacks are out of scope for DMARC, as
@@ -2069,9 +2069,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 37]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 37]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Note that the addresses shown in the "ruf" tag receive more
@@ -2125,9 +2125,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 38]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 38]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    [RFC5234]  Crocker, D., Ed. and P. Overell, "Augmented BNF for Syntax
@@ -2181,9 +2181,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 39]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 39]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    [RFC2142]  Crocker, D., "Mailbox Names for Common Services, Roles and
@@ -2237,9 +2237,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 40]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 40]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    [RFC8601]  Kucherawy, M., "Message Header Field for Indicating
@@ -2293,9 +2293,9 @@ A.2.  Method Exclusion
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 41]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 41]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Specifically, consider a Domain Owner that has deployed one of the
@@ -2349,9 +2349,9 @@ A.3.  Sender Header Field
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 42]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 42]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    3.  Allowing multiple ways to discover policy introduces unacceptable
@@ -2405,9 +2405,9 @@ A.5.  Issues with ADSP in Operation
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 43]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 43]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    5.  ADSP has no support for a slow rollout, i.e., no way to configure
@@ -2461,9 +2461,9 @@ A.6.  Organizational Domain Discovery Issues
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 44]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 44]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
 A.6.1.  Public Suffix Lists
@@ -2517,9 +2517,9 @@ B.1.1.  SPF
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 45]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 45]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    In this case, the RFC5322.From parameter includes a DNS domain that
@@ -2573,9 +2573,9 @@ B.1.2.  DKIM
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 46]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 46]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
         DKIM-Signature: v=1; ...; d=sample.net; ...
@@ -2629,9 +2629,9 @@ B.2.1.  Entire Domain, Monitoring Only
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 47]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 47]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    The DMARC policy record might look like this when retrieved using a
@@ -2685,9 +2685,9 @@ B.2.2.  Entire Domain, Monitoring Only, Per-Message Reports
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 48]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 48]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
      ; DMARC record for the domain example.com
@@ -2741,9 +2741,9 @@ B.2.3.  Per-Message Failure Reports Directed to Third Party
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 49]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 49]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    *  Given the DMARC record published by the Domain Owner at
@@ -2797,9 +2797,9 @@ B.2.4.  Subdomain, Sampling, and Multiple Aggregate Report URIs
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 50]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 50]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    *  Receivers should quarantine messages from this Organizational
@@ -2853,9 +2853,9 @@ B.4.  Processing of SMTP Time
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 51]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 51]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    2.  DKIM checks that yield one or more DKIM-authenticated
@@ -2909,9 +2909,9 @@ Internet-Draft                  DMARCbis                    January 2021
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 52]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 52]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    The Mail Receiver is now ready to reply to the DATA command.  If the
@@ -2965,9 +2965,9 @@ B.5.  Utilization of Aggregate Feedback: Example
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 53]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 53]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
    Domain Owner can begin deployment of authentication technologies
@@ -3021,9 +3021,9 @@ B.6.  mailto Transport Example
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 54]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 54]
 
-Internet-Draft                  DMARCbis                    January 2021
+Internet-Draft                  DMARCbis                   February 2021
 
 
 Acknowledgements
@@ -3077,4 +3077,4 @@ Authors' Addresses
 
 
 
-Gustafsson (ed), et al.   Expires 29 July 2021                 [Page 55]
+Gustafsson (ed), et al.  Expires 14 August 2021                [Page 55]

--- a/draft-ietf-dmarc-dmarcbis-01.xml
+++ b/draft-ietf-dmarc-dmarcbis-01.xml
@@ -297,7 +297,7 @@ and verifies.</t>
 <section anchor="spf-identifiers"><name>SPF-Authenticated Identifiers</name>
 <t>DMARC permits Identifier Alignment, based on the result of an SPF
 authentication, to be strict or relaxed.</t>
-<t>In relaxed mode, the <xref target="RFC3986"></xref>-authenticated domain and RFC5322.From
+<t>In relaxed mode, the <xref target="RFC7208"></xref>-authenticated domain and RFC5322.From
 domain must have the same Organizational Domain.  In strict mode,
 only an exact DNS domain match is considered to produce Identifier
 Alignment.</t>
@@ -376,7 +376,7 @@ are supported in this version of DMARC:</t>
 <li><t><xref target="RFC6376"></xref>, which provides a domain-level identifier in the content of
 the &quot;d=&quot; tag of a validated DKIM-Signature header field.</t>
 </li>
-<li><t><xref target="RFC3986"></xref>, which can authenticate both the domain found in an <xref target="RFC5322"></xref>
+<li><t><xref target="RFC7208"></xref>, which can authenticate both the domain found in an <xref target="RFC5322"></xref>
 HELO/EHLO command (the HELO identity) and the domain found in an
 SMTP MAIL command (the MAIL FROM identity).  DMARC uses the result
 of SPF authentication of the MAIL FROM identity.  Section 2.4 of
@@ -717,7 +717,7 @@ else
 separated plain-text list of values; OPTIONAL; default is &quot;afrf&quot;).
 The value of this tag is a list of one or more report formats as
 requested by the Domain Owner to be used when a message fails both
-<xref target="RFC3986"></xref> and <xref target="RFC6376"></xref> tests to report details of the individual
+<xref target="RFC7208"></xref> and <xref target="RFC6376"></xref> tests to report details of the individual
 failure.  The values MUST be present in the registry of reporting
 formats defined in <xref target="iana-considerations"></xref>; a Mail Receiver observing a
 different value SHOULD ignore it or MAY ignore the entire DMARC

--- a/draft-ietf-dmarc-dmarcbis.md
+++ b/draft-ietf-dmarc-dmarcbis.md
@@ -345,7 +345,7 @@ and verifies.
 DMARC permits Identifier Alignment, based on the result of an SPF
 authentication, to be strict or relaxed.
 
-In relaxed mode, the [@!RFC3986]-authenticated domain and RFC5322.From
+In relaxed mode, the [@!RFC7208]-authenticated domain and RFC5322.From
 domain must have the same Organizational Domain.  In strict mode,
 only an exact DNS domain match is considered to produce Identifier
 Alignment.
@@ -426,7 +426,7 @@ are supported in this version of DMARC:
 *  [@!RFC6376], which provides a domain-level identifier in the content of
    the "d=" tag of a validated DKIM-Signature header field.
 
-*  [@!RFC3986], which can authenticate both the domain found in an [@!RFC5322]
+*  [@!RFC7208], which can authenticate both the domain found in an [@!RFC5322]
    HELO/EHLO command (the HELO identity) and the domain found in an
    SMTP MAIL command (the MAIL FROM identity).  DMARC uses the result
    of SPF authentication of the MAIL FROM identity.  Section 2.4 of
@@ -783,7 +783,7 @@ rf:
 separated plain-text list of values; OPTIONAL; default is "afrf").
 The value of this tag is a list of one or more report formats as
 requested by the Domain Owner to be used when a message fails both
-[@!RFC3986] and [@!RFC6376] tests to report details of the individual
+[@!RFC7208] and [@!RFC6376] tests to report details of the individual
 failure.  The values MUST be present in the registry of reporting
 formats defined in (#iana-considerations); a Mail Receiver observing a
 different value SHOULD ignore it or MAY ignore the entire DMARC


### PR DESCRIPTION
The erroneous refs should've been to RFC 7208. They are now.