### PR TITLE
Rev 04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # built using mmark 2.
 
-VERSION = 03
+VERSION = 04
 DOCNAME = draft-ietf-dmarc-dmarcbis
 
 all: $(DOCNAME)-$(VERSION).txt $(DOCNAME)-$(VERSION).html

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ DMARC                                                       T. Herr (ed)
 Internet-Draft                                                  Valimail
 Obsoletes: 7489 (if approved)                             J. Levine (ed)
 Intended status: Standards Track                           Standcore LLC
-Expires: 24 March 2022                                 20 September 2021
+Expires: 21 May 2022                                    17 November 2021
 
 
 Domain-based Message Authentication, Reporting, and Conformance (DMARC)
@@ -42,7 +42,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 24 March 2022.
+   This Internet-Draft will expire on 21 May 2022.
 
 Copyright Notice
 
@@ -54,9 +54,9 @@ Copyright Notice
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                 [Page 1]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 1]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -95,165 +95,165 @@ Table of Contents
        3.14.2.  SPF-Authenticated Identifiers  . . . . . . . . . . .  12
        3.14.3.  Alignment and Extension Technologies . . . . . . . .  13
      3.15. Determining The Organizational Domain . . . . . . . . . .  13
-   4.  Overview  . . . . . . . . . . . . . . . . . . . . . . . . . .  13
+   4.  Overview  . . . . . . . . . . . . . . . . . . . . . . . . . .  14
      4.1.  Authentication Mechanisms . . . . . . . . . . . . . . . .  14
      4.2.  Key Concepts  . . . . . . . . . . . . . . . . . . . . . .  14
      4.3.  Flow Diagram  . . . . . . . . . . . . . . . . . . . . . .  15
-   5.  Use of RFC5322.From . . . . . . . . . . . . . . . . . . . . .  16
+   5.  Use of RFC5322.From . . . . . . . . . . . . . . . . . . . . .  17
    6.  Policy  . . . . . . . . . . . . . . . . . . . . . . . . . . .  17
-     6.1.  DMARC Policy Record . . . . . . . . . . . . . . . . . . .  17
-     6.2.  DMARC URIs  . . . . . . . . . . . . . . . . . . . . . . .  18
-     6.3.  General Record Format . . . . . . . . . . . . . . . . . .  18
-     6.4.  Formal Definition . . . . . . . . . . . . . . . . . . . .  22
-     6.5.  Domain Owner Actions  . . . . . . . . . . . . . . . . . .  23
-       6.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  23
+     6.1.  DMARC Policy Record . . . . . . . . . . . . . . . . . . .  18
+     6.2.  DMARC URIs  . . . . . . . . . . . . . . . . . . . . . . .  19
+     6.3.  General Record Format . . . . . . . . . . . . . . . . . .  19
+     6.4.  Formal Definition . . . . . . . . . . . . . . . . . . . .  23
+     6.5.  Domain Owner Actions  . . . . . . . . . . . . . . . . . .  24
+       6.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  24
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                 [Page 2]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 2]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
        6.5.2.  Configure Sending System for DKIM Signing Using an
                Aligned Domain  . . . . . . . . . . . . . . . . . . .  24
-       6.5.3.  Setup a Mailbox to Receive Aggregate Reports  . . . .  24
-       6.5.4.  Publish a DMARC Policy for the Author Domain  . . . .  24
+       6.5.3.  Setup a Mailbox to Receive Aggregate Reports  . . . .  25
+       6.5.4.  Publish a DMARC Policy for the Author Domain  . . . .  25
        6.5.5.  Collect and Analyze Reports and Adjust
                Authentication  . . . . . . . . . . . . . . . . . . .  25
-       6.5.6.  Decide If and When to Update DMARC Policy . . . . . .  25
-     6.6.  PSO Actions . . . . . . . . . . . . . . . . . . . . . . .  25
-     6.7.  Mail Receiver Actions . . . . . . . . . . . . . . . . . .  25
-       6.7.1.  Extract Author Domain . . . . . . . . . . . . . . . .  25
-       6.7.2.  Determine Handling Policy . . . . . . . . . . . . . .  26
-       6.7.3.  Policy Discovery  . . . . . . . . . . . . . . . . . .  27
-       6.7.4.  Store Results of DMARC Processing . . . . . . . . . .  29
-       6.7.5.  Send Aggregate Reports  . . . . . . . . . . . . . . .  29
-     6.8.  Policy Enforcement Considerations . . . . . . . . . . . .  30
-   7.  DMARC Feedback  . . . . . . . . . . . . . . . . . . . . . . .  31
-   8.  Other Topics  . . . . . . . . . . . . . . . . . . . . . . . .  31
-     8.1.  Issues Specific to SPF  . . . . . . . . . . . . . . . . .  31
-     8.2.  DNS Load and Caching  . . . . . . . . . . . . . . . . . .  32
-     8.3.  Rejecting Messages  . . . . . . . . . . . . . . . . . . .  32
-     8.4.  Identifier Alignment Considerations . . . . . . . . . . .  33
-     8.5.  Interoperability Issues . . . . . . . . . . . . . . . . .  33
-   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  34
-     9.1.  Authentication-Results Method Registry Update . . . . . .  34
-     9.2.  Authentication-Results Result Registry Update . . . . . .  35
-     9.3.  Feedback Report Header Fields Registry Update . . . . . .  36
-     9.4.  DMARC Tag Registry  . . . . . . . . . . . . . . . . . . .  36
-     9.5.  DMARC Report Format Registry  . . . . . . . . . . . . . .  38
+       6.5.6.  Decide If and When to Update DMARC Policy . . . . . .  26
+     6.6.  PSO Actions . . . . . . . . . . . . . . . . . . . . . . .  26
+     6.7.  Mail Receiver Actions . . . . . . . . . . . . . . . . . .  26
+       6.7.1.  Extract Author Domain . . . . . . . . . . . . . . . .  26
+       6.7.2.  Determine Handling Policy . . . . . . . . . . . . . .  27
+       6.7.3.  Policy Discovery  . . . . . . . . . . . . . . . . . .  28
+       6.7.4.  Store Results of DMARC Processing . . . . . . . . . .  30
+       6.7.5.  Send Aggregate Reports  . . . . . . . . . . . . . . .  30
+     6.8.  Policy Enforcement Considerations . . . . . . . . . . . .  31
+   7.  DMARC Feedback  . . . . . . . . . . . . . . . . . . . . . . .  32
+   8.  Other Topics  . . . . . . . . . . . . . . . . . . . . . . . .  32
+     8.1.  Issues Specific to SPF  . . . . . . . . . . . . . . . . .  32
+     8.2.  DNS Load and Caching  . . . . . . . . . . . . . . . . . .  33
+     8.3.  Rejecting Messages  . . . . . . . . . . . . . . . . . . .  33
+     8.4.  Identifier Alignment Considerations . . . . . . . . . . .  34
+     8.5.  Interoperability Issues . . . . . . . . . . . . . . . . .  34
+   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  35
+     9.1.  Authentication-Results Method Registry Update . . . . . .  35
+     9.2.  Authentication-Results Result Registry Update . . . . . .  36
+     9.3.  Feedback Report Header Fields Registry Update . . . . . .  37
+     9.4.  DMARC Tag Registry  . . . . . . . . . . . . . . . . . . .  37
+     9.5.  DMARC Report Format Registry  . . . . . . . . . . . . . .  39
      9.6.  Underscored and Globally Scoped DNS Node Names
-           Registry  . . . . . . . . . . . . . . . . . . . . . . . .  38
-   10. Security Considerations . . . . . . . . . . . . . . . . . . .  38
-     10.1.  Authentication Methods . . . . . . . . . . . . . . . . .  39
-     10.2.  Attacks on Reporting URIs  . . . . . . . . . . . . . . .  39
-     10.3.  DNS Security . . . . . . . . . . . . . . . . . . . . . .  39
-     10.4.  Display Name Attacks . . . . . . . . . . . . . . . . . .  40
-     10.5.  External Reporting Addresses . . . . . . . . . . . . . .  41
-     10.6.  Secure Protocols . . . . . . . . . . . . . . . . . . . .  41
-   11. Normative References  . . . . . . . . . . . . . . . . . . . .  41
-   12. Informative References  . . . . . . . . . . . . . . . . . . .  43
-   Appendix A.  Technology Considerations  . . . . . . . . . . . . .  45
-     A.1.  S/MIME  . . . . . . . . . . . . . . . . . . . . . . . . .  45
-     A.2.  Method Exclusion  . . . . . . . . . . . . . . . . . . . .  45
-     A.3.  Sender Header Field . . . . . . . . . . . . . . . . . . .  46
-     A.4.  Domain Existence Test . . . . . . . . . . . . . . . . . .  47
-     A.5.  Issues with ADSP in Operation . . . . . . . . . . . . . .  47
-     A.6.  Organizational Domain Discovery Issues  . . . . . . . . .  48
-       A.6.1.  Public Suffix Lists . . . . . . . . . . . . . . . . .  49
-     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  49
+           Registry  . . . . . . . . . . . . . . . . . . . . . . . .  39
+   10. Security Considerations . . . . . . . . . . . . . . . . . . .  39
+     10.1.  Authentication Methods . . . . . . . . . . . . . . . . .  40
+     10.2.  Attacks on Reporting URIs  . . . . . . . . . . . . . . .  40
+     10.3.  DNS Security . . . . . . . . . . . . . . . . . . . . . .  40
+     10.4.  Display Name Attacks . . . . . . . . . . . . . . . . . .  41
+     10.5.  External Reporting Addresses . . . . . . . . . . . . . .  42
+     10.6.  Secure Protocols . . . . . . . . . . . . . . . . . . . .  42
+   11. Normative References  . . . . . . . . . . . . . . . . . . . .  42
+   12. Informative References  . . . . . . . . . . . . . . . . . . .  44
+   Appendix A.  Technology Considerations  . . . . . . . . . . . . .  46
+     A.1.  S/MIME  . . . . . . . . . . . . . . . . . . . . . . . . .  46
+     A.2.  Method Exclusion  . . . . . . . . . . . . . . . . . . . .  46
+     A.3.  Sender Header Field . . . . . . . . . . . . . . . . . . .  47
+     A.4.  Domain Existence Test . . . . . . . . . . . . . . . . . .  48
+     A.5.  Issues with ADSP in Operation . . . . . . . . . . . . . .  48
+     A.6.  Organizational Domain Discovery Issues  . . . . . . . . .  49
+       A.6.1.  Public Suffix Lists . . . . . . . . . . . . . . . . .  50
+     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  50
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                 [Page 3]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 3]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
-   Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  50
-     B.1.  Identifier Alignment Examples . . . . . . . . . . . . . .  50
-       B.1.1.  SPF . . . . . . . . . . . . . . . . . . . . . . . . .  50
-       B.1.2.  DKIM  . . . . . . . . . . . . . . . . . . . . . . . .  51
-     B.2.  Domain Owner Example  . . . . . . . . . . . . . . . . . .  52
-       B.2.1.  Entire Domain, Monitoring Only  . . . . . . . . . . .  52
+   Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  51
+     B.1.  Identifier Alignment Examples . . . . . . . . . . . . . .  51
+       B.1.1.  SPF . . . . . . . . . . . . . . . . . . . . . . . . .  51
+       B.1.2.  DKIM  . . . . . . . . . . . . . . . . . . . . . . . .  52
+     B.2.  Domain Owner Example  . . . . . . . . . . . . . . . . . .  53
+       B.2.1.  Entire Domain, Monitoring Only  . . . . . . . . . . .  53
        B.2.2.  Entire Domain, Monitoring Only, Per-Message
-               Reports . . . . . . . . . . . . . . . . . . . . . . .  53
+               Reports . . . . . . . . . . . . . . . . . . . . . . .  54
        B.2.3.  Per-Message Failure Reports Directed to Third
-               Party . . . . . . . . . . . . . . . . . . . . . . . .  54
+               Party . . . . . . . . . . . . . . . . . . . . . . . .  55
        B.2.4.  Subdomain, Testing, and Multiple Aggregate Report
-               URIs  . . . . . . . . . . . . . . . . . . . . . . . .  56
-     B.3.  Mail Receiver Example . . . . . . . . . . . . . . . . . .  57
-     B.4.  Processing of SMTP Time . . . . . . . . . . . . . . . . .  58
-     B.5.  Utilization of Aggregate Feedback: Example  . . . . . . .  59
-   Appendix C.  Change Log . . . . . . . . . . . . . . . . . . . . .  60
-     C.1.  January 5, 2021 . . . . . . . . . . . . . . . . . . . . .  60
+               URIs  . . . . . . . . . . . . . . . . . . . . . . . .  57
+     B.3.  Mail Receiver Example . . . . . . . . . . . . . . . . . .  58
+     B.4.  Processing of SMTP Time . . . . . . . . . . . . . . . . .  59
+     B.5.  Utilization of Aggregate Feedback: Example  . . . . . . .  60
+   Appendix C.  Change Log . . . . . . . . . . . . . . . . . . . . .  61
+     C.1.  January 5, 2021 . . . . . . . . . . . . . . . . . . . . .  61
        C.1.1.  Ticket 80 - DMARCbis SHould Have Clear and Concise
-               Defintion of DMARC  . . . . . . . . . . . . . . . . .  60
-     C.2.  February 4, 2021  . . . . . . . . . . . . . . . . . . . .  60
-       C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208 . . . . . . . . . . .  60
-     C.3.  February 10, 2021 . . . . . . . . . . . . . . . . . . . .  61
-       C.3.1.  Ticket 84 - Remove Erroneous References to RFC3986  .  61
-     C.4.  March 1, 2021 . . . . . . . . . . . . . . . . . . . . . .  61
-       C.4.1.  Design Team Work Begins . . . . . . . . . . . . . . .  61
-     C.5.  March 8, 2021 . . . . . . . . . . . . . . . . . . . . . .  61
-       C.5.1.  Removed E.  Gustafsson as editor  . . . . . . . . . .  61
-       C.5.2.  Ticket 3 - Two tiny nits  . . . . . . . . . . . . . .  61
-       C.5.3.  Ticket 4 - Definition of "fo" parameter . . . . . . .  61
-     C.6.  March 16, 2021  . . . . . . . . . . . . . . . . . . . . .  61
-       C.6.1.  Ticket 7 - ABNF for dmarc-record is slightly wrong  .  61
-       C.6.2.  Ticket 26 - ABNF for pct allows "999" . . . . . . . .  62
-     C.7.  March 23, 2021  . . . . . . . . . . . . . . . . . . . . .  62
+               Defintion of DMARC  . . . . . . . . . . . . . . . . .  61
+     C.2.  February 4, 2021  . . . . . . . . . . . . . . . . . . . .  61
+       C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208 . . . . . . . . . . .  61
+     C.3.  February 10, 2021 . . . . . . . . . . . . . . . . . . . .  62
+       C.3.1.  Ticket 84 - Remove Erroneous References to RFC3986  .  62
+     C.4.  March 1, 2021 . . . . . . . . . . . . . . . . . . . . . .  62
+       C.4.1.  Design Team Work Begins . . . . . . . . . . . . . . .  62
+     C.5.  March 8, 2021 . . . . . . . . . . . . . . . . . . . . . .  62
+       C.5.1.  Removed E.  Gustafsson as editor  . . . . . . . . . .  62
+       C.5.2.  Ticket 3 - Two tiny nits  . . . . . . . . . . . . . .  62
+       C.5.3.  Ticket 4 - Definition of "fo" parameter . . . . . . .  62
+     C.6.  March 16, 2021  . . . . . . . . . . . . . . . . . . . . .  62
+       C.6.1.  Ticket 7 - ABNF for dmarc-record is slightly wrong  .  62
+       C.6.2.  Ticket 26 - ABNF for pct allows "999" . . . . . . . .  63
+     C.7.  March 23, 2021  . . . . . . . . . . . . . . . . . . . . .  63
        C.7.1.  Ticket 75 - Using wording alternatives to
-               'disposition', 'dispose', and the like  . . . . . . .  62
+               'disposition', 'dispose', and the like  . . . . . . .  63
        C.7.2.  Ticket 72 - Remove absolute requirement for p= tag in
-               DMARC record  . . . . . . . . . . . . . . . . . . . .  62
-     C.8.  March 29, 2021  . . . . . . . . . . . . . . . . . . . . .  62
+               DMARC record  . . . . . . . . . . . . . . . . . . . .  63
+     C.8.  March 29, 2021  . . . . . . . . . . . . . . . . . . . . .  63
        C.8.1.  Ticket 54 - Remove or expand limits on number of
-               recipients per report . . . . . . . . . . . . . . . .  62
-     C.9.  April 12, 2021  . . . . . . . . . . . . . . . . . . . . .  63
-       C.9.1.  Ticket 50 - Remove ri= tag  . . . . . . . . . . . . .  63
+               recipients per report . . . . . . . . . . . . . . . .  63
+     C.9.  April 12, 2021  . . . . . . . . . . . . . . . . . . . . .  64
+       C.9.1.  Ticket 50 - Remove ri= tag  . . . . . . . . . . . . .  64
        C.9.2.  Ticket 66 - Define what it means to have implemented
-               DMARC . . . . . . . . . . . . . . . . . . . . . . . .  63
-       C.9.3.  Ticket 96 - Tweaks to Abstract and Introduction . . .  63
-     C.10. April 13, 2021  . . . . . . . . . . . . . . . . . . . . .  63
+               DMARC . . . . . . . . . . . . . . . . . . . . . . . .  64
+       C.9.3.  Ticket 96 - Tweaks to Abstract and Introduction . . .  64
+     C.10. April 13, 2021  . . . . . . . . . . . . . . . . . . . . .  64
        C.10.1.  Ticket 53 - Remove reporting message size
-               chunking  . . . . . . . . . . . . . . . . . . . . . .  63
+               chunking  . . . . . . . . . . . . . . . . . . . . . .  64
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                 [Page 4]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 4]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
        C.10.2.  Ticket 52 - Remove strict alignment (and adkim and
-               aspf tags)  . . . . . . . . . . . . . . . . . . . . .  63
-       C.10.3.  Ticket 47 - Remove pct= tag  . . . . . . . . . . . .  63
-       C.10.4.  Ticket 2 - Flow of operations text in dmarc-base . .  64
-     C.11. April 14, 2021  . . . . . . . . . . . . . . . . . . . . .  64
+               aspf tags)  . . . . . . . . . . . . . . . . . . . . .  64
+       C.10.3.  Ticket 47 - Remove pct= tag  . . . . . . . . . . . .  64
+       C.10.4.  Ticket 2 - Flow of operations text in dmarc-base . .  65
+     C.11. April 14, 2021  . . . . . . . . . . . . . . . . . . . . .  65
        C.11.1.  Ticket 107 - DMARCbis should take a stand on
-               multi-valued From fields  . . . . . . . . . . . . . .  64
-       C.11.2.  Ticket 82 - Deprecate rf= and maybe fo= tag  . . . .  64
+               multi-valued From fields  . . . . . . . . . . . . . .  65
+       C.11.2.  Ticket 82 - Deprecate rf= and maybe fo= tag  . . . .  65
        C.11.3.  Ticket 85 - Proposed change to wording describing 'p'
-               tag and values  . . . . . . . . . . . . . . . . . . .  64
-     C.12. April 15, 2021  . . . . . . . . . . . . . . . . . . . . .  64
-       C.12.1.  Ticket 86 - A-R results for DMARC  . . . . . . . . .  64
+               tag and values  . . . . . . . . . . . . . . . . . . .  65
+     C.12. April 15, 2021  . . . . . . . . . . . . . . . . . . . . .  65
+       C.12.1.  Ticket 86 - A-R results for DMARC  . . . . . . . . .  65
        C.12.2.  Ticket 62 - Make aggregate reporting a normative
-               MUST  . . . . . . . . . . . . . . . . . . . . . . . .  64
-     C.13. April 19, 2021  . . . . . . . . . . . . . . . . . . . . .  64
-       C.13.1.  Ticket 109 - Sanity Check DMARCbis Document  . . . .  65
-     C.14. April 20, 2021  . . . . . . . . . . . . . . . . . . . . .  65
-       C.14.1.  Ticket 108 - Changes to DMARCbis for PSD . . . . . .  65
-     C.15. April 22, 2021  . . . . . . . . . . . . . . . . . . . . .  65
+               MUST  . . . . . . . . . . . . . . . . . . . . . . . .  65
+     C.13. April 19, 2021  . . . . . . . . . . . . . . . . . . . . .  65
+       C.13.1.  Ticket 109 - Sanity Check DMARCbis Document  . . . .  66
+     C.14. April 20, 2021  . . . . . . . . . . . . . . . . . . . . .  66
+       C.14.1.  Ticket 108 - Changes to DMARCbis for PSD . . . . . .  66
+     C.15. April 22, 2021  . . . . . . . . . . . . . . . . . . . . .  66
        C.15.1.  Ticket 104 - Update the Security Considerations
-               section 11.3 on DNS . . . . . . . . . . . . . . . . .  65
-     C.16. June 16, 2021 . . . . . . . . . . . . . . . . . . . . . .  65
-       C.16.1.  Publication of draft-ietf-dmarc-dmarcbis-02  . . . .  65
-     C.17. August 12, 2021 . . . . . . . . . . . . . . . . . . . . .  65
-       C.17.1.  Publication of draft-ietf-dmarc-dmarcbis-03  . . . .  65
-   Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . .  66
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  66
+               section 11.3 on DNS . . . . . . . . . . . . . . . . .  66
+     C.16. June 16, 2021 . . . . . . . . . . . . . . . . . . . . . .  66
+       C.16.1.  Publication of draft-ietf-dmarc-dmarcbis-02  . . . .  66
+     C.17. August 12, 2021 . . . . . . . . . . . . . . . . . . . . .  66
+       C.17.1.  Publication of draft-ietf-dmarc-dmarcbis-03  . . . .  66
+   Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . .  67
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  67
 
 1.  Introduction
 
@@ -278,9 +278,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                 [Page 5]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 5]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    *  Desire for reports about email use of the domain name
@@ -334,9 +334,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                 [Page 6]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 6]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 2.  Requirements
@@ -390,9 +390,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                 [Page 7]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 7]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    *  content analysis.
@@ -446,9 +446,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                 [Page 8]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 8]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    Readers are encouraged to be familiar with the contents of [RFC5598].
@@ -502,9 +502,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                 [Page 9]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 9]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 3.7.  Mail Receiver
@@ -558,9 +558,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 10]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 10]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 3.14.  More on Identifier Alignment
@@ -614,9 +614,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 11]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 11]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    In relaxed mode, the Organizational Domains of both the DKIM-
@@ -670,9 +670,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 12]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 12]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 3.14.3.  Alignment and Extension Technologies
@@ -684,52 +684,78 @@ Internet-Draft                  DMARCbis                  September 2021
 
 3.15.  Determining The Organizational Domain
 
-   The Organizational Domain is determined using the following
-   algorithm:
+   The Organizational Domain for a subject DNS domain name is defined as
+   the domain that is found in the DNS hierarchy one level below the PSD
+   in the subject DNS domain name.  The Organizational Domain is
+   determined using the following algorithm, similar to the one
+   described in Section 6.7.3
 
-   1.  Acquire a "public suffix" list, i.e., a list of DNS domain names
-       reserved for registrations.  Some country Top-Level Domains
-       (TLDs) make specific registration requirements, e.g., the United
-       Kingdom places company registrations under ".co.uk"; other TLDs
-       such as ".com" appear in the IANA registry of top-level DNS
-       domains.  A public suffix list is the union of all of these.
-       Appendix A.6.1 contains some discussion about obtaining a public
-       suffix list.
+   1.  Query the DNS for a DMARC TXT record at the DNS domain matching
+       the one found in the RFC5322.From domain in the message.  A
+       possibly empty set of records is returned.
 
-   2.  Break the subject DNS domain name into a set of "n" ordered
+   2.  Records that do not start with a "v=" tag that identifies the
+       current version of DMARC are discarded.
+
+   3.  If the set is now empty, or the set contains one valid DMARC
+       record that does not include a psd tag with a value of 'y', then
+       determine the target for additional queries, using steps 4
+       through 8 below.
+
+   4.  Break the subject DNS domain name into a set of "n" ordered
        labels.  Number these labels from right to left; e.g., for
        "example.com", "com" would be label 1 and "example" would be
        label 2.
 
-   3.  Search the public suffix list for the name that matches the
-       largest number of labels found in the subject DNS domain.  Let
-       that number be "x".
+   5.  Count the number of labels found in the subject DNS domain.  Let
+       that number be "x".  If x < 5, remove the left-most (highest-
+       numbered) label from the subject domain.  If x >= 5, remove the
+       left-most (highest-numbered) labels from the subject domain until
+       4 labels remain.  The resulting DNS domain name is the new target
+       for subsequent lookups.
 
-   4.  Construct a new DNS domain name using the name that matched from
-       the public suffix list and prefixing to it the "x+1"th label from
-       the subject domain.  This new name is the Organizational Domain.
+   6.  Query the DNS for a DMARC TXT record at the DNS domain matching
+       this new target in place of the RFC5322.From domain in the
+       message.  A possibly empty set of records is returned.
 
-   Thus, since "com" is an IANA-registered TLD, a subject domain of
-   "a.b.c.d.example.com" would have an Organizational Domain of
-   "example.com".
+   7.  Records that do not start with a "v=" tag that identifies the
+       current version of DMARC are discarded.
 
-   The process of determining a suffix is currently a heuristic one.  No
-   list is guaranteed to be accurate or current.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 13]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+   8.  If the set is now empty, or the set contains one valid DMARC
+       record that does not include a psd tag with the value of 'y',
+       then determine the target for additional queries by removing a
+       single label from the target domain as described in step 5 and
+       repeating steps 6 and 7 until there are no more labels remaining
+       or a record containing a psd tag with a value of 'y' is found.
+
+   9.  Once a valid DMARC record containing a psd tag with a value of
+       'y' has been found, the Organizational Domain for the DNS domain
+       matching the one found in the RFC5322.From domain can be declared
+       to be the target domain queried for in the step prior to the
+       query that found the PSD domain.
+
+   For example, given the RFC5322.From domain "a.mail.example.com", a
+   series of DNS queries for DMARC records would be executed starting
+   with "_dmarc.a.mail.example.com" and finishing with "_dmarc.com".
+   The "_dmarc.com" record would contain a psd tag with a value of 'y',
+   and so the Organizational Domain for this RFC5322.From domain would
+   be determined to be "example.com", the domain of the DMARC query
+   executed prior to the query for "_dmarc.com".
 
 4.  Overview
 
    This section provides a general overview of the design and operation
    of the DMARC environment.
-
-
-
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 13]
-
-Internet-Draft                  DMARCbis                  September 2021
-
 
 4.1.  Authentication Mechanisms
 
@@ -751,6 +777,15 @@ Internet-Draft                  DMARCbis                  September 2021
 
    DMARC policies are published by the Domain Owner or PSO, and
    retrieved by the Mail Receiver during the SMTP session, via the DNS.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 14]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    DMARC's verification function is based on whether the RFC5322.From
    domain is aligned with an authenticated domain name from SPF or DKIM.
@@ -779,14 +814,6 @@ Internet-Draft                  DMARCbis                  September 2021
    defined in other referenced material such as [RFC6591] and
    [DMARC-Failure-Reporting]
 
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 14]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
    A message satisfies the DMARC checks if at least one of the supported
    authentication mechanisms:
 
@@ -796,6 +823,25 @@ Internet-Draft                  DMARCbis                  September 2021
        as defined in Section 3.
 
 4.3.  Flow Diagram
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 15]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
     +---------------+                             +--------------------+
     | Author Domain |< . . . . . . . . . . . .    | Return-Path Domain |
@@ -834,15 +880,6 @@ Internet-Draft                  DMARCbis                  September 2021
    authentication modules.  "sMTA" is the sending MTA, and "rMTA" is the
    receiving MTA.
 
-
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 15]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
    Put simply, when a message reaches a DMARC-aware rMTA, a DNS query
    will be initiated to determine if the author domain has published a
    DMARC policy.  If a policy is found, the rMTA will use the results of
@@ -852,6 +889,15 @@ Internet-Draft                  DMARCbis                  September 2021
 
    More details on specific actions for the parties involved can be
    found in Section 6.5 and Section 6.7.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 16]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 5.  Use of RFC5322.From
 
@@ -890,15 +936,6 @@ Internet-Draft                  DMARCbis                  September 2021
    operate under a slightly restricted profile of RFC5322 with respect
    to the expected syntax of this field.  See Section 6.7 for details.
 
-
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 16]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
 6.  Policy
 
    DMARC policies are published by Domain Owners and PSOs and can be
@@ -910,6 +947,14 @@ Internet-Draft                  DMARCbis                  September 2021
    severity of concern regarding failed authentication for email
    messages making use of their domain in the RFC5322.From header field
    as well as the provision of feedback about those messages.  Mail
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 17]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    Receivers in turn can take into account the Domain Owner's severity
    of concern when making handling decisions about email messages that
    fail DMARC authentication checks.
@@ -945,16 +990,6 @@ Internet-Draft                  DMARCbis                  September 2021
    "_dmarc.example.com".  The DNS-located DMARC preference data will
    hereafter be called the "DMARC record".
 
-
-
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 17]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
    DMARC's use of the Domain Name Service is driven by DMARC's use of
    domain names and the nature of the query it performs.  The query
    requirement matches with the DNS, for obtaining simple parametric
@@ -964,6 +999,17 @@ Internet-Draft                  DMARCbis                  September 2021
    the DNS as the query service has the benefit of reusing an extremely
    well-established operations, administration, and management
    infrastructure, rather than creating a new one.
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 18]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    Per [RFC1035], a TXT record can comprise several "character-string"
    objects.  Where this is the case, the module performing DMARC
@@ -996,21 +1042,6 @@ Internet-Draft                  DMARCbis                  September 2021
 
    The following tags are valid DMARC tags:
 
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 18]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
    adkim:  (plain-text; OPTIONAL; default is "r".)  Indicates whether
       strict or relaxed DKIM Identifier Alignment mode is required by
       the Domain Owner.  See Section 3.14.1 for details.  Valid values
@@ -1028,6 +1059,13 @@ Internet-Draft                  DMARCbis                  September 2021
       r:  relaxed mode
 
       s:  strict mode
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 19]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    fo:  Failure reporting options (plain-text; OPTIONAL; default is "0")
       Provides requested options for generation of failure reports.
@@ -1059,14 +1097,6 @@ Internet-Draft                  DMARCbis                  September 2021
       evaluation, regardless of its alignment.  SPF-specific
       reporting is described in [@!RFC6652].
 
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 19]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
    np:  Domain Owner Assessment Policy for non-existent subdomains
       (plain-text; OPTIONAL).  Indicates the severity of concern the
       Domain Owner or PSO has for mail using non-existent subdomains of
@@ -1085,6 +1115,14 @@ Internet-Draft                  DMARCbis                  September 2021
       policy records).  Indicates the severity of concern the Domain
       Owner or PSO has for mail using its domain but not passing DMARC
       verification.  Policy applies to the domain queried and to
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 20]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
       subdomains, unless subdomain policy is explicitly described using
       the "sp" or "np" tags.  This tag is mandatory for policy records
       only, but not for third-party reporting records (see
@@ -1102,6 +1140,18 @@ Internet-Draft                  DMARCbis                  September 2021
          See Section 8.3 for some discussion of SMTP rejection methods
          and their implications.
 
+   psd:  A flag indicating whether the domain is a PSD. (plain-text;
+      OPTIONAL; default is 'n').  Possible values are:
+
+      y:  Domains on the PSL that publish DMARC policy records SHOULD
+         include this tag with a value of 'y' to indicate that the
+         domain is a PSD.  This information will be used during policy
+         discovery to determine how to apply any DMARC policy records
+         that are discovered during the tree walk.
+
+      n:  The default, indicating that the DMARC policy record is
+         published for a domain that is not a PSD.
+
    rua:  Addresses to which aggregate feedback is to be sent (comma-
       separated plain-text list of DMARC URIs; OPTIONAL).  Section 3 of
       [DMARC-Aggregate-Reporting] discusses considerations that apply
@@ -1115,20 +1165,20 @@ Internet-Draft                  DMARCbis                  September 2021
       The aggregate feedback report format is described in
       [DMARC-Aggregate-Reporting]
 
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 20]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
    ruf:  Addresses to which message-specific failure information is to
       be reported (comma-separated plain-text list of DMARC URIs;
       OPTIONAL).  If present, the Domain Owner or PSO is requesting Mail
       Receivers to send detailed failure reports about messages that
       fail the DMARC evaluation in specific ways (see the "fo" tag
       above).  The format of the message to be generated MUST follow the
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 21]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
       format specified for the "rf" tag.  Section 3 of
       [DMARC-Aggregate-Reporting] discusses considerations that apply
       when the domain name of a URI differs from that of the domain
@@ -1168,22 +1218,22 @@ Internet-Draft                  DMARCbis                  September 2021
       n:  The default, a request to apply the policy as specified to any
          message that produces a DMARC "fail" result.
 
-
-
-
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 21]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
    v:  Version (plain-text; REQUIRED).  Identifies the record retrieved
       as a DMARC record.  It MUST have the value of "DMARC1".  The value
       of this tag MUST match precisely; if it does not or it is absent,
       the entire retrieved record MUST be ignored.  It MUST be the first
       tag in the list.
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 22]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    A DMARC policy record MUST comply with the formal specification found
    in Section 6.4 in that the "v" tag MUST be present and MUST appear
@@ -1227,20 +1277,19 @@ Internet-Draft                  DMARCbis                  September 2021
      dmarc-sep       = *WSP %x3b *WSP
 
      dmarc-request   = "p" *WSP "=" *WSP
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 22]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
                        ( "none" / "quarantine" / "reject" )
 
      dmarc-test      = "t" *WSP "=" ( "y" / "n" )
 
      dmarc-srequest  = "sp" *WSP "=" *WSP
                        ( "none" / "quarantine" / "reject" )
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 23]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
      dmarc-nprequest  = "np" *WSP "=" *WSP
                        ( "none" / "quarantine" / "reject" )
@@ -1278,19 +1327,6 @@ Internet-Draft                  DMARCbis                  September 2021
    with the Author Domain, and then publish an SPF policy in DNS for
    that domain.
 
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 23]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
 6.5.2.  Configure Sending System for DKIM Signing Using an Aligned
         Domain
 
@@ -1301,6 +1337,15 @@ Internet-Draft                  DMARCbis                  September 2021
    Signing domain (i.e., the d= domain in the DKIM-Signature header)
    that aligns with the Author Domain and configure its system to sign
    using that domain.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 24]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 6.5.3.  Setup a Mailbox to Receive Aggregate Reports
 
@@ -1329,24 +1374,6 @@ Internet-Draft                  DMARCbis                  September 2021
    SHOULD start with "p=none", with the rua tag containg the mailbox
    created in the previous step.
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 24]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
 6.5.5.  Collect and Analyze Reports and Adjust Authentication
 
    The reason for starting at "p=none" is to ensure that nothing's been
@@ -1358,6 +1385,23 @@ Internet-Draft                  DMARCbis                  September 2021
    its own mail streams.  Should any overlooked systems be found in the
    reports, the Domain Owner can adjust the SPF record and/or configure
    DKIM signing for those systems.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 25]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 6.5.6.  Decide If and When to Update DMARC Policy
 
@@ -1395,14 +1439,6 @@ Internet-Draft                  DMARCbis                  September 2021
    the handling of those that are forbidden under [RFC5322] or that
    contain no meaningful domains is outside the scope of this document.
 
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 25]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
    The case of a syntactically valid multi-valued RFC5322.From header
    field presents a particular challenge.  When a single RFC5322.From
    header field contains multiple addresses, it is possible that there
@@ -1414,6 +1450,14 @@ Internet-Draft                  DMARCbis                  September 2021
 
    Note that domain names that appear on a public suffix list are not
    exempt from DMARC policy application and reporting.
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 26]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 6.7.2.  Determine Handling Policy
 
@@ -1452,13 +1496,6 @@ Internet-Draft                  DMARCbis                  September 2021
        failures, identifier mismatches) are considered to be DMARC
        mechanism check failures.
 
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 26]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
    6.  Apply policy.  Emails that fail the DMARC mechanism check are
        handled in accordance with the discovered DMARC policy of the
        Domain Owner and any local policy rules enforced by the Mail
@@ -1469,6 +1506,14 @@ Internet-Draft                  DMARCbis                  September 2021
    the case that the Domain Owner wishes a Message Receiver not to
    consider the results of that underlying authentication protocol at
    all.
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 27]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    DMARC evaluation can only yield a "pass" result after one of the
    underlying authentication mechanisms passes for an aligned
@@ -1490,60 +1535,70 @@ Internet-Draft                  DMARCbis                  September 2021
    important differences between DMARC and SPF mechanisms, are discussed
    below.
 
-   To balance the conflicting requirements of supporting wildcarding,
-   allowing subdomain policy overrides, and limiting DNS query load, the
-   following DNS lookup scheme is employed:
+   To balance the conflicting requirements of supporting wildcarding and
+   allowing subdomain policy overrides, the following DNS lookup scheme
+   is employed:
 
-   1.  Mail Receivers MUST query the DNS for a DMARC TXT record at the
-       DNS domain matching the one found in the RFC5322.From domain in
-       the message.  A possibly empty set of records is returned.
+   1.   Mail Receivers MUST query the DNS for a DMARC TXT record at the
+        DNS domain matching the one found in the RFC5322.From domain in
+        the message.  A possibly empty set of records is returned.
 
-   2.  Records that do not start with a "v=" tag that identifies the
-       current version of DMARC are discarded.
+   2.   Records that do not start with a "v=" tag that identifies the
+        current version of DMARC are discarded.
 
-   3.  If the set is now empty, the Mail Receiver MUST query the DNS for
-       a DMARC TXT record at the DNS domain matching the Organizational
-       Domain in place of the RFC5322.From domain in the message (if
-       different).  This record can contain policy to be asserted for
-       subdomains of the Organizational Domain.  A possibly empty set of
-       records is returned.
+   3.   If the set is now empty, the Mail Receiver determines the target
+        for additional queries, using steps 4 through 8 below.
+
+   4.   Break the subject DNS domain name into a set of "n" ordered
+        labels.  Number these lables from right to left; e.g., for
+        "example.com", "com" would be label 1 and "example" would be
+        label 2.
+
+   5.   Count the number of labels found in the subject DNS domain.  Let
+        that number be "x".  If x < 5, remove the left-most (highest-
+        numbered) label from the subject domain.  If x >= 5, remove the
+        left-most (highest-numbered) labels from the subject domain
+        until 4 labels remain.  The resulting DNS domain name is the new
+        target for subsequent lookups.
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 27]
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 28]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
-   4.  Records that do not start with a "v=" tag that identifies the
-       current version of DMARC are discarded.
+   6.   The Mail Receiver MUST query the DNS for a DMARC TXT record at
+        the DNS domain matching this new target in place of the
+        RFC5322.From domain in the message.  This record can contain
+        policy to be asserted for subdomains of the target.  A possibly
+        empty set of records is returned.
 
-   5.  If the set is now empty and the longest PSD Section 3.6 of the
-       Organizational Domain is one that the receiver has determined is
-       acceptable for PSD DMARC (based on the data in one of the DMARC
-       PSD Registry Examples decribed in Appendix B of [RFC9091]) the
-       Mail Receiver MUST query the DNS for a DMARC TXT record at the
-       DNS domain matching the longest PSD in place of the RFC5322.From
-       domain in the message (if different).  A possibly empty set of
-       records is returned.
+   7.   Records that do not start with a "v=" tag that identifies the
+        current version of DMARC are discarded.
 
-   6.  Records that do not start with a "v=" tag that identifies the
-       current version of DMARC are discarded.
+   8.   If the set is now empty, the Mail Receiver determines the target
+        for additional queries by removing a single label from the
+        target domain as described in step 5 and repeating steps 6 and 7
+        until there are no more labels remaining.
 
-   7.  If the remaining set contains multiple records or no records,
-       policy discovery terminates and DMARC processing is not applied
-       to this message.
+   9.   If the remaining set contains multiple records or no records,
+        policy discovery terminates and DMARC processing is not applied
+        to this message.
 
-   8.  If a retrieved policy record does not contain a valid "p" tag, or
-       contains an "sp" tag that is not valid, then:
+   10.  If a retrieved policy record does not contain a valid "p" tag,
+        or contains an "sp" tag that is not valid, then:
 
-       1.  if a "rua" tag is present and contains at least one
-           syntactically valid reporting URI, the Mail Receiver SHOULD
-           act as if a record containing a valid "v" tag and "p=none"
-           was retrieved, and continue processing;
+        1.  if a "rua" tag is present and contains at least one
+            syntactically valid reporting URI, the Mail Receiver SHOULD
+            act as if a record containing a valid "v" tag and "p=none"
+            was retrieved, and continue processing;
 
-       2.  otherwise, the Mail Receiver applies no DMARC processing to
-           this message.
+        2.  otherwise, the Mail Receiver applies no DMARC processing to
+            this message.
 
    If the set produced by the mechanism above contains no DMARC policy
    record (i.e., any indication that there is no such record as opposed
@@ -1566,9 +1621,10 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 28]
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 29]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 6.7.3.1.  Longest PSD Example
@@ -1622,9 +1678,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 29]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 30]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 6.8.  Policy Enforcement Considerations
@@ -1678,9 +1734,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 30]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 31]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    Mail Receivers MUST also implement reporting instructions of DMARC,
@@ -1734,9 +1790,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 31]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 32]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 8.2.  DNS Load and Caching
@@ -1790,9 +1846,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 32]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 33]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    Similarly, the text portion of the SMTP reply may be important to
@@ -1846,9 +1902,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 33]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 34]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    Additional DMARC constraints occur when a message is processed by
@@ -1902,9 +1958,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 34]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 35]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 9.2.  Authentication-Results Result Registry Update
@@ -1958,9 +2014,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 35]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 36]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    |           |           |           |(added)| error occurred |      |
@@ -2014,9 +2070,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 36]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 37]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    specification adequately describes the new tag and clearly presents
@@ -2070,9 +2126,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 37]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 38]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 9.5.  DMARC Report Format Registry
@@ -2126,9 +2182,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 38]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 39]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 10.1.  Authentication Methods
@@ -2182,9 +2238,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 39]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 40]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    *  DNS over TLS [RFC7858] or DNS over HTTPS [RFC8484] can mitigate
@@ -2238,9 +2294,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 40]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 41]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 10.5.  External Reporting Addresses
@@ -2294,9 +2350,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 41]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 42]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    [DMARC-Failure-Reporting]
@@ -2350,9 +2406,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 42]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 43]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    [RFC6591]  Fontana, H., "Authentication Failure Reporting Using the
@@ -2406,9 +2462,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 43]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 44]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    [RFC3464]  Moore, K. and G. Vaudreuil, "An Extensible Message Format
@@ -2462,9 +2518,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 44]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 45]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    [RFC8601]  Kucherawy, M., "Message Header Field for Indicating
@@ -2518,9 +2574,9 @@ A.2.  Method Exclusion
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 45]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 46]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    Specifically, consider a Domain Owner that has deployed one of the
@@ -2574,9 +2630,9 @@ A.3.  Sender Header Field
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 46]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 47]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    3.  Allowing multiple ways to discover policy introduces unacceptable
@@ -2630,9 +2686,9 @@ A.5.  Issues with ADSP in Operation
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 47]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 48]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    5.  ADSP has no support for a slow rollout, i.e., no way to configure
@@ -2686,9 +2742,9 @@ A.6.  Organizational Domain Discovery Issues
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 48]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 49]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 A.6.1.  Public Suffix Lists
@@ -2742,9 +2798,9 @@ A.7.  Removal of the "pct" Tag
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 49]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 50]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    These custom actions when the pct= tag was set to "0" proved valuable
@@ -2798,9 +2854,9 @@ B.1.1.  SPF
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 50]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 51]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
         MAIL FROM: <sender@example.com>
@@ -2854,9 +2910,9 @@ B.1.2.  DKIM
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 51]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 52]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
         DKIM-Signature: v=1; ...; d=example.com; ...
@@ -2910,9 +2966,9 @@ B.2.1.  Entire Domain, Monitoring Only
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 52]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 53]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    *  Confirm that its legitimate messages are authenticating correctly
@@ -2966,9 +3022,9 @@ B.2.2.  Entire Domain, Monitoring Only, Per-Message Reports
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 53]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 54]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    Not all Receivers will honor such a request, but the Domain Owner
@@ -3022,9 +3078,9 @@ B.2.3.  Per-Message Failure Reports Directed to Third Party
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 54]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 55]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    The DMARC policy record might look like this when retrieved using a
@@ -3078,9 +3134,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 55]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 56]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    Mediators and other third parties should refer to Section 3 of
@@ -3134,9 +3190,9 @@ B.2.4.  Subdomain, Testing, and Multiple Aggregate Report URIs
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 56]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 57]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
      % dig +short TXT _dmarc.test.example.com
@@ -3190,9 +3246,9 @@ B.3.  Mail Receiver Example
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 57]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 58]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 B.4.  Processing of SMTP Time
@@ -3246,9 +3302,9 @@ B.4.  Processing of SMTP Time
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 58]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 59]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    If no Authenticated Identifiers align with the Author Domain, then
@@ -3302,9 +3358,9 @@ B.5.  Utilization of Aggregate Feedback: Example
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 59]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 60]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    directly correct the problem or understand where authentication-
@@ -3358,9 +3414,9 @@ C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 60]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 61]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 C.3.  February 10, 2021
@@ -3414,9 +3470,9 @@ C.6.1.  Ticket 7 - ABNF for dmarc-record is slightly wrong
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 61]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 62]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    *  New text documented here - https://trac.ietf.org/trac/dmarc/
@@ -3470,9 +3526,9 @@ C.8.1.  Ticket 54 - Remove or expand limits on number of recipients per
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 62]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 63]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 C.9.  April 12, 2021
@@ -3526,9 +3582,9 @@ C.10.3.  Ticket 47 - Remove pct= tag
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 63]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 64]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    *  Data demonstrating lack of use of feature entered into ticket -
@@ -3582,9 +3638,9 @@ C.13.  April 19, 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 64]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 65]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 C.13.1.  Ticket 109 - Sanity Check DMARCbis Document
@@ -3638,9 +3694,9 @@ C.17.1.  Publication of draft-ietf-dmarc-dmarcbis-03
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 65]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 66]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 Acknowledgements
@@ -3694,5 +3750,5 @@ Authors' Addresses
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 66]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 67]
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ DMARC                                                       T. Herr (ed)
 Internet-Draft                                                  Valimail
 Obsoletes: 7489 (if approved)                             J. Levine (ed)
 Intended status: Standards Track                           Standcore LLC
-Expires: 21 May 2022                                    17 November 2021
+Expires: 22 May 2022                                    18 November 2021
 
 
 Domain-based Message Authentication, Reporting, and Conformance (DMARC)
@@ -20,7 +20,7 @@ Abstract
 
    DMARC permits the owner of an email author's domain name to enable
    verification of the domain's use, to indicate the Domain Owner's or
-   Public Suffix Operator's severity of concern regarding failed
+   Public Suffix Operator's message handling preference regarding failed
    verification, and to request reports about use of the domain name.
    Mail receiving organizations can use this information when evaluating
    handling choices for incoming mail.
@@ -42,7 +42,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 21 May 2022.
+   This Internet-Draft will expire on 22 May 2022.
 
 Copyright Notice
 
@@ -54,7 +54,7 @@ Copyright Notice
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 1]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 1]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -77,28 +77,29 @@ Table of Contents
      2.3.  Scalability . . . . . . . . . . . . . . . . . . . . . . .   8
      2.4.  Anti-Phishing . . . . . . . . . . . . . . . . . . . . . .   8
    3.  Terminology and Definitions . . . . . . . . . . . . . . . . .   8
-     3.1.  Conventions Used in This Document . . . . . . . . . . . .   8
-     3.2.  Authenticated Identifiers . . . . . . . . . . . . . . . .   9
-     3.3.  Author Domain . . . . . . . . . . . . . . . . . . . . . .   9
-     3.4.  Domain Owner  . . . . . . . . . . . . . . . . . . . . . .   9
-     3.5.  Identifier Alignment  . . . . . . . . . . . . . . . . . .   9
-     3.6.  Longest PSD . . . . . . . . . . . . . . . . . . . . . . .   9
-     3.7.  Mail Receiver . . . . . . . . . . . . . . . . . . . . . .  10
-     3.8.  Non-existent Domains  . . . . . . . . . . . . . . . . . .  10
-     3.9.  Organizational Domain . . . . . . . . . . . . . . . . . .  10
-     3.10. Public Suffix Domain (PSD)  . . . . . . . . . . . . . . .  10
-     3.11. Public Suffix Operator (PSO)  . . . . . . . . . . . . . .  10
-     3.12. PSO Controlled Domain Names . . . . . . . . . . . . . . .  10
-     3.13. Report Receiver . . . . . . . . . . . . . . . . . . . . .  10
-     3.14. More on Identifier Alignment  . . . . . . . . . . . . . .  11
-       3.14.1.  DKIM-Authenticated Identifiers . . . . . . . . . . .  11
-       3.14.2.  SPF-Authenticated Identifiers  . . . . . . . . . . .  12
-       3.14.3.  Alignment and Extension Technologies . . . . . . . .  13
-     3.15. Determining The Organizational Domain . . . . . . . . . .  13
+     3.1.  Conventions Used in This Document . . . . . . . . . . . .   9
+     3.2.  Defintions  . . . . . . . . . . . . . . . . . . . . . . .   9
+       3.2.1.  Authenticated Identifiers . . . . . . . . . . . . . .   9
+       3.2.2.  Author Domain . . . . . . . . . . . . . . . . . . . .   9
+       3.2.3.  Domain Owner  . . . . . . . . . . . . . . . . . . . .   9
+       3.2.4.  Identifier Alignment  . . . . . . . . . . . . . . . .  10
+       3.2.5.  Longest PSD . . . . . . . . . . . . . . . . . . . . .  10
+       3.2.6.  Mail Receiver . . . . . . . . . . . . . . . . . . . .  10
+       3.2.7.  Non-existent Domains  . . . . . . . . . . . . . . . .  10
+       3.2.8.  Organizational Domain . . . . . . . . . . . . . . . .  10
+       3.2.9.  Public Suffix Domain (PSD)  . . . . . . . . . . . . .  10
+       3.2.10. Public Suffix Operator (PSO)  . . . . . . . . . . . .  10
+       3.2.11. PSO Controlled Domain Names . . . . . . . . . . . . .  10
+       3.2.12. Report Receiver . . . . . . . . . . . . . . . . . . .  11
+     3.3.  More on Identifier Alignment  . . . . . . . . . . . . . .  11
+       3.3.1.  DKIM-Authenticated Identifiers  . . . . . . . . . . .  12
+       3.3.2.  SPF-Authenticated Identifiers . . . . . . . . . . . .  12
+       3.3.3.  Alignment and Extension Technologies  . . . . . . . .  13
+     3.4.  Determining The Organizational Domain . . . . . . . . . .  13
    4.  Overview  . . . . . . . . . . . . . . . . . . . . . . . . . .  14
      4.1.  Authentication Mechanisms . . . . . . . . . . . . . . . .  14
-     4.2.  Key Concepts  . . . . . . . . . . . . . . . . . . . . . .  14
-     4.3.  Flow Diagram  . . . . . . . . . . . . . . . . . . . . . .  15
+     4.2.  Key Concepts  . . . . . . . . . . . . . . . . . . . . . .  15
+     4.3.  Flow Diagram  . . . . . . . . . . . . . . . . . . . . . .  16
    5.  Use of RFC5322.From . . . . . . . . . . . . . . . . . . . . .  17
    6.  Policy  . . . . . . . . . . . . . . . . . . . . . . . . . . .  17
      6.1.  DMARC Policy Record . . . . . . . . . . . . . . . . . . .  18
@@ -106,15 +107,15 @@ Table of Contents
      6.3.  General Record Format . . . . . . . . . . . . . . . . . .  19
      6.4.  Formal Definition . . . . . . . . . . . . . . . . . . . .  23
      6.5.  Domain Owner Actions  . . . . . . . . . . . . . . . . . .  24
-       6.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  24
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 2]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 2]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
+       6.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  24
        6.5.2.  Configure Sending System for DKIM Signing Using an
                Aligned Domain  . . . . . . . . . . . . . . . . . . .  24
        6.5.3.  Setup a Mailbox to Receive Aggregate Reports  . . . .  25
@@ -162,15 +163,15 @@ Internet-Draft                  DMARCbis                   November 2021
      A.5.  Issues with ADSP in Operation . . . . . . . . . . . . . .  48
      A.6.  Organizational Domain Discovery Issues  . . . . . . . . .  49
        A.6.1.  Public Suffix Lists . . . . . . . . . . . . . . . . .  50
-     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  50
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 3]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 3]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
+     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  50
    Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  51
      B.1.  Identifier Alignment Examples . . . . . . . . . . . . . .  51
        B.1.1.  SPF . . . . . . . . . . . . . . . . . . . . . . . . .  51
@@ -217,16 +218,17 @@ Internet-Draft                  DMARCbis                   November 2021
                DMARC . . . . . . . . . . . . . . . . . . . . . . . .  64
        C.9.3.  Ticket 96 - Tweaks to Abstract and Introduction . . .  64
      C.10. April 13, 2021  . . . . . . . . . . . . . . . . . . . . .  64
-       C.10.1.  Ticket 53 - Remove reporting message size
-               chunking  . . . . . . . . . . . . . . . . . . . . . .  64
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 4]
+
+Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 4]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
+       C.10.1.  Ticket 53 - Remove reporting message size
+               chunking  . . . . . . . . . . . . . . . . . . . . . .  64
        C.10.2.  Ticket 52 - Remove strict alignment (and adkim and
                aspf tags)  . . . . . . . . . . . . . . . . . . . . .  64
        C.10.3.  Ticket 47 - Remove pct= tag  . . . . . . . . . . . .  64
@@ -266,47 +268,40 @@ Internet-Draft                  DMARCbis                   November 2021
    domain name in the RFC5322.From header field.  The domain typically
    belongs to an organization expected to be known to - and presumably
    trusted by - the recipient.  The Sender Policy Framework (SPF)
-   ([RFC7208]) and DomainKeys Identified Mail (DKIM) ([RFC6376])
-   protocols provide domain-level authentication but are not directly
-   associated with the RFC5322.From domain.  DMARC leverages them, so
-   that Domain Owners publish a DNS record indicating their RFC5322.From
-   field:
-
-   *  Email authentication policies
-
-   *  Level of concern for mail that fails authentication checks
+   [RFC7208] and DomainKeys Identified Mail (DKIM) [RFC6376] protocols
+   provide domain-level authentication but are not directly associated
+   with the RFC5322.From domain.  DMARC leverages them, and provides a
+   method for Domain Owners to publish a DNS record describing the email
+   authentication policies for the RFC5322.From domain and to request a
+   specific handling for messages using that domain that fail
+   authentication checks.
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 5]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 5]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-   *  Desire for reports about email use of the domain name
-
-   DMARC can cover non-existent sub-domains, below the "Organizational
-   Domain", as well as domains at the top of the name hierarchy,
-   controlled by Public Suffix Operators (PSOs).
-
-   As with SPF and DKIM, DMARC classes results as "pass" or "fail".  A
-   pass from either SPF or DKIM is required.  Depending on the stated
-   DMARC policy, the passed domain must be "aligned" with the
-   RFC5322.From domain in one of two modes - "relaxed" or "strict".
-   Domains are said to be "in relaxed alignment" if they have the same
-   Organizational Domain, which is at the top of the domain hierarchy,
-   while having the same administrative authority as the RFC5322.From
-   domain, while domains are "in strict alignment" if and only if they
-   are identical.
+   As with SPF and DKIM, DMARC classes results as "pass" or "fail".  In
+   order to get a DMARC result of "pass", a pass from either SPF or DKIM
+   is required.  In addition, the passed domain must be "aligned" with
+   the RFC5322.From domain in one of two modes - "relaxed" or "strict".
+   The mode is expressed in the domain's DMARC policy record.  Domains
+   are said to be "in relaxed alignment" if they have the same
+   "Organizational Domain", which is the domain at the top of the domain
+   hierarchy for the RFC5322.From domain while having the same
+   administrative authority as the RFC5322.From domain.  Domains are "in
+   strict alignment" if and only if they are identical.
 
    A DMARC pass indicates only that the RFC5322.From domain has been
-   authenticated for that message; authentication does not carry an
+   authenticated for that message.  Authentication does not carry an
    explicit or implicit value assertion about that message or about the
-   Domain Owner.  Indeed, a mail-receiving organization that performs
-   DMARC verification can choose to follow the Domain Owner's requested
-   disposition for authentication failures, and to inform the Domain
-   Owner of the mail handling decision for that message.  It also might
-   choose different actions.
+   Domain Owner.  Furthermore, a mail-receiving organization that
+   performs DMARC verification can choose to honor the Domain Owner's
+   requested message handling for authentication failures, but it is
+   under no obligation to do so; it might choose different actions
+   entirely.
 
    For a mail-receiving organization supporting DMARC, a message that
    passes verification is part of a message stream that is reliably
@@ -317,27 +312,37 @@ Internet-Draft                  DMARCbis                   November 2021
    verification is not necessarily associated with the Domain Owner's
    domain and its reputation.
 
+   DMARC policy records can also cover non-existent sub-domains, below
+   the "Organizational Domain", as well as domains at the top of the
+   name hierarchy, controlled by Public Suffix Operators (PSOs).
+
    DMARC, in the associated [DMARC-Aggregate-Reporting] and
    [DMARC-Failure-Reporting] documents, also specifies a reporting
    framework.  Using it, a mail-receiving domain can generate regular
    reports about messages that claim to be from a domain publishing
    DMARC policies, sending those reports to the address(es) specified by
-   the Domain Owner.
+   the Domain Owner in the latter's DMARC policy record.  Domain Owners
+   can use these reports, especially the aggregate reports, to identify
+   not only sources of mail attempting to fraudulently use their domain,
+   but also (and perhaps more importantly) gaps in their own
+   authentication practices.  However, as with honoring the Domain
+   Owner's stated mail handling preference, a mail-receiving
+   organization supporting DMARC is under no obligation to send
+   requested reports.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 6]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    Use of DMARC creates some interoperability challenges that require
    due consideration before deployment, particularly with configurations
    that can cause mail to be rejected.  These are discussed in
    Section 8.
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 6]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 2.  Requirements
 
@@ -349,9 +354,9 @@ Internet-Draft                  DMARCbis                   November 2021
 
    DMARC has the following high-level goals:
 
-   *  Allow Domain Owners and PSOs to assert their severity of concern
-      for authentication failures for messages purporting to have
-      authorship within the domain.
+   *  Allow Domain Owners and PSOs to assert their desired message
+      handling for authentication failures for messages purporting to
+      have authorship within the domain.
 
    *  Allow Domain Owners and PSOs to verify their authentication
       deployment.
@@ -369,33 +374,34 @@ Internet-Draft                  DMARCbis                   November 2021
    Several topics and issues are specifically out of scope for this
    work.  These include the following:
 
-   *  different treatment of messages that are not authenticated versus
+   *  Different treatment of messages that are not authenticated versus
       those that fail authentication;
 
-   *  evaluation of anything other than RFC5322.From header field;
+   *  Evaluation of anything other than RFC5322.From header field;
 
-   *  multiple reporting formats;
+   *  Multiple reporting formats;
 
-   *  publishing policy other than via the DNS;
+   *  Publishing policy other than via the DNS;
 
-   *  reporting or otherwise evaluating other than the last-hop IP
+   *  Reporting or otherwise evaluating other than the last-hop IP
       address;
 
-   *  attacks in the From: header field, also known as "display name"
-      attacks;
-
-   *  authentication of entities other than domains, since DMARC is
-      built upon SPF and DKIM, which authenticate domains; and
 
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 7]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 7]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-   *  content analysis.
+   *  Attacks in the From: header field, also known as "display name"
+      attacks;
+
+   *  Authentication of entities other than domains, since DMARC is
+      built upon SPF and DKIM, which authenticate domains; and
+
+   *  Content analysis.
 
 2.3.  Scalability
 
@@ -434,22 +440,24 @@ Internet-Draft                  DMARCbis                   November 2021
 
    This section defines terms used in the rest of the document.
 
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 8]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 3.1.  Conventions Used in This Document
 
    The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
    "OPTIONAL" in this document are to be interpreted as described in BCP
-   14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   14 [RFC2119] and [RFC8174] when, and only when, they appear in all
    capitals, as shown here.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 8]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    Readers are encouraged to be familiar with the contents of [RFC5598].
    In particular, that document defines various roles in the messaging
@@ -461,18 +469,22 @@ Internet-Draft                  DMARCbis                   November 2021
    reader is encouraged to become familiar with that material before
    continuing.
 
-3.2.  Authenticated Identifiers
+3.2.  Defintions
+
+   The following sections define terms used in this document.
+
+3.2.1.  Authenticated Identifiers
 
    Domain-level identifiers that are verified using authentication
    technologies are referred to as "Authenticated Identifiers".  See
    Section 4.1 for details about the supported mechanisms.
 
-3.3.  Author Domain
+3.2.2.  Author Domain
 
    The domain name of the apparent author, as extracted from the From:
    header field.
 
-3.4.  Domain Owner
+3.2.3.  Domain Owner
 
    An entity or organization that owns a DNS domain.  The term "owns"
    here indicates that the entity or organization being referenced holds
@@ -485,63 +497,73 @@ Internet-Draft                  DMARCbis                   November 2021
    Receivers, when those are outside of their immediate management
    domain.
 
-3.5.  Identifier Alignment
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 9]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+3.2.4.  Identifier Alignment
 
    When the domain in the address in the From: header field has the same
    Organizational Domain as a domain verified by SPF or DKIM (or both),
    it has Identifier Alignment. (see below)
 
-3.6.  Longest PSD
+3.2.5.  Longest PSD
 
    The term Longest PSD is defined in [RFC9091].
 
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 9]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-3.7.  Mail Receiver
+3.2.6.  Mail Receiver
 
    The entity or organization that receives and processes email.
    Mail Receivers operate one or more Internet-facing Mail Transport
    Agents (MTAs).
 
-3.8.  Non-existent Domains
+3.2.7.  Non-existent Domains
 
    For DMARC purposes, a non-existent domain is a domain for which there
    is an NXDOMAIN or NODATA response for A, AAAA, and MX records.  This
    is a broader definition than that in [RFC8020].
 
-3.9.  Organizational Domain
+3.2.8.  Organizational Domain
 
-   The domain that was registered with a domain name registrar.  In the
-   absence of more accurate methods, heuristics are used to determine
-   this, since it is not always the case that the registered domain name
-   is simply a top-level DNS domain plus one component (e.g.,
-   "example.com", where "com" is a top-level domain).  The
-   Organizational Domain is determined by applying the algorithm found
-   in Section 3.15.
+   The Organizational Domain is typically a domain that was registered
+   with a domain name registrar.  More formally, it is a Public Suffix
+   Domain plus one label.  The Organizational Domain for the domain in
+   the RFC5322.From domain is determined by applying the algorithm found
+   in Section 3.4.
 
-3.10.  Public Suffix Domain (PSD)
+3.2.9.  Public Suffix Domain (PSD)
 
    The term Public Suffix Domain is defined in [RFC9091].
 
-3.11.  Public Suffix Operator (PSO)
+3.2.10.  Public Suffix Operator (PSO)
 
    The term Public Suffix Operator is defined in [RFC9091].
 
-3.12.  PSO Controlled Domain Names
+3.2.11.  PSO Controlled Domain Names
 
    The term PSO Controlled Domain Names is defined in [RFC9091].
 
-3.13.  Report Receiver
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 10]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+3.2.12.  Report Receiver
 
    An operator that receives reports from another operator implementing
    the reporting mechanisms described in this document and/or the
@@ -552,18 +574,7 @@ Internet-Draft                  DMARCbis                   November 2021
    collectively to the system components that receive and process these
    reports and the organizations that operate them.
 
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 10]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-3.14.  More on Identifier Alignment
+3.3.  More on Identifier Alignment
 
    Email authentication technologies authenticate various (and
    disparate) aspects of an individual message.  For example, DKIM
@@ -599,7 +610,16 @@ Internet-Draft                  DMARCbis                   November 2021
    as input yields authenticated domains as their outputs when they
    succeed.
 
-3.14.1.  DKIM-Authenticated Identifiers
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 11]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+3.3.1.  DKIM-Authenticated Identifiers
 
    DMARC requires Identifier Alignment based on the result of a DKIM
    authentication because a message can bear a valid signature from any
@@ -610,14 +630,6 @@ Internet-Draft                  DMARCbis                   November 2021
    DMARC permits Identifier Alignment based on the result of a DKIM
    authentication to be strict or relaxed.  (Note that these terms are
    not related to DKIM's "simple" and "relaxed" canonicalization modes.)
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 11]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    In relaxed mode, the Organizational Domains of both the DKIM-
    authenticated signing domain (taken from the value of the d= tag in
@@ -635,15 +647,14 @@ Internet-Draft                  DMARCbis                   November 2021
    d= domain does not exactly match the RFC5322.From domain.
 
    However, a DKIM signature bearing a value of "d=com" would never
-   allow an "in alignment" result, as "com" should appear on all public
-   suffix lists (see Appendix A.6.1) and therefore cannot be an
-   Organizational Domain.
+   allow an "in alignment" result, as "com" should be identified as a
+   PSD and therefore cannot be an Organizational Domain.
 
    Note that a single email can contain multiple DKIM signatures, and it
    is considered to produce a DMARC "pass" result if any DKIM signature
    is aligned and verifies.
 
-3.14.2.  SPF-Authenticated Identifiers
+3.3.2.  SPF-Authenticated Identifiers
 
    DMARC permits Identifier Alignment based on the result of an SPF
    authentication.  As with DKIM, Identifier Alignement can be either
@@ -653,6 +664,16 @@ Internet-Draft                  DMARCbis                   November 2021
    domain and RFC5322.From domain must be equal if the identifiers are
    to be considered to be aligned.  In strict mode, the two FQDNs must
    match exactly in order from them to be considered to be aligned.
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 12]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    For example, in relaxed mode, if a message passes an SPF check with
    an RFC5321.MailFrom domain of "cbg.bounces.example.com", and the
@@ -668,21 +689,14 @@ Internet-Draft                  DMARCbis                   November 2021
    [RFC7208], which recommends that SPF checks be done on not only the
    "MAIL FROM" but also on a separate check of the "HELO" identity.
 
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 12]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-3.14.3.  Alignment and Extension Technologies
+3.3.3.  Alignment and Extension Technologies
 
    If in the future DMARC is extended to include the use of other
    authentication mechanisms, the extensions will need to allow for
    domain identifier extraction so that alignment with the RFC5322.From
    domain can be verified.
 
-3.15.  Determining The Organizational Domain
+3.4.  Determining The Organizational Domain
 
    The Organizational Domain for a subject DNS domain name is defined as
    the domain that is found in the DNS hierarchy one level below the PSD
@@ -707,6 +721,16 @@ Internet-Draft                  DMARCbis                   November 2021
        "example.com", "com" would be label 1 and "example" would be
        label 2.
 
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 13]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    5.  Count the number of labels found in the subject DNS domain.  Let
        that number be "x".  If x < 5, remove the left-most (highest-
        numbered) label from the subject domain.  If x >= 5, remove the
@@ -720,16 +744,6 @@ Internet-Draft                  DMARCbis                   November 2021
 
    7.  Records that do not start with a "v=" tag that identifies the
        current version of DMARC are discarded.
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 13]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    8.  If the set is now empty, or the set contains one valid DMARC
        record that does not include a psd tag with the value of 'y',
@@ -765,6 +779,14 @@ Internet-Draft                  DMARCbis                   November 2021
    *  DKIM, [RFC6376], which provides a domain-level identifier in the
       content of the "d=" tag of a verified DKIM-Signature header field.
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 14]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    *  SPF, [RFC7208], which can authenticate both the domain found in an
       [RFC5321] HELO/EHLO command (the HELO identity) and the domain
       found in an SMTP MAIL command (the MAIL FROM identity).  As noted
@@ -777,15 +799,6 @@ Internet-Draft                  DMARCbis                   November 2021
 
    DMARC policies are published by the Domain Owner or PSO, and
    retrieved by the Mail Receiver during the SMTP session, via the DNS.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 14]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    DMARC's verification function is based on whether the RFC5322.From
    domain is aligned with an authenticated domain name from SPF or DKIM.
@@ -822,26 +835,15 @@ Internet-Draft                  DMARCbis                   November 2021
    2.  produces that result based on an identifier that is in alignment,
        as defined in Section 3.
 
-4.3.  Flow Diagram
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 15]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 15]
 
 Internet-Draft                  DMARCbis                   November 2021
 
+
+4.3.  Flow Diagram
 
     +---------------+                             +--------------------+
     | Author Domain |< . . . . . . . . . . . .    | Return-Path Domain |
@@ -892,9 +894,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 16]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 16]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -944,19 +944,19 @@ Internet-Draft                  DMARCbis                   November 2021
    A Domain Owner or PSO advertises DMARC participation of one or more
    of its domains by adding a DNS TXT record (described in Section 6.1)
    to those domains.  In doing so, Domain Owners and PSOs indicate their
-   severity of concern regarding failed authentication for email
+   handling preference regarding failed authentication for email
    messages making use of their domain in the RFC5322.From header field
    as well as the provision of feedback about those messages.  Mail
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 17]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 17]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-   Receivers in turn can take into account the Domain Owner's severity
-   of concern when making handling decisions about email messages that
+   Receivers in turn can take into account the Domain Owner's stated
+   preference when making handling decisions about email messages that
    fail DMARC authentication checks.
 
    A Domain Owner or PSO may choose not to participate in DMARC
@@ -1006,7 +1006,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 18]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 18]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1044,7 +1044,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    adkim:  (plain-text; OPTIONAL; default is "r".)  Indicates whether
       strict or relaxed DKIM Identifier Alignment mode is required by
-      the Domain Owner.  See Section 3.14.1 for details.  Valid values
+      the Domain Owner.  See Section 3.3.1 for details.  Valid values
       are as follows:
 
       r:  relaxed mode
@@ -1053,8 +1053,8 @@ Internet-Draft                  DMARCbis                   November 2021
 
    aspf:  (plain-text; OPTIONAL; default is "r".)  Indicates whether
       strict or relaxed SPF Identifier Alignment mode is required by the
-      Domain Owner.  See Section 3.14.2 for details.  Valid values are
-      as follows:
+      Domain Owner.  See Section 3.3.2 for details.  Valid values are as
+      follows:
 
       r:  relaxed mode
 
@@ -1062,7 +1062,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 19]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 19]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1098,27 +1098,27 @@ Internet-Draft                  DMARCbis                   November 2021
       reporting is described in [@!RFC6652].
 
    np:  Domain Owner Assessment Policy for non-existent subdomains
-      (plain-text; OPTIONAL).  Indicates the severity of concern the
-      Domain Owner or PSO has for mail using non-existent subdomains of
-      the domain queried.  It applies only to non-existent subdomains of
-      the domain queried and not to either existing subdomains or the
-      domain itself.  Its syntax is identical to that of the "p" tag
-      defined below.  If the "np" tag is absent, the policy specified by
-      the "sp" tag (if the "sp" tag is present) or the policy specified
-      by the "p" tag, if the "sp" tag is not present, MUST be applied
-      for non-existent subdomains.  Note that "np" will be ignored for
-      DMARC records published on subdomains of Organizational Domains
-      and PSDs due to the effect of the DMARC policy discovery mechanism
-      described in Section 6.7.3.
+      (plain-text; OPTIONAL).  Indicates the message handling preference
+      that the Domain Owner or PSO has for mail using non-existent
+      subdomains of the domain queried.  It applies only to non-existent
+      subdomains of the domain queried and not to either existing
+      subdomains or the domain itself.  Its syntax is identical to that
+      of the "p" tag defined below.  If the "np" tag is absent, the
+      policy specified by the "sp" tag (if the "sp" tag is present) or
+      the policy specified by the "p" tag, if the "sp" tag is not
+      present, MUST be applied for non-existent subdomains.  Note that
+      "np" will be ignored for DMARC records published on subdomains of
+      Organizational Domains and PSDs due to the effect of the DMARC
+      policy discovery mechanism described in Section 6.7.3.
 
    p:  Domain Owner Assessment Policy (plain-text; RECOMMENDED for
-      policy records).  Indicates the severity of concern the Domain
-      Owner or PSO has for mail using its domain but not passing DMARC
-      verification.  Policy applies to the domain queried and to
+      policy records).  Indicates the message handling preference the
+      Domain Owner or PSO has for mail using its domain but not passing
+      DMARC verification.  Policy applies to the domain queried and to
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 20]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 20]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1174,7 +1174,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 21]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 21]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1189,17 +1189,17 @@ Internet-Draft                  DMARCbis                   November 2021
       considerations.
 
    sp:  Domain Owner Assessment Policy for all subdomains (plain-text;
-      OPTIONAL).  Indicates the severity of concern the Domain Owner or
-      PSO has for mail using an existing subdomain of the domain queried
-      but not passing DMARC verification.  It applies only to subdomains
-      of the domain queried and not to the domain itself.  Its syntax is
-      identical to that of the "p" tag defined above.  If both the "sp"
-      tag is absent and the "np" tag is either absent or not applicable,
-      the policy specified by the "p" tag MUST be applied for
-      subdomains.  Note that "sp" will be ignored for DMARC records
-      published on subdomains of Organizational Domains due to the
-      effect of the DMARC policy discovery mechanism described in
-      Section 6.7.3.
+      OPTIONAL).  Indicates the message handling preference the Domain
+      Owner or PSO has for mail using an existing subdomain of the
+      domain queried but not passing DMARC verification.  It applies
+      only to subdomains of the domain queried and not to the domain
+      itself.  Its syntax is identical to that of the "p" tag defined
+      above.  If both the "sp" tag is absent and the "np" tag is either
+      absent or not applicable, the policy specified by the "p" tag MUST
+      be applied for subdomains.  Note that "sp" will be ignored for
+      DMARC records published on subdomains of Organizational Domains
+      due to the effect of the DMARC policy discovery mechanism
+      described in Section 6.7.3.
 
    t:  DMARC policy test mode (plain-text; OPTIONAL; default is 'n').
       For the RFC5322.From domain to which the DMARC record applies, the
@@ -1230,7 +1230,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 22]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 22]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1286,7 +1286,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 23]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 23]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1342,7 +1342,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 24]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 24]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1398,7 +1398,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 25]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 25]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1454,7 +1454,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 26]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 26]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1510,7 +1510,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 27]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 27]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1566,7 +1566,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 28]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 28]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1622,7 +1622,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 29]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 29]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1656,8 +1656,8 @@ Internet-Draft                  DMARCbis                   November 2021
    illegitimate uses but also, and perhaps more importantly, all
    legitimate uses.  Domain Owners can use aggregate reports to ensure
    that all legitimate uses of their domain for sending email are
-   properly authenticated, and once they are, increase the severity of
-   concern expressed in the p= tag in their DMARC policy records from
+   properly authenticated, and once they are, express a stricter message
+   handling preference in the p= tag in their DMARC policy records from
    none to quarantine to reject, if appropriate.  In turn, DMARC policy
    records with p= tag values of 'quarantine' or 'reject' are higher
    value signals to Mail Receivers, ones that can assist Mail Receivers
@@ -1678,7 +1678,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 30]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 30]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1734,7 +1734,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 31]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 31]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1790,7 +1790,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 32]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 32]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1846,7 +1846,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 33]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 33]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1902,7 +1902,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 34]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 34]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1958,7 +1958,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 35]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 35]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2014,7 +2014,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 36]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 36]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2070,7 +2070,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 37]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 37]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2126,7 +2126,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 38]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 38]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2182,7 +2182,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 39]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 39]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2238,7 +2238,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 40]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 40]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2294,7 +2294,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 41]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 41]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2350,7 +2350,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 42]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 42]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2406,7 +2406,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 43]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 43]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2462,7 +2462,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 44]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 44]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2518,7 +2518,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 45]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 45]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2574,7 +2574,7 @@ A.2.  Method Exclusion
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 46]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 46]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2630,7 +2630,7 @@ A.3.  Sender Header Field
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 47]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 47]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2686,7 +2686,7 @@ A.5.  Issues with ADSP in Operation
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 48]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 48]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2731,7 +2731,7 @@ A.6.  Organizational Domain Discovery Issues
    constitutes an amplified denial-of-service attack.
 
    The Organizational Domain mechanism is a necessary component to the
-   goals of DMARC.  The method described in Section 3.15 is far from
+   goals of DMARC.  The method described in Section 3.4 is far from
    perfect but serves this purpose reasonably well without adding undue
    burden or semantics to the DNS.  If a method is created to do so that
    is more reliable and secure than the use of a public suffix list,
@@ -2742,7 +2742,7 @@ A.6.  Organizational Domain Discovery Issues
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 49]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 49]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2798,7 +2798,7 @@ A.7.  Removal of the "pct" Tag
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 50]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 50]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2854,7 +2854,7 @@ B.1.1.  SPF
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 51]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 51]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2910,7 +2910,7 @@ B.1.2.  DKIM
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 52]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 52]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2966,7 +2966,7 @@ B.2.1.  Entire Domain, Monitoring Only
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 53]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 53]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3022,7 +3022,7 @@ B.2.2.  Entire Domain, Monitoring Only, Per-Message Reports
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 54]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 54]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3078,7 +3078,7 @@ B.2.3.  Per-Message Failure Reports Directed to Third Party
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 55]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 55]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3134,7 +3134,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 56]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 56]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3146,7 +3146,7 @@ B.2.4.  Subdomain, Testing, and Multiple Aggregate Report URIs
 
    The Domain Owner has implemented SPF and DKIM in a subdomain used for
    pre-production testing of messaging services.  It now wishes to
-   express a severity of concern for messages from this subdomain that
+   express a handling preference for messages from this subdomain that
    fail to authenticate to indicate to participating receivers that use
    of this domain is not valid.
 
@@ -3190,7 +3190,7 @@ B.2.4.  Subdomain, Testing, and Multiple Aggregate Report URIs
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 57]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 57]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3246,7 +3246,7 @@ B.3.  Mail Receiver Example
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 58]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 58]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3302,7 +3302,7 @@ B.4.  Processing of SMTP Time
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 59]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 59]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3358,7 +3358,7 @@ B.5.  Utilization of Aggregate Feedback: Example
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 60]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 60]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3414,7 +3414,7 @@ C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 61]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 61]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3470,7 +3470,7 @@ C.6.1.  Ticket 7 - ABNF for dmarc-record is slightly wrong
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 62]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 62]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3526,7 +3526,7 @@ C.8.1.  Ticket 54 - Remove or expand limits on number of recipients per
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 63]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 63]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3582,7 +3582,7 @@ C.10.3.  Ticket 47 - Remove pct= tag
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 64]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 64]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3638,7 +3638,7 @@ C.13.  April 19, 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 65]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 65]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3694,7 +3694,7 @@ C.17.1.  Publication of draft-ietf-dmarc-dmarcbis-03
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 66]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 66]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3750,5 +3750,5 @@ Authors' Addresses
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 67]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 67]
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ DMARC                                                       T. Herr (ed)
 Internet-Draft                                                  Valimail
 Obsoletes: 7489 (if approved)                             J. Levine (ed)
 Intended status: Standards Track                           Standcore LLC
-Expires: 27 May 2022                                    23 November 2021
+Expires: 3 June 2022                                    30 November 2021
 
 
 Domain-based Message Authentication, Reporting, and Conformance (DMARC)
@@ -42,7 +42,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 27 May 2022.
+   This Internet-Draft will expire on 3 June 2022.
 
 Copyright Notice
 
@@ -54,7 +54,7 @@ Copyright Notice
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 1]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                  [Page 1]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -70,192 +70,123 @@ Internet-Draft                  DMARCbis                   November 2021
 
 Table of Contents
 
-   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   5
-   2.  Requirements  . . . . . . . . . . . . . . . . . . . . . . . .   7
-     2.1.  High-Level Goals  . . . . . . . . . . . . . . . . . . . .   7
-     2.2.  Out of Scope  . . . . . . . . . . . . . . . . . . . . . .   7
-     2.3.  Scalability . . . . . . . . . . . . . . . . . . . . . . .   8
-     2.4.  Anti-Phishing . . . . . . . . . . . . . . . . . . . . . .   8
-   3.  Terminology and Definitions . . . . . . . . . . . . . . . . .   8
-     3.1.  Conventions Used in This Document . . . . . . . . . . . .   9
-     3.2.  Defintions  . . . . . . . . . . . . . . . . . . . . . . .   9
-       3.2.1.  Authenticated Identifiers . . . . . . . . . . . . . .   9
-       3.2.2.  Author Domain . . . . . . . . . . . . . . . . . . . .   9
-       3.2.3.  Domain Owner  . . . . . . . . . . . . . . . . . . . .   9
-       3.2.4.  Identifier Alignment  . . . . . . . . . . . . . . . .  10
-       3.2.5.  Longest PSD . . . . . . . . . . . . . . . . . . . . .  10
-       3.2.6.  Mail Receiver . . . . . . . . . . . . . . . . . . . .  10
-       3.2.7.  Non-existent Domains  . . . . . . . . . . . . . . . .  10
-       3.2.8.  Organizational Domain . . . . . . . . . . . . . . . .  10
-       3.2.9.  Public Suffix Domain (PSD)  . . . . . . . . . . . . .  10
-       3.2.10. Public Suffix Operator (PSO)  . . . . . . . . . . . .  10
-       3.2.11. PSO Controlled Domain Names . . . . . . . . . . . . .  10
-       3.2.12. Report Receiver . . . . . . . . . . . . . . . . . . .  11
-   4.  Overview and Key Concepts . . . . . . . . . . . . . . . . . .  11
-     4.1.  DMARC Basics  . . . . . . . . . . . . . . . . . . . . . .  11
-     4.2.  Use of RFC5322.From . . . . . . . . . . . . . . . . . . .  12
-     4.3.  Authentication Mechanisms . . . . . . . . . . . . . . . .  13
-     4.4.  Flow Diagram  . . . . . . . . . . . . . . . . . . . . . .  13
-     4.5.  DNS Tree Walk . . . . . . . . . . . . . . . . . . . . . .  15
-     4.6.  Determining the Organizational Domain . . . . . . . . . .  16
-     4.7.  Identifier Alignment Explained  . . . . . . . . . . . . .  17
-       4.7.1.  DKIM-Authenticated Identifiers  . . . . . . . . . . .  17
-       4.7.2.  SPF-Authenticated Identifiers . . . . . . . . . . . .  18
-       4.7.3.  Alignment and Extension Technologies  . . . . . . . .  19
-   5.  Policy  . . . . . . . . . . . . . . . . . . . . . . . . . . .  19
-     5.1.  DMARC Policy Record . . . . . . . . . . . . . . . . . . .  20
-     5.2.  DMARC URIs  . . . . . . . . . . . . . . . . . . . . . . .  20
-     5.3.  General Record Format . . . . . . . . . . . . . . . . . .  20
-     5.4.  Formal Definition . . . . . . . . . . . . . . . . . . . .  25
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   4
+   2.  Requirements  . . . . . . . . . . . . . . . . . . . . . . . .   5
+     2.1.  High-Level Goals  . . . . . . . . . . . . . . . . . . . .   6
+     2.2.  Anti-Phishing . . . . . . . . . . . . . . . . . . . . . .   6
+     2.3.  Scalability . . . . . . . . . . . . . . . . . . . . . . .   6
+     2.4.  Out of Scope  . . . . . . . . . . . . . . . . . . . . . .   7
+   3.  Terminology and Definitions . . . . . . . . . . . . . . . . .   7
+     3.1.  Conventions Used in This Document . . . . . . . . . . . .   7
+     3.2.  Defintions  . . . . . . . . . . . . . . . . . . . . . . .   8
+       3.2.1.  Authenticated Identifiers . . . . . . . . . . . . . .   8
+       3.2.2.  Author Domain . . . . . . . . . . . . . . . . . . . .   8
+       3.2.3.  Domain Owner  . . . . . . . . . . . . . . . . . . . .   8
+       3.2.4.  Identifier Alignment  . . . . . . . . . . . . . . . .   8
+       3.2.5.  Mail Receiver . . . . . . . . . . . . . . . . . . . .   8
+       3.2.6.  Non-existent Domains  . . . . . . . . . . . . . . . .   9
+       3.2.7.  Organizational Domain . . . . . . . . . . . . . . . .   9
+       3.2.8.  Public Suffix Domain (PSD)  . . . . . . . . . . . . .   9
+       3.2.9.  Public Suffix Operator (PSO)  . . . . . . . . . . . .   9
+       3.2.10. PSO Controlled Domain Names . . . . . . . . . . . . .   9
+       3.2.11. Report Receiver . . . . . . . . . . . . . . . . . . .   9
+   4.  Overview and Key Concepts . . . . . . . . . . . . . . . . . .   9
+     4.1.  DMARC Basics  . . . . . . . . . . . . . . . . . . . . . .  10
+     4.2.  Use of RFC5322.From . . . . . . . . . . . . . . . . . . .  11
+     4.3.  Authentication Mechanisms . . . . . . . . . . . . . . . .  11
+     4.4.  Flow Diagram  . . . . . . . . . . . . . . . . . . . . . .  12
+     4.5.  DNS Tree Walk . . . . . . . . . . . . . . . . . . . . . .  13
+     4.6.  Determining the Organizational Domain . . . . . . . . . .  14
+     4.7.  Identifier Alignment Explained  . . . . . . . . . . . . .  15
+       4.7.1.  DKIM-Authenticated Identifiers  . . . . . . . . . . .  16
+       4.7.2.  SPF-Authenticated Identifiers . . . . . . . . . . . .  16
+       4.7.3.  Alignment and Extension Technologies  . . . . . . . .  17
+   5.  Policy  . . . . . . . . . . . . . . . . . . . . . . . . . . .  17
+     5.1.  DMARC Policy Record . . . . . . . . . . . . . . . . . . .  18
+     5.2.  DMARC URIs  . . . . . . . . . . . . . . . . . . . . . . .  18
+     5.3.  General Record Format . . . . . . . . . . . . . . . . . .  19
+     5.4.  Formal Definition . . . . . . . . . . . . . . . . . . . .  22
+     5.5.  Domain Owner Actions  . . . . . . . . . . . . . . . . . .  24
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 2]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                  [Page 2]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-     5.5.  Domain Owner Actions  . . . . . . . . . . . . . . . . . .  26
-       5.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  26
+       5.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  24
        5.5.2.  Configure Sending System for DKIM Signing Using an
-               Aligned Domain  . . . . . . . . . . . . . . . . . . .  26
-       5.5.3.  Setup a Mailbox to Receive Aggregate Reports  . . . .  27
-       5.5.4.  Publish a DMARC Policy for the Author Domain  . . . .  27
+               Aligned Domain  . . . . . . . . . . . . . . . . . . .  24
+       5.5.3.  Setup a Mailbox to Receive Aggregate Reports  . . . .  24
+       5.5.4.  Publish a DMARC Policy for the Author Domain  . . . .  25
        5.5.5.  Collect and Analyze Reports and Adjust
-               Authentication  . . . . . . . . . . . . . . . . . . .  27
-       5.5.6.  Decide If and When to Update DMARC Policy . . . . . .  28
-     5.6.  PSO Actions . . . . . . . . . . . . . . . . . . . . . . .  28
-     5.7.  Mail Receiver Actions . . . . . . . . . . . . . . . . . .  28
-       5.7.1.  Extract Author Domain . . . . . . . . . . . . . . . .  28
-       5.7.2.  Determine Handling Policy . . . . . . . . . . . . . .  29
-       5.7.3.  Store Results of DMARC Processing . . . . . . . . . .  31
-       5.7.4.  Send Aggregate Reports  . . . . . . . . . . . . . . .  31
-     5.8.  Policy Enforcement Considerations . . . . . . . . . . . .  31
-   6.  DMARC Feedback  . . . . . . . . . . . . . . . . . . . . . . .  32
-   7.  Other Topics  . . . . . . . . . . . . . . . . . . . . . . . .  33
-     7.1.  Issues Specific to SPF  . . . . . . . . . . . . . . . . .  33
-     7.2.  DNS Load and Caching  . . . . . . . . . . . . . . . . . .  33
-     7.3.  Rejecting Messages  . . . . . . . . . . . . . . . . . . .  34
-     7.4.  Identifier Alignment Considerations . . . . . . . . . . .  35
-     7.5.  Interoperability Issues . . . . . . . . . . . . . . . . .  35
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  35
-     8.1.  Authentication-Results Method Registry Update . . . . . .  35
-     8.2.  Authentication-Results Result Registry Update . . . . . .  36
-     8.3.  Feedback Report Header Fields Registry Update . . . . . .  37
-     8.4.  DMARC Tag Registry  . . . . . . . . . . . . . . . . . . .  38
-     8.5.  DMARC Report Format Registry  . . . . . . . . . . . . . .  39
+               Authentication  . . . . . . . . . . . . . . . . . . .  25
+       5.5.6.  Decide If and When to Update DMARC Policy . . . . . .  25
+     5.6.  PSO Actions . . . . . . . . . . . . . . . . . . . . . . .  25
+     5.7.  Mail Receiver Actions . . . . . . . . . . . . . . . . . .  25
+       5.7.1.  Extract Author Domain . . . . . . . . . . . . . . . .  25
+       5.7.2.  Determine Handling Policy . . . . . . . . . . . . . .  26
+       5.7.3.  Store Results of DMARC Processing . . . . . . . . . .  28
+       5.7.4.  Send Aggregate Reports  . . . . . . . . . . . . . . .  29
+     5.8.  Policy Enforcement Considerations . . . . . . . . . . . .  29
+   6.  DMARC Feedback  . . . . . . . . . . . . . . . . . . . . . . .  30
+   7.  Other Topics  . . . . . . . . . . . . . . . . . . . . . . . .  30
+     7.1.  Issues Specific to SPF  . . . . . . . . . . . . . . . . .  31
+     7.2.  DNS Load and Caching  . . . . . . . . . . . . . . . . . .  31
+     7.3.  Rejecting Messages  . . . . . . . . . . . . . . . . . . .  31
+     7.4.  Identifier Alignment Considerations . . . . . . . . . . .  32
+     7.5.  Interoperability Issues . . . . . . . . . . . . . . . . .  33
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  33
+     8.1.  Authentication-Results Method Registry Update . . . . . .  33
+     8.2.  Authentication-Results Result Registry Update . . . . . .  34
+     8.3.  Feedback Report Header Fields Registry Update . . . . . .  35
+     8.4.  DMARC Tag Registry  . . . . . . . . . . . . . . . . . . .  36
+     8.5.  DMARC Report Format Registry  . . . . . . . . . . . . . .  37
      8.6.  Underscored and Globally Scoped DNS Node Names
-           Registry  . . . . . . . . . . . . . . . . . . . . . . . .  40
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  40
-     9.1.  Authentication Methods  . . . . . . . . . . . . . . . . .  40
-     9.2.  Attacks on Reporting URIs . . . . . . . . . . . . . . . .  41
-     9.3.  DNS Security  . . . . . . . . . . . . . . . . . . . . . .  41
-     9.4.  Display Name Attacks  . . . . . . . . . . . . . . . . . .  42
-     9.5.  External Reporting Addresses  . . . . . . . . . . . . . .  42
-     9.6.  Secure Protocols  . . . . . . . . . . . . . . . . . . . .  43
-   10. Normative References  . . . . . . . . . . . . . . . . . . . .  43
-   11. Informative References  . . . . . . . . . . . . . . . . . . .  45
-   Appendix A.  Technology Considerations  . . . . . . . . . . . . .  46
-     A.1.  S/MIME  . . . . . . . . . . . . . . . . . . . . . . . . .  47
-     A.2.  Method Exclusion  . . . . . . . . . . . . . . . . . . . .  47
-     A.3.  Sender Header Field . . . . . . . . . . . . . . . . . . .  48
-     A.4.  Domain Existence Test . . . . . . . . . . . . . . . . . .  48
-     A.5.  Issues with ADSP in Operation . . . . . . . . . . . . . .  49
-     A.6.  Organizational Domain Discovery Issues  . . . . . . . . .  50
-       A.6.1.  Public Suffix Lists . . . . . . . . . . . . . . . . .  50
+           Registry  . . . . . . . . . . . . . . . . . . . . . . . .  38
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  38
+     9.1.  Authentication Methods  . . . . . . . . . . . . . . . . .  38
+     9.2.  Attacks on Reporting URIs . . . . . . . . . . . . . . . .  39
+     9.3.  DNS Security  . . . . . . . . . . . . . . . . . . . . . .  39
+     9.4.  Display Name Attacks  . . . . . . . . . . . . . . . . . .  40
+     9.5.  External Reporting Addresses  . . . . . . . . . . . . . .  40
+     9.6.  Secure Protocols  . . . . . . . . . . . . . . . . . . . .  41
+   10. Normative References  . . . . . . . . . . . . . . . . . . . .  41
+   11. Informative References  . . . . . . . . . . . . . . . . . . .  43
+   Appendix A.  Technology Considerations  . . . . . . . . . . . . .  44
+     A.1.  S/MIME  . . . . . . . . . . . . . . . . . . . . . . . . .  45
+     A.2.  Method Exclusion  . . . . . . . . . . . . . . . . . . . .  45
+     A.3.  Sender Header Field . . . . . . . . . . . . . . . . . . .  46
+     A.4.  Domain Existence Test . . . . . . . . . . . . . . . . . .  46
+     A.5.  Issues with ADSP in Operation . . . . . . . . . . . . . .  47
+     A.6.  Organizational Domain Discovery Issues  . . . . . . . . .  48
+     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  49
+   Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  50
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 3]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                  [Page 3]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  51
-   Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  52
-     B.1.  Identifier Alignment Examples . . . . . . . . . . . . . .  52
-       B.1.1.  SPF . . . . . . . . . . . . . . . . . . . . . . . . .  52
-       B.1.2.  DKIM  . . . . . . . . . . . . . . . . . . . . . . . .  53
-     B.2.  Domain Owner Example  . . . . . . . . . . . . . . . . . .  54
-       B.2.1.  Entire Domain, Monitoring Only  . . . . . . . . . . .  54
+     B.1.  Identifier Alignment Examples . . . . . . . . . . . . . .  50
+       B.1.1.  SPF . . . . . . . . . . . . . . . . . . . . . . . . .  50
+       B.1.2.  DKIM  . . . . . . . . . . . . . . . . . . . . . . . .  51
+     B.2.  Domain Owner Example  . . . . . . . . . . . . . . . . . .  52
+       B.2.1.  Entire Domain, Monitoring Only  . . . . . . . . . . .  52
        B.2.2.  Entire Domain, Monitoring Only, Per-Message
-               Reports . . . . . . . . . . . . . . . . . . . . . . .  55
+               Reports . . . . . . . . . . . . . . . . . . . . . . .  53
        B.2.3.  Per-Message Failure Reports Directed to Third
-               Party . . . . . . . . . . . . . . . . . . . . . . . .  56
+               Party . . . . . . . . . . . . . . . . . . . . . . . .  54
        B.2.4.  Subdomain, Testing, and Multiple Aggregate Report
-               URIs  . . . . . . . . . . . . . . . . . . . . . . . .  57
-     B.3.  Mail Receiver Example . . . . . . . . . . . . . . . . . .  59
-     B.4.  Processing of SMTP Time . . . . . . . . . . . . . . . . .  59
-     B.5.  Utilization of Aggregate Feedback: Example  . . . . . . .  61
-   Appendix C.  Change Log . . . . . . . . . . . . . . . . . . . . .  61
-     C.1.  January 5, 2021 . . . . . . . . . . . . . . . . . . . . .  61
-       C.1.1.  Ticket 80 - DMARCbis SHould Have Clear and Concise
-               Defintion of DMARC  . . . . . . . . . . . . . . . . .  61
-     C.2.  February 4, 2021  . . . . . . . . . . . . . . . . . . . .  62
-       C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208 . . . . . . . . . . .  62
-     C.3.  February 10, 2021 . . . . . . . . . . . . . . . . . . . .  62
-       C.3.1.  Ticket 84 - Remove Erroneous References to RFC3986  .  62
-     C.4.  March 1, 2021 . . . . . . . . . . . . . . . . . . . . . .  62
-       C.4.1.  Design Team Work Begins . . . . . . . . . . . . . . .  62
-     C.5.  March 8, 2021 . . . . . . . . . . . . . . . . . . . . . .  62
-       C.5.1.  Removed E.  Gustafsson as editor  . . . . . . . . . .  62
-       C.5.2.  Ticket 3 - Two tiny nits  . . . . . . . . . . . . . .  62
-       C.5.3.  Ticket 4 - Definition of "fo" parameter . . . . . . .  63
-     C.6.  March 16, 2021  . . . . . . . . . . . . . . . . . . . . .  63
-       C.6.1.  Ticket 7 - ABNF for dmarc-record is slightly wrong  .  63
-       C.6.2.  Ticket 26 - ABNF for pct allows "999" . . . . . . . .  63
-     C.7.  March 23, 2021  . . . . . . . . . . . . . . . . . . . . .  63
-       C.7.1.  Ticket 75 - Using wording alternatives to
-               'disposition', 'dispose', and the like  . . . . . . .  63
-       C.7.2.  Ticket 72 - Remove absolute requirement for p= tag in
-               DMARC record  . . . . . . . . . . . . . . . . . . . .  63
-     C.8.  March 29, 2021  . . . . . . . . . . . . . . . . . . . . .  64
-       C.8.1.  Ticket 54 - Remove or expand limits on number of
-               recipients per report . . . . . . . . . . . . . . . .  64
-     C.9.  April 12, 2021  . . . . . . . . . . . . . . . . . . . . .  64
-       C.9.1.  Ticket 50 - Remove ri= tag  . . . . . . . . . . . . .  64
-       C.9.2.  Ticket 66 - Define what it means to have implemented
-               DMARC . . . . . . . . . . . . . . . . . . . . . . . .  64
-       C.9.3.  Ticket 96 - Tweaks to Abstract and Introduction . . .  64
-     C.10. April 13, 2021  . . . . . . . . . . . . . . . . . . . . .  64
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 4]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-       C.10.1.  Ticket 53 - Remove reporting message size
-               chunking  . . . . . . . . . . . . . . . . . . . . . .  64
-       C.10.2.  Ticket 52 - Remove strict alignment (and adkim and
-               aspf tags)  . . . . . . . . . . . . . . . . . . . . .  64
-       C.10.3.  Ticket 47 - Remove pct= tag  . . . . . . . . . . . .  65
-       C.10.4.  Ticket 2 - Flow of operations text in dmarc-base . .  65
-     C.11. April 14, 2021  . . . . . . . . . . . . . . . . . . . . .  65
-       C.11.1.  Ticket 107 - DMARCbis should take a stand on
-               multi-valued From fields  . . . . . . . . . . . . . .  65
-       C.11.2.  Ticket 82 - Deprecate rf= and maybe fo= tag  . . . .  65
-       C.11.3.  Ticket 85 - Proposed change to wording describing 'p'
-               tag and values  . . . . . . . . . . . . . . . . . . .  65
-     C.12. April 15, 2021  . . . . . . . . . . . . . . . . . . . . .  65
-       C.12.1.  Ticket 86 - A-R results for DMARC  . . . . . . . . .  65
-       C.12.2.  Ticket 62 - Make aggregate reporting a normative
-               MUST  . . . . . . . . . . . . . . . . . . . . . . . .  66
-     C.13. April 19, 2021  . . . . . . . . . . . . . . . . . . . . .  66
-       C.13.1.  Ticket 109 - Sanity Check DMARCbis Document  . . . .  66
-     C.14. April 20, 2021  . . . . . . . . . . . . . . . . . . . . .  66
-       C.14.1.  Ticket 108 - Changes to DMARCbis for PSD . . . . . .  66
-     C.15. April 22, 2021  . . . . . . . . . . . . . . . . . . . . .  66
-       C.15.1.  Ticket 104 - Update the Security Considerations
-               section 11.3 on DNS . . . . . . . . . . . . . . . . .  66
-     C.16. June 16, 2021 . . . . . . . . . . . . . . . . . . . . . .  66
-       C.16.1.  Publication of draft-ietf-dmarc-dmarcbis-02  . . . .  66
-     C.17. August 12, 2021 . . . . . . . . . . . . . . . . . . . . .  66
-       C.17.1.  Publication of draft-ietf-dmarc-dmarcbis-03  . . . .  66
-   Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . .  67
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  67
+               URIs  . . . . . . . . . . . . . . . . . . . . . . . .  55
+     B.3.  Mail Receiver Example . . . . . . . . . . . . . . . . . .  57
+       B.3.1.  SMTP Session Example  . . . . . . . . . . . . . . . .  57
+     B.4.  Utilization of Aggregate Feedback: Example  . . . . . . .  59
+   Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . .  59
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  60
 
 1.  Introduction
 
@@ -270,18 +201,11 @@ Internet-Draft                  DMARCbis                   November 2021
    trusted by - the recipient.  The Sender Policy Framework (SPF)
    [RFC7208] and DomainKeys Identified Mail (DKIM) [RFC6376] protocols
    provide domain-level authentication but are not directly associated
-   with the RFC5322.From domain.  DMARC leverages them, and provides a
-   method for Domain Owners to publish a DNS record describing the email
-   authentication policies for the RFC5322.From domain and to request a
-   specific handling for messages using that domain that fail
-   authentication checks.
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 5]
-
-Internet-Draft                  DMARCbis                   November 2021
-
+   with the RFC5322.From domain.  DMARC leverages these two protocols,
+   providing a method for Domain Owners to publish a DNS record
+   describing the email authentication policies for the RFC5322.From
+   domain and to request specific handling for messages using that
+   domain that fail authentication checks.
 
    As with SPF and DKIM, DMARC classes results as "pass" or "fail".  In
    order to get a DMARC result of "pass", a pass from either SPF or DKIM
@@ -293,6 +217,15 @@ Internet-Draft                  DMARCbis                   November 2021
    hierarchy for the RFC5322.From domain while having the same
    administrative authority as the RFC5322.From domain.  Domains are "in
    strict alignment" if and only if they are identical.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                  [Page 4]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    A DMARC pass indicates only that the RFC5322.From domain has been
    authenticated for that message.  Authentication does not carry an
@@ -328,16 +261,8 @@ Internet-Draft                  DMARCbis                   November 2021
    authentication practices.  However, as with honoring the Domain
    Owner's stated mail handling preference, a mail-receiving
    organization supporting DMARC is under no obligation to send
-   requested reports.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 6]
-
-Internet-Draft                  DMARCbis                   November 2021
-
+   requested reports, although it is recommended that they do send
+   aggregate reports.
 
    Use of DMARC creates some interoperability challenges that require
    due consideration before deployment, particularly with configurations
@@ -349,6 +274,14 @@ Internet-Draft                  DMARCbis                   November 2021
    Specification of DMARC is guided by the following high-level goals,
    security dependencies, detailed requirements, and items that are
    documented as out of scope.
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                  [Page 5]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 2.1.  High-Level Goals
 
@@ -369,54 +302,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    *  Work at Internet scale.
 
-2.2.  Out of Scope
-
-   Several topics and issues are specifically out of scope for this
-   work.  These include the following:
-
-   *  Different treatment of messages that are not authenticated versus
-      those that fail authentication;
-
-   *  Evaluation of anything other than RFC5322.From header field;
-
-   *  Multiple reporting formats;
-
-   *  Publishing policy other than via the DNS;
-
-   *  Reporting or otherwise evaluating other than the last-hop IP
-      address;
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 7]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-   *  Attacks in the From: header field, also known as "display name"
-      attacks;
-
-   *  Authentication of entities other than domains, since DMARC is
-      built upon SPF and DKIM, which authenticate domains; and
-
-   *  Content analysis.
-
-2.3.  Scalability
-
-   Scalability is a major issue for systems that need to operate in a
-   system as widely deployed as current SMTP email.  For this reason,
-   DMARC seeks to avoid the need for third parties or pre-sending
-   agreements between senders and receivers.  This preserves the
-   positive aspects of the current email infrastructure.
-
-   Although DMARC does not introduce third-party senders (namely
-   external agents authorized to send on behalf of an operator) to the
-   email-handling flow, it also does not preclude them.  Such third
-   parties are free to provide services in conjunction with DMARC.
-
-2.4.  Anti-Phishing
+2.2.  Anti-Phishing
 
    DMARC is designed to prevent bad actors from sending mail that claims
    to come from legitimate senders, particularly senders of
@@ -436,20 +322,56 @@ Internet-Draft                  DMARCbis                   November 2021
    use of visually similar domain names ("cousin domains") or abuse of
    the RFC5322.From human-readable <display-name>.
 
-3.  Terminology and Definitions
+2.3.  Scalability
 
-   This section defines terms used in the rest of the document.
+   Scalability is a major issue for systems that need to operate in a
+   system as widely deployed as current SMTP email.  For this reason,
+   DMARC seeks to avoid the need for third parties or pre-sending
+   agreements between senders and receivers.  This preserves the
+   positive aspects of the current email infrastructure.
 
 
 
 
 
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 8]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                  [Page 6]
 
 Internet-Draft                  DMARCbis                   November 2021
 
+
+   Although DMARC does not introduce third-party senders (namely
+   external agents authorized to send on behalf of an operator) to the
+   email-handling flow, it also does not preclude them.  Such third
+   parties are free to provide services in conjunction with DMARC.
+
+2.4.  Out of Scope
+
+   Several topics and issues are specifically out of scope for this
+   work.  These include the following:
+
+   *  Different treatment of messages that are not authenticated versus
+      those that fail authentication;
+
+   *  Evaluation of anything other than RFC5322.From header field;
+
+   *  Multiple reporting formats;
+
+   *  Publishing policy other than via the DNS;
+
+   *  Reporting or otherwise evaluating other than the last-hop IP
+      address;
+
+   *  Attacks in the RFC5322.From header field, also known as "display
+      name" attacks;
+
+   *  Authentication of entities other than domains, since DMARC is
+      built upon SPF and DKIM, which authenticate domains; and
+
+   *  Content analysis.
+
+3.  Terminology and Definitions
+
+   This section defines terms used in the rest of the document.
 
 3.1.  Conventions Used in This Document
 
@@ -465,6 +387,14 @@ Internet-Draft                  DMARCbis                   November 2021
    contexts.  For example, a Domain Owner could, via the messaging
    security mechanisms on which DMARC is based, delegate the ability to
    send mail as the Domain Owner to a third party with another role.
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                  [Page 7]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    This document does not address the distinctions among such roles; the
    reader is encouraged to become familiar with that material before
    continuing.
@@ -481,8 +411,8 @@ Internet-Draft                  DMARCbis                   November 2021
 
 3.2.2.  Author Domain
 
-   The domain name of the apparent author, as extracted from the From:
-   header field.
+   The domain name of the apparent author, as extracted from the
+   RFC5322.From header field.
 
 3.2.3.  Domain Owner
 
@@ -497,39 +427,37 @@ Internet-Draft                  DMARCbis                   November 2021
    Receivers, when those are outside of their immediate management
    domain.
 
+3.2.4.  Identifier Alignment
+
+   When the domain in the address in the RFC5322.From header field has
+   the same Organizational Domain as a domain verified by an
+   authenticated identifier, it has Identifier Alignment. (see
+   Section 3.2.7)
+
+3.2.5.  Mail Receiver
+
+   The entity or organization that receives and processes email.  Mail
+   Receivers operate one or more Internet-facing Mail Transport Agents
+   (MTAs).
 
 
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 9]
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                  [Page 8]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-3.2.4.  Identifier Alignment
-
-   When the domain in the address in the From: header field has the same
-   Organizational Domain as a domain verified by an authenticated
-   identifier, it has Identifier Alignment. (see below)
-
-3.2.5.  Longest PSD
-
-   The term Longest PSD is defined in [RFC9091].
-
-3.2.6.  Mail Receiver
-
-   The entity or organization that receives and processes email.
-   Mail Receivers operate one or more Internet-facing Mail Transport
-   Agents (MTAs).
-
-3.2.7.  Non-existent Domains
+3.2.6.  Non-existent Domains
 
    For DMARC purposes, a non-existent domain is a domain for which there
    is an NXDOMAIN or NODATA response for A, AAAA, and MX records.  This
    is a broader definition than that in [RFC8020].
 
-3.2.8.  Organizational Domain
+3.2.7.  Organizational Domain
 
    The Organizational Domain is typically a domain that was registered
    with a domain name registrar.  More formally, it is any Public Suffix
@@ -537,33 +465,19 @@ Internet-Draft                  DMARCbis                   November 2021
    the RFC5322.From domain is determined by applying the algorithm found
    in Section 4.6.
 
-3.2.9.  Public Suffix Domain (PSD)
+3.2.8.  Public Suffix Domain (PSD)
 
    The term Public Suffix Domain is defined in [RFC9091].
 
-3.2.10.  Public Suffix Operator (PSO)
+3.2.9.  Public Suffix Operator (PSO)
 
    The term Public Suffix Operator is defined in [RFC9091].
 
-3.2.11.  PSO Controlled Domain Names
+3.2.10.  PSO Controlled Domain Names
 
    The term PSO Controlled Domain Names is defined in [RFC9091].
 
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 10]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-3.2.12.  Report Receiver
+3.2.11.  Report Receiver
 
    An operator that receives reports from another operator implementing
    the reporting mechanisms described in this document and/or the
@@ -579,6 +493,20 @@ Internet-Draft                  DMARCbis                   November 2021
    This section provides a general overview of the design and operation
    of the DMARC environment.
 
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                  [Page 9]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 4.1.  DMARC Basics
 
    DMARC permits a Domain Owner or PSO to enable verification of a
@@ -590,12 +518,12 @@ Internet-Draft                  DMARCbis                   November 2021
 
    DMARC's verification function is based on whether the RFC5322.From
    domain is aligned with a domain name used in a supported
-   authentication mechanism.  Section 4.3 When a DMARC policy exists for
-   the domain name found in the RFC5322.From header field, and that
-   domain name is not verified through an aligned supported
-   authentication mechanism, the handling of that message can be
-   affected based on the DMARC policy when delivered to a participating
-   receiver.
+   authentication mechanism, as described in Section 4.3.  When a DMARC
+   policy exists for the domain name found in the RFC5322.From header
+   field, and that domain name is not verified through an aligned
+   supported authentication mechanism, the handling of that message can
+   be affected based on the DMARC policy when delivered to a
+   participating receiver.
 
    A message satisfies the DMARC checks if at least one of the supported
    authentication mechanisms:
@@ -609,15 +537,6 @@ Internet-Draft                  DMARCbis                   November 2021
    by DMARC authenticate only a DNS domain and do not authenticate the
    local-part of any email address identifier found in a message, nor do
    they validate the legitimacy of message content.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 11]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    DMARC's feedback component involves the collection of information
    about received messages claiming to be from the Author Domain for
@@ -633,6 +552,16 @@ Internet-Draft                  DMARCbis                   November 2021
    analyzing attacks.  The capability for such services is enabled by
    DMARC but defined in other referenced material such as [RFC6591] and
    [DMARC-Failure-Reporting]
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 10]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 4.2.  Use of RFC5322.From
 
@@ -662,18 +591,9 @@ Internet-Draft                  DMARCbis                   November 2021
       with that mailbox, if the end user knows that these various
       protections have been provided.
 
-   The absence of a single, properly formed RFC5322.From header field
-   renders the message invalid.  Handling of such a message is outside
-   of the scope of this specification.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 12]
-
-Internet-Draft                  DMARCbis                   November 2021
-
+   *  The absence of a single, properly formed RFC5322.From header field
+      renders the message invalid.  Handling of such a message is
+      outside of the scope of this specification.
 
    Since the sorts of mail typically protected by DMARC participants
    tend to only have single Authors, DMARC participants generally
@@ -689,47 +609,22 @@ Internet-Draft                  DMARCbis                   November 2021
       content of the "d=" tag of a verified DKIM-Signature header field.
 
    *  SPF, [RFC7208], which can authenticate both the domain found in an
-      [RFC5321] HELO/EHLO command (the HELO identity) and the domain
-      found in an SMTP MAIL command (the MAIL FROM identity).  As noted
-      earlier, however, DMARC relies solely on SPF authentication of the
-      domain found in SMTP MAIL FROM command.  Section 2.4 of [RFC7208]
-      describes MAIL FROM processing for cases in which the MAIL command
-      has a null path.
-
-4.4.  Flow Diagram
+      SMTP [RFC5321] HELO/EHLO command (the HELO identity) and the
+      domain found in an SMTP MAIL command (the MAIL FROM identity).  As
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 13]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 11]
 
 Internet-Draft                  DMARCbis                   November 2021
 
+
+      noted earlier, however, DMARC relies solely on SPF authentication
+      of the domain found in SMTP MAIL FROM command.  Section 2.4 of
+      [RFC7208] describes MAIL FROM processing for cases in which the
+      MAIL command has a null path.
+
+4.4.  Flow Diagram
 
     +---------------+                             +--------------------+
     | Author Domain |< . . . . . . . . . . . .    | Return-Path Domain |
@@ -768,6 +663,18 @@ Internet-Draft                  DMARCbis                   November 2021
    authentication modules.  "sMTA" is the sending MTA, and "rMTA" is the
    receiving MTA.
 
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 12]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    Put simply, when a message reaches a DMARC-aware rMTA, a DNS query
    will be initiated to determine if a DMARC policy exists that applies
    to the author domain.  If a policy is found, the rMTA will use the
@@ -778,25 +685,17 @@ Internet-Draft                  DMARCbis                   November 2021
    More details on specific actions for the parties involved can be
    found in Section 5.5 and Section 5.7.
 
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 14]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
 4.5.  DNS Tree Walk
 
    While the DMARC protocol defines a method for communicating
-   information through publishing records in DNS, it is not necessarily
-   true that a DMARC policy record for a given domain will be found in
-   DNS at the same level as the name label for the domain in question.
-   Instead, some domains will inherit their DNS policy records from
-   parent domains one level or more above them in the DNS hierarchy, and
-   these records can only be discovered through a technique described
-   here, one known colloquially as a "DNS Tree Walk".
+   information through the publishing of records in DNS, it is not
+   necessarily true that a DMARC policy record for a given domain will
+   be found in DNS at the same level as the name label for the domain in
+   question.  Instead, some domains will inherit their DNS policy
+   records from parent domains one level or more above them in the DNS
+   hierarchy, and these records can only be discovered through a
+   technique described here, one known colloquially as a "DNS Tree
+   Walk".
 
    The process for a DNS Tree Walk will always start at the point in the
    DNS hierarchy that matches the domain in the RFC5322.From header of
@@ -825,6 +724,13 @@ Internet-Draft                  DMARCbis                   November 2021
        "a.mail.example.com", "com" would be label 1, "example" would be
        label 2, "mail.example.com" would be label 3, and so forth.
 
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 13]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    5.  Count the number of labels found in the subject DNS domain.  Let
        that number be "x".  If x < 5, remove the left-most (highest-
        numbered) label from the subject domain.  If x >= 5, remove the
@@ -835,13 +741,6 @@ Internet-Draft                  DMARCbis                   November 2021
    6.  Query the DNS for a DMARC TXT record at the DNS domain matching
        this new target in place of the RFC5322.From domain in the
        message.  A possibly empty set of records is returned.
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 15]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    7.  Records that do not start with a "v=" tag that identifies the
        current version of DMARC are discarded.
@@ -880,6 +779,14 @@ Internet-Draft                  DMARCbis                   November 2021
    Section 4.5.  The target of the search is a valid DMARC record that
    contains a psd tag with a value of 'y'.  Once such a record has been
    found, the Organizational Domain for the DNS domain matching the one
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 14]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    found in the RFC5322.From domain can be declared to be the target
    domain queried for in the step just prior to the query that found the
    PSD domain.
@@ -891,13 +798,6 @@ Internet-Draft                  DMARCbis                   November 2021
    and so the Organizational Domain for this RFC5322.From domain would
    be determined to be "example.com", the domain of the DMARC query
    executed prior to the query for "_dmarc.com".
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 16]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 4.7.  Identifier Alignment Explained
 
@@ -915,7 +815,7 @@ Internet-Draft                  DMARCbis                   November 2021
    Authenticated Identifier (a condition known as "relaxed alignment")
    or that it be identical to the domain of the Authenticated Identifier
    (a condition known as "strict alignment").  The choice of relaxed or
-   strict alignment is left to the domain owner and is expressed in the
+   strict alignment is left to the Domain Owner and is expressed in the
    domain's DMARC policy record.  Domain names in this context are to be
    compared in a case-insensitive manner, per [RFC4343].
 
@@ -933,6 +833,16 @@ Internet-Draft                  DMARCbis                   November 2021
    as input yields authenticated domains as their outputs when they
    succeed.
 
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 15]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 4.7.1.  DKIM-Authenticated Identifiers
 
    DMARC requires Identifier Alignment based on the result of a DKIM
@@ -944,16 +854,6 @@ Internet-Draft                  DMARCbis                   November 2021
    DMARC permits Identifier Alignment based on the result of a DKIM
    authentication to be strict or relaxed.  (Note that these terms are
    not related to DKIM's "simple" and "relaxed" canonicalization modes.)
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 17]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    In relaxed mode, the Organizational Domains of both the DKIM-
    authenticated signing domain (taken from the value of the d= tag in
@@ -989,6 +889,16 @@ Internet-Draft                  DMARCbis                   November 2021
    to be considered to be aligned.  In strict mode, the two FQDNs must
    match exactly in order from them to be considered to be aligned.
 
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 16]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    For example, in relaxed mode, if a message passes an SPF check with
    an RFC5321.MailFrom domain of "cbg.bounces.example.com", and the
    address portion of the RFC5322.From header field contains
@@ -1003,14 +913,6 @@ Internet-Draft                  DMARCbis                   November 2021
    [RFC7208], which recommends that SPF checks be done on not only the
    "MAIL FROM" but also on a separate check of the "HELO" identity.
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 18]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
 4.7.3.  Alignment and Extension Technologies
 
    If in the future DMARC is extended to include the use of other
@@ -1020,21 +922,21 @@ Internet-Draft                  DMARCbis                   November 2021
 
 5.  Policy
 
-   DMARC policies are published by Domain Owners and PSOs and can be
-   used by Mail Receivers to inform their message handling decisions.
-
    A Domain Owner or PSO advertises DMARC participation of one or more
    of its domains by adding a DNS TXT record (described in Section 5.1)
    to those domains.  In doing so, Domain Owners and PSOs indicate their
    handling preference regarding failed authentication for email
    messages making use of their domain in the RFC5322.From header field
-   as well as the provision of feedback about those messages.  Mail
+   as well as their desire for feedback about those messages.  Mail
    Receivers in turn can take into account the Domain Owner's stated
    preference when making handling decisions about email messages that
    fail DMARC authentication checks.
 
    A Domain Owner or PSO may choose not to participate in DMARC
-   evaluation by Mail Receivers.  In this case, the Domain Owner simply
+   evaluation by Mail Receivers simply by not publishing an appropriate
+   DNS TXT record for its domain(s).  A Domain Owner can also choose to
+   not have some underlying authentication technologies apply to DMARC
+   evaluation of its domain(s).  In this case, the Domain Owner simply
    declines to advertise participation in those schemes.  For example,
    if the results of path authorization checks ought not be considered
    as part of the overall DMARC result for a given Author Domain, then
@@ -1045,27 +947,20 @@ Internet-Draft                  DMARCbis                   November 2021
    effort attempt to adhere to the Domain Owner's or PSO's published
    DMARC Domain Owner Assessment Policy when a message fails the DMARC
    test.  Since email streams can be complicated (due to forwarding,
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 17]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    existing RFC5322.From domain-spoofing services, etc.), Mail Receivers
    MAY deviate from a published Domain Owner Assessment Policy during
    message processing and SHOULD make available the fact of and reason
    for the deviation to the Domain Owner via feedback reporting,
    specifically using the "PolicyOverride" feature of the aggregate
    report defined in [DMARC-Aggregate-Reporting]
-
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 19]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 5.1.  DMARC Policy Record
 
@@ -1107,21 +1002,19 @@ Internet-Draft                  DMARCbis                   November 2021
 
    A formal definition is provided in Section 5.4.
 
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 18]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 5.3.  General Record Format
 
    DMARC records follow the extensible "tag-value" syntax for DNS-based
    key records defined in DKIM [RFC6376].
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 20]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    Section 8 creates a registry for known DMARC tags and registers the
    initial set defined in this document.  Only tags defined in this
@@ -1154,50 +1047,32 @@ Internet-Draft                  DMARCbis                   November 2021
       This tag's content MUST be ignored if a "ruf" tag (below) is not
       also specified.  Failure reporting options are shown below.  The
       value of this tag is either "0", "1", or a colon-separated list of
-      the options represented by alphabetic characters.
+      the options represented by alphabetic characters.  The valid
+      values and their meanings are:
 
-   The valid values and their meanings are:
+      0:  Generate a DMARC failure report if all underlying
+         authentication mechanisms fail to produce an aligned "pass"
+         result.
 
+      1:  Generate a DMARC failure report if any underlying
+         authentication mechanism produced something other than an
+         aligned "pass" result.
 
-
-
-
-
-
-
-
-
-
+      d:  Generate a DKIM failure report if the message had a signature
 
 
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 21]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 19]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-   0:
-   :  Generate a DMARC failure report if all underlying
-      authentication mechanisms fail to produce an aligned "pass"
-      result.
+         that failed evaluation, regardless of its alignment.  DKIM-
+         specific reporting is described in [RFC6651].
 
-   1:
-   :  Generate a DMARC failure report if any underlying
-      authentication mechanism produced something other than an
-      aligned "pass" result.
-
-   d:
-   :  Generate a DKIM failure report if the message had a signature
-      that failed evaluation, regardless of its alignment.  DKIM-
-      specific reporting is described in [@!RFC6651].
-
-   s:
-   :  Generate an SPF failure report if the message failed SPF
-      evaluation, regardless of its alignment.  SPF-specific
-      reporting is described in [@!RFC6652].
+      s:  Generate an SPF failure report if the message failed SPF
+         evaluation, regardless of its alignment.  SPF-specific
+         reporting is described in [RFC6652].
 
    np:  Domain Owner Assessment Policy for non-existent subdomains
       (plain-text; OPTIONAL).  Indicates the message handling preference
@@ -1227,14 +1102,6 @@ Internet-Draft                  DMARCbis                   November 2021
 
       quarantine:  The Domain Owner considers such mail to be
          suspicious.  It is possible the mail is valid, although the
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 22]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
          failure creates a significant concern.
 
       reject:  The Domain Owner considers all such failures to be a
@@ -1248,6 +1115,14 @@ Internet-Draft                  DMARCbis                   November 2021
       y:  Domains on the PSL that publish DMARC policy records SHOULD
          include this tag with a value of 'y' to indicate that the
          domain is a PSD.  This information will be used during policy
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 20]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
          discovery to determine how to apply any DMARC policy records
          that are discovered during the tree walk.
 
@@ -1259,12 +1134,12 @@ Internet-Draft                  DMARCbis                   November 2021
       [DMARC-Aggregate-Reporting] discusses considerations that apply
       when the domain name of a URI differs from that of the domain
       advertising the policy.  See Section 9.5 for additional
-      considerations.  Any valid URI can be specified.
-         A Mail Receiver MUST implement support for a "mailto:" URI,
-      i.e., the ability to send a DMARC report via electronic mail.  If
-      not provided, Mail Receivers MUST NOT generate aggregate feedback
-      reports.  URIs not supported by Mail Receivers MUST be ignored.
-      The aggregate feedback report format is described in
+      considerations.  Any valid URI can be specified.  A Mail Receiver
+      MUST implement support for a "mailto:" URI, i.e., the ability to
+      send a DMARC report via electronic mail.  If the tag is not
+      provided, Mail Receivers MUST NOT generate aggregate feedback
+      reports for the domain.  URIs not supported by Mail Receivers MUST
+      be ignored.  The aggregate feedback report format is described in
       [DMARC-Aggregate-Reporting]
 
    ruf:  Addresses to which message-specific failure information is to
@@ -1277,19 +1152,9 @@ Internet-Draft                  DMARCbis                   November 2021
       discusses considerations that apply when the domain name of a URI
       differs from that of the domain advertising the policy.  A Mail
       Receiver MUST implement support for a "mailto:" URI, i.e., the
-      ability to send a DMARC report via electronic mail.  If not
-      provided, Mail Receivers MUST NOT generate failure reports.  See
-      Section 9.5 for additional considerations.
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 23]
-
-Internet-Draft                  DMARCbis                   November 2021
-
+      ability to send a DMARC report via electronic mail.  If the tag is
+      not provided, Mail Receivers MUST NOT generate failure reports for
+      the domain.  See Section 9.5 for additional considerations.
 
    sp:  Domain Owner Assessment Policy for all subdomains (plain-text;
       OPTIONAL).  Indicates the message handling preference the Domain
@@ -1303,6 +1168,16 @@ Internet-Draft                  DMARCbis                   November 2021
       DMARC records published on subdomains of Organizational Domains
       due to the effect of the DMARC policy discovery mechanism
       described in Section 5.7.2.1.
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 21]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    t:  DMARC policy test mode (plain-text; OPTIONAL; default is 'n').
       For the RFC5322.From domain to which the DMARC record applies, the
@@ -1339,14 +1214,6 @@ Internet-Draft                  DMARCbis                   November 2021
    the "v" tag's value), but a change to any existing tags does require
    a new version of DMARC.
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 24]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
 5.4.  Formal Definition
 
    The formal definition of the DMARC format, using [RFC5234], is as
@@ -1360,9 +1227,17 @@ Internet-Draft                  DMARCbis                   November 2021
      dmarc-record    = dmarc-version dmarc-sep *(dmarc-tag dmarc-sep)
 
      dmarc-tag       = dmarc-request /
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 22]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
                        dmarc-test /
                        dmarc-psd /
-                       dmarc-srequest /
+                       dmarc-sprequest /
                        dmarc-nprequest /
                        dmarc-adkim /
                        dmarc-aspf /
@@ -1384,7 +1259,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
      dmarc-psd       = "psd" *WSP "=" ( "y" / "n" )
 
-     dmarc-srequest  = "sp" *WSP "=" *WSP
+     dmarc-sprequest = "sp" *WSP "=" *WSP
                        ( "none" / "quarantine" / "reject" )
 
      dmarc-nprequest  = "np" *WSP "=" *WSP
@@ -1395,14 +1270,6 @@ Internet-Draft                  DMARCbis                   November 2021
      dmarc-aspf      = "aspf" *WSP "=" *WSP ( "r" / "s" )
 
      dmarc-auri      = "rua" *WSP "=" *WSP
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 25]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
                        dmarc-uri *(*WSP "," *WSP dmarc-uri)
 
      dmarc-furi      = "ruf" *WSP "=" *WSP
@@ -1416,6 +1283,14 @@ Internet-Draft                  DMARCbis                   November 2021
 
    "Keyword" is imported from Section 4.1.2 of [RFC5321].
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 23]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 5.5.  Domain Owner Actions
 
    This section describes Domain Owner actions to fully implement the
@@ -1425,11 +1300,13 @@ Internet-Draft                  DMARCbis                   November 2021
 
    Because DMARC relies on SPF [RFC7208] and DKIM [RFC6376], in order to
    take full advantage of DMARC, a Domain Owner SHOULD first ensure that
-   SPF and DKIM authentication are properly configured.  The easiest
-   first step here is to choose a domain to use as the RFC5321.From
-   domain (i.e., the Return-Path domain) for its mail, one that aligns
-   with the Author Domain, and then publish an SPF policy in DNS for
-   that domain.
+   SPF and DKIM authentication are properly configured.  As a first step
+   the Domain Owner SHOULD choose a domain to use as the
+   RFC5321.MailFrom domain (i.e., the Return-Path domain) for its mail,
+   one that aligns with the Author Domain, and then publish an SPF
+   policy in DNS for that domain.  The SPF record SHOULD be constructed
+   at a minimum to ensure an SPF pass verdict for all known sources of
+   mail for the RFC5321.MailFrom domain.
 
 5.5.2.  Configure Sending System for DKIM Signing Using an Aligned
         Domain
@@ -1440,24 +1317,8 @@ Internet-Draft                  DMARCbis                   November 2021
    failure of just one of them.  The Domain Owner SHOULD choose a DKIM-
    Signing domain (i.e., the d= domain in the DKIM-Signature header)
    that aligns with the Author Domain and configure its system to sign
-   using that domain.
-
-
-
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 26]
-
-Internet-Draft                  DMARCbis                   November 2021
-
+   using that domain, to include publishing a corresponding DKIM public
+   key in DNS.
 
 5.5.3.  Setup a Mailbox to Receive Aggregate Reports
 
@@ -1470,21 +1331,28 @@ Internet-Draft                  DMARCbis                   November 2021
    could be legitimate ones that were overlooked during the intial
    deployment of SPF and/or DKIM.
 
-   Because the aggregate reports are XML documents, it is strongly
-   advised that they be machine-parsed, so setting up a mailbox involves
-   more than just the physical creation of the mailbox.  Many third-
-   party services exist that will process DMARC aggregate reports, or
-   the Domain Owner can create its own set of tools.  No matter which
-   method is chosen, the ability to parse these reports and consume the
-   data contained in them will go a long way to ensuring a successful
+   Because the aggregate reports are XML documents, it is recommended
+   that they be machine-parsed, so setting up a mailbox involves more
+   than just the physical creation of that mailbox.  Many third-party
+   services exist that will process DMARC aggregate reports, or the
+   Domain Owner can create its own set of tools.  No matter which method
+   is chosen, the ability to parse these reports and consume the data
+   contained in them will go a long way to ensuring a successful
    deployment.
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 24]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 5.5.4.  Publish a DMARC Policy for the Author Domain
 
    Once SPF, DKIM, and the aggregate reports mailbox are all in place,
    it's time to publish a DMARC record.  For best results, Domain Owners
-   SHOULD start with "p=none", with the rua tag containg the mailbox
-   created in the previous step.
+   SHOULD start with "p=none", with the rua tag containg a URI that
+   references the mailbox created in the previous step.
 
 5.5.5.  Collect and Analyze Reports and Adjust Authentication
 
@@ -1497,23 +1365,6 @@ Internet-Draft                  DMARCbis                   November 2021
    its own mail streams.  Should any overlooked systems be found in the
    reports, the Domain Owner can adjust the SPF record and/or configure
    DKIM signing for those systems.
-
-
-
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 27]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 5.5.6.  Decide If and When to Update DMARC Policy
 
@@ -1545,6 +1396,13 @@ Internet-Draft                  DMARCbis                   November 2021
    8, the domain name must be converted to an A-label, as described in
    Section 2.3 of [RFC5890], for further processing.
 
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 25]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    In order to be processed by DMARC, a message typically needs to
    contain exactly one RFC5322.From domain (a single From: field with a
    single domain in it).  Not all messages meet this requirement, and
@@ -1562,14 +1420,6 @@ Internet-Draft                  DMARCbis                   November 2021
 
    Note that Public Suffix Domains are not exempt from DMARC policy
    application and reporting.
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 28]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 5.7.2.  Determine Handling Policy
 
@@ -1599,14 +1449,24 @@ Internet-Draft                  DMARCbis                   November 2021
        reasons for failure.  The results MUST further include the domain
        name used to complete the SPF check.
 
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 26]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    5.  Conduct Identifier Alignment checks.  With authentication checks
        and policy discovery performed, the Mail Receiver checks to see
        if Authenticated Identifiers fall into alignment as described in
-       Section 3.  If one or more of the Authenticated Identifiers align
-       with the RFC5322.From domain, the message is considered to pass
-       the DMARC mechanism check.  All other conditions (authentication
-       failures, identifier mismatches) are considered to be DMARC
-       mechanism check failures.
+       Section 4.7.  If one or more of the Authenticated Identifiers
+       align with the RFC5322.From domain, the message is considered to
+       pass the DMARC mechanism check.  All other conditions
+       (authentication failures, identifier mismatches) are considered
+       to be DMARC mechanism check failures.
 
    6.  Apply policy, if appropriate.  Emails that fail the DMARC
        mechanism check are handled in accordance with the discovered
@@ -1618,14 +1478,6 @@ Internet-Draft                  DMARCbis                   November 2021
    the case that the Domain Owner wishes a Message Receiver not to
    consider the results of that underlying authentication protocol at
    all.
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 29]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    DMARC evaluation can only yield a "pass" result after one of the
    underlying authentication mechanisms passes for an aligned
@@ -1653,6 +1505,16 @@ Internet-Draft                  DMARCbis                   November 2021
    2.  If a retrieved policy record does not contain a valid "p" tag, or
        contains an "sp" tag that is not valid, then:
 
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 27]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
        *  If a "rua" tag is present and contains at least one
           syntactically valid reporting URI, the Mail Receiver SHOULD
           act as if a record containing a valid "v" tag and "p=none" was
@@ -1675,18 +1537,10 @@ Internet-Draft                  DMARCbis                   November 2021
    cleared, allowing a definite DMARC conclusion to be reached ("fail
    closed").
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 30]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    Note: Because the PSD policy query comes after the Organizational
    Domain policy query, PSD policy is not used for Organizational
    domains that have published a DMARC policy.  Specifically, this is
-   not a mechanism to provide feedback addresses (RUA/RUF) when an
+   not a mechanism to provide feedback addresses (rua/ruf) when an
    Organizational Domain has declined to do so.
 
 5.7.3.  Store Results of DMARC Processing
@@ -1695,6 +1549,27 @@ Internet-Draft                  DMARCbis                   November 2021
    for eventual presentation back to the Domain Owner in the form of
    aggregate feedback reports.  Section 5.3 and
    [DMARC-Aggregate-Reporting] discuss aggregate feedback.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 28]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 5.7.4.  Send Aggregate Reports
 
@@ -1711,9 +1586,9 @@ Internet-Draft                  DMARCbis                   November 2021
    with handling decisions for a message in ways that p= tag values of
    'none' cannot.
 
-   In order to ensure maximum usefulness for DMARC across the email
-   ecosystem, then, Mail Receivers SHOULD generate and send aggregate
-   reports with a frequency of at least once every 24 hours.
+   Given the above, in order to ensure maximum usefulness for DMARC
+   across the email ecosystem, Mail Receivers SHOULD generate and send
+   aggregate reports with a frequency of at least once every 24 hours.
 
 5.8.  Policy Enforcement Considerations
 
@@ -1731,14 +1606,6 @@ Internet-Draft                  DMARCbis                   November 2021
    increase the likelihood of accepting abusive mail if they choose not
    to honor the published Domain Owner Assessment Policy.  At a minimum,
    addition of the Authentication-Results header field (see [RFC8601])
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 31]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    is RECOMMENDED when delivery of failing mail is done.  When this is
    done, the DNS domain name thus recorded MUST be encoded as an
    A-label.
@@ -1750,6 +1617,15 @@ Internet-Draft                  DMARCbis                   November 2021
    of local policy.  If local policy information is exposed, abusers can
    gain insight into the effectiveness and delivery rates of spam
    campaigns.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 29]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    Final handling of a message is always a matter of local policy.  An
    operator that wishes to favor DMARC policy over SPF policy, for
@@ -1788,13 +1664,6 @@ Internet-Draft                  DMARCbis                   November 2021
    The details of this feedback are described in
    [DMARC-Aggregate-Reporting]
 
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 32]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    Operational note for PSD DMARC: For PSOs, feedback for non-existent
    domains is desirable and useful, just as it is for org-level DMARC
    operators.  See Section 4 of [RFC9091] for discussion of Privacy
@@ -1804,6 +1673,15 @@ Internet-Draft                  DMARCbis                   November 2021
 
    This section discusses some topics regarding choices made in the
    development of DMARC, largely to commit the history to record.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 30]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 7.1.  Issues Specific to SPF
 
@@ -1843,24 +1721,23 @@ Internet-Draft                  DMARCbis                   November 2021
    responsiveness of DMARC preference changes while preserving the
    benefits of DNS caching.
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 33]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
 7.3.  Rejecting Messages
 
    This protocol calls for rejection of a message during the SMTP
    session under certain circumstances.  This is preferable to
-   generation of a Delivery Status Notification ([RFC3464]), since
+   generation of a Delivery Status Notification [RFC3464], since
    fraudulent messages caught and rejected using DMARC would then result
    in annoying generation of such failure reports that go back to the
    RFC5321.MailFrom address.
 
    This synchronous rejection is typically done in one of two ways:
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 31]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    *  Full rejection, wherein the SMTP server issues a 5xy reply code as
       an indication to the SMTP client that the transaction failed; the
@@ -1900,13 +1777,6 @@ Internet-Draft                  DMARCbis                   November 2021
    retrieve or apply DMARC policy, this is best done with a 4xy SMTP
    reply code.
 
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 34]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
 7.4.  Identifier Alignment Considerations
 
    The DMARC mechanism allows both DKIM and SPF-authenticated
@@ -1915,6 +1785,15 @@ Internet-Draft                  DMARCbis                   November 2021
    users can gain control of the SPF record or DKIM selector records for
    a subdomain, the subdomain can be used to generate DMARC-passing
    email on behalf of the Organizational Domain.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 32]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    For example, an attacker who controls the SPF record for
    "evil.example.com" can send mail with an RFC5322.From header field
@@ -1958,7 +1837,16 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 35]
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 33]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2014,7 +1902,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 36]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 34]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2070,7 +1958,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 37]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 35]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2126,7 +2014,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 38]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 36]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2182,7 +2070,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 39]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 37]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2238,7 +2126,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 40]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 38]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2270,8 +2158,10 @@ Internet-Draft                  DMARCbis                   November 2021
 
    The DMARC mechanism and its underlying technologies (SPF, DKIM)
    depend on the security of the DNS.  Examples of how hostile parties
-   can have an adverse impact on DNS traffic include: * If they can
-   snoop on DNS traffic, they can get an idea of who is sending mail.
+   can have an adverse impact on DNS traffic include:
+
+   *  If they can snoop on DNS traffic, they can get an idea of who is
+      sending mail.
 
    *  If they can block outgoing or reply DNS messages, they can prevent
       systems from discovering senders' DMARC policies, causing
@@ -2292,9 +2182,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 41]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 39]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2350,7 +2238,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 42]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 40]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2406,7 +2294,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 43]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 41]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2462,7 +2350,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 44]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 42]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2518,7 +2406,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 45]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 43]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2566,15 +2454,15 @@ Internet-Draft                  DMARCbis                   November 2021
 Appendix A.  Technology Considerations
 
    This section documents some design decisions that were made in the
-   development of DMARC.  Specifically, addressed here are some
-   suggestions that were considered but not included in the design.
-   This text is included to explain why they were considered and not
-   included in this version.
+   development of DMARC.  Specifically addressed here are some
+   suggestions that were considered but not included in the design, with
+   explanatory text regarding the decision.
 
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 46]
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 44]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2630,7 +2518,7 @@ A.2.  Method Exclusion
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 47]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 45]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2686,7 +2574,7 @@ A.4.  Domain Existence Test
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 48]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 46]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2742,66 +2630,77 @@ A.5.  Issues with ADSP in Operation
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 49]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 47]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
 A.6.  Organizational Domain Discovery Issues
 
-   Although protocols like ADSP are useful for "protecting" a specific
-   domain name, they are not helpful at protecting subdomains.  If one
-   wished to protect "example.com" by requiring via ADSP that all mail
-   bearing an RFC5322.From domain of "example.com" be signed, this would
-   "protect" that domain; however, one could then craft an email whose
-   RFC5322.From domain is "security.example.com", and ADSP would not
-   provide any protection.  One could use a DNS wildcard, but this can
-   undesirably interfere with other DNS activity; one could add ADSP
-   records as fraudulent domains are discovered, but this solution does
-   not scale and is a purely reactive measure against abuse.
+   An earlier informational version of the DMARC protocol [RFC7489]
+   noted that the DNS does not provide a method by which the "domain of
+   record", or the domain that was actually registered with a domain
+   registrar, can be determined given an arbitrary domain name.  That
+   version further mentioned suggestions that have been made that
+   attempt to glean such information from SOA or NS resource records,
+   but these too are not fully reliable, as the partitioning of the DNS
+   is not always done at administrative boundaries.
 
-   The DNS does not provide a method by which the "domain of record", or
-   the domain that was actually registered with a domain registrar, can
-   be determined given an arbitrary domain name.  Suggestions have been
-   made that attempt to glean such information from SOA or NS resource
-   records, but these too are not fully reliable, as the partitioning of
-   the DNS is not always done at administrative boundaries.
+   That previous version posited that one could "climb the tree" to find
+   the Organizational Domain, but expressed concern that an attacker
+   could exploit this for a denial-of-service attack through sending a
+   high number of messages each with a relatively large number of
+   nonsense labels, causing a Mail Receiver to perform a large number of
+   DNS queries in search of a policy record.  This version defines a
+   method for performing a DNS Tree Walk, described in Section 4.5, and
+   further mitigates the risk of the denial-of-service attack by
+   expressly limiting the number of DNS queries to execute regardless of
+   the number of labels in the domain name.
 
-   When seeking domain-specific policy based on an arbitrary domain
-   name, one could "climb the tree", dropping labels off the left end of
-   the name until the root is reached or a policy is discovered, but
-   then one could craft a name that has a large number of nonsense
-   labels; this would cause a Mail Receiver to attempt a large number of
-   queries in search of a policy record.  Sending many such messages
-   constitutes an amplified denial-of-service attack.
+   As a matter of historical record, the method for finding the
+   Organizational Domain described in [RFC7489] is preserved here:
 
-   The Organizational Domain mechanism is a necessary component to the
-   goals of DMARC.  The method described in Section 4.6 is far from
-   perfect but serves this purpose reasonably well without adding undue
-   burden or semantics to the DNS.  If a method is created to do so that
-   is more reliable and secure than the use of a public suffix list,
-   DMARC should be amended to use that method as soon as it is generally
-   available.
+   1.  Acquire a "public suffix" list (PSL), i.e., a list of DNS domain
+       names reserved for registrations.  Some country Top-Level Domains
+       (TLDs) make specific registration requirements, e.g., the United
+       Kingdom places company registrations under ".co.uk"; other TLDs
+       such as ".com" appear in the IANA registry of top-level DNS
+       domains.  A PSL is the union of all of these.
 
-A.6.1.  Public Suffix Lists
+       A PSL can be obtained from various sources.  The most common one
+       is maintained by the Mozilla Foundation and made public at
+       http://publicsuffix.org (http://publicsuffix.org).  License terms
+       governing the use of that list are available at that URI.
 
-   A public suffix list for the purposes of determining the
-   Organizational Domain can be obtained from various sources.  The most
-   common one is maintained by the Mozilla Foundation and made public at
-   http://publicsuffix.org (http://publicsuffix.org).  License terms
-   governing the use of that list are available at that URI.
+       Note that if operators use a variety of public suffix lists,
+       interoperability will be difficult or impossible to guarantee.
 
-   Note that if operators use a variety of public suffix lists,
-   interoperability will be difficult or impossible to guarantee.
+   2.  Break the subject DNS domain name into a set of "n" ordered
+       labels.  Number these labels from right to left; e.g., for
+       "example.com", "com" would be label 1 and "example" would be
+       label 2.
 
-
+   3.  Search the public suffix list for the name that matches the
+       largest number of labels found in the subject DNS domain.  Let
+       that number be "x".
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 50]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 48]
 
 Internet-Draft                  DMARCbis                   November 2021
 
+
+   4.  Construct a new DNS domain name using the name that matched from
+       the public suffix list and prefixing to it the "x+1"th label from
+       the subject domain.  This new name is the Organizational Domain.
+
+   Thus, since "com" is an IANA-registered TLD, a subject domain of
+   "a.b.c.d.example.com" would have an Organizational Domain of
+   "example.com".
+
+   The process of determining a suffix is currently a heuristic one.  No
+   list is guaranteed to be accurate or current.
 
 A.7.  Removal of the "pct" Tag
 
@@ -2814,18 +2713,16 @@ A.7.  Removal of the "pct" Tag
    for just a percentage of messages that produced DMARC results of
    "fail".
 
-   Operational experience and mathematics (specifically the Probability
-   Mass Function as applied to Binomial Distributions) showed that the
-   pct tag was usually not accurately applied, unless the value
-   specified was either "0" or "100" (the default), and the inaccuracies
-   with other values varied widely from implementation to
-   implementation.  The default value was easily implemented, as it
-   required no special processing on the part of the message receiver,
-   while the value of "0" took on unintended significance as a value
-   used by some intermediaries and mailbox providers as an indicator to
-   deviate from standard handling of the message, usually by rewriting
-   the RFC5322.From header in an effort to avoid DMARC failures
-   downstream.
+   Operational experience showed that the pct tag was usually not
+   accurately applied, unless the value specified was either "0" or
+   "100" (the default), and the inaccuracies with other values varied
+   widely from implementation to implementation.  The default value was
+   easily implemented, as it required no special processing on the part
+   of the message receiver, while the value of "0" took on unintended
+   significance as a value used by some intermediaries and mailbox
+   providers as an indicator to deviate from standard handling of the
+   message, usually by rewriting the RFC5322.From header in an effort to
+   avoid DMARC failures downstream.
 
    These custom actions when the pct= tag was set to "0" proved valuable
    to the email community.  In particular, header rewriting by an
@@ -2843,6 +2740,13 @@ A.7.  Removal of the "pct" Tag
    informed decision regarding subjecting its mail traffic to possible
    DMARC failures based on the Domain Owner's tolerance for such things.
 
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 49]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    Because of the value provided by "pct=0" to Domain Owners, it was
    logical to keep this functionality in the protocol; at the same time
    it didn't make sense to support a tag named "pct" that had only two
@@ -2851,13 +2755,6 @@ A.7.  Removal of the "pct" Tag
    values of "y" and "n", which are meant to be analogous in their
    application by mailbox providers and intermediaries to the "pct" tag
    values "0" and "100", respectively.
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 51]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 Appendix B.  Examples
 
@@ -2898,22 +2795,20 @@ B.1.1.  SPF
         To: receiver@example.org
         Subject: here's a sample
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 50]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    In this case, the RFC5322.From header parameter includes a DNS domain
    that is a parent of the RFC5321.MailFrom domain.  Thus, the
    identifiers are in relaxed alignment, because they both have the same
    Organizational Domain (example.com).
 
    Example 3: SPF not in alignment:
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 52]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
         MAIL FROM: <sender@example.net>
 
@@ -2956,6 +2851,14 @@ B.1.2.  DKIM
    identifiers are in relaxed alignment, as they have the same
    Organizational Domain (example.com).
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 51]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    Example 3: DKIM not in alignment:
 
         DKIM-Signature: v=1; ...; d=sample.net; ...
@@ -2963,13 +2866,6 @@ B.1.2.  DKIM
         Date: Fri, Feb 15 2002 16:54:30 -0800
         To: receiver@example.org
         Subject: here's a sample
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 53]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    In this case, the DKIM signature's "d=" parameter includes a DNS
    domain that is neither the same as, a parent of, nor a child of the
@@ -3012,20 +2908,18 @@ B.2.1.  Entire Domain, Monitoring Only
    *  All messages from this Organizational Domain are subject to this
       policy (no "t" tag present, so the default of "n" applies).
 
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 52]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    The DMARC policy record might look like this when retrieved using a
    common command-line tool:
 
      % dig +short TXT _dmarc.example.com.
      "v=DMARC1; p=none; rua=mailto:dmarc-feedback@example.com"
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 54]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    To publish such a record, the DNS administrator for the Domain Owner
    creates an entry like the following in the appropriate zone file
@@ -3045,13 +2939,13 @@ B.2.2.  Entire Domain, Monitoring Only, Per-Message Reports
    problems, they wish to request per-message failure reports when
    authentication failures occur.
 
-   Not all Receivers will honor such a request, but the Domain Owner
-   feels that any reports it does receive will be helpful enough to
-   justify publishing this record.  The default per-message report
+   Not all Mail Receivers will honor such a request, but the Domain
+   Owner feels that any reports it does receive will be helpful enough
+   to justify publishing this record.  The default per-message report
    format ([RFC6591]) meets the Domain Owner's needs in this scenario.
 
    The Domain Owner accomplishes this by adding the following to its
-   policy record from Appendix B.2:
+   policy record from Appendix B.2.1:
 
    *  Per-message failure reports should be sent via email to the
       address "auth-reports@example.com" ("ruf=mailto:auth-
@@ -3069,28 +2963,28 @@ B.2.2.  Entire Domain, Monitoring Only, Per-Message Reports
    might create an entry like the following in the appropriate zone file
    (following the conventional zone file format):
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 53]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
      ; DMARC record for the domain example.com
 
      _dmarc  IN TXT ( "v=DMARC1; p=none; "
                        "rua=mailto:dmarc-feedback@example.com; "
                        "ruf=mailto:auth-reports@example.com" )
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 55]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
 B.2.3.  Per-Message Failure Reports Directed to Third Party
 
    The Domain Owner from the previous example is maintaining the same
    policy but now wishes to have a third party receive and process the
-   per-message failure reports.  Again, not all Receivers will honor
-   this request, but those that do may implement additional checks to
-   verify that the third party wishes to receive the failure reports for
-   this domain.
+   per-message failure reports.  Again, not all Mail Receivers will
+   honor this request, but those that do may implement additional checks
+   to verify that the third party wishes to receive the failure reports
+   for this domain.
 
    The Domain Owner needs to alter its policy record from Appendix B.2.2
    as follows:
@@ -3119,25 +3013,25 @@ B.2.3.  Per-Message Failure Reports Directed to Third Party
 
    Because the address used in the "ruf" tag is outside the
    Organizational Domain in which this record is published, conforming
-   Receivers will implement additional checks as described in Section 3
-   of [DMARC-Aggregate-Reporting].  In order to pass these additional
-   checks, the third party will need to publish an additional DNS record
-   as follows:
+   Mail Receivers will implement additional checks as described in
+   Section 3 of [DMARC-Aggregate-Reporting].  In order to pass these
+   additional checks, the third party will need to publish an additional
+   DNS record as follows:
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 54]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    *  Given the DMARC record published by the Domain Owner at
       "_dmarc.example.com", the DNS administrator for the third party
       will need to publish a TXT resource record at
       "example.com._report._dmarc.thirdparty.example.net" with the value
       "v=DMARC1;".
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 56]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    The resulting DNS record might look like this when retrieved using a
    common command-line tool (the output shown would appear on a single
@@ -3180,20 +3074,20 @@ B.2.4.  Subdomain, Testing, and Multiple Aggregate Report URIs
 
    *  The version of DMARC being used is "DMARC1" ("v=DMARC1;")
 
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 55]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    *  It is applied only to this subdomain (record is published at
       "_dmarc.test.example.com" and not "_dmarc.example.com")
 
    *  Receivers are advised that the Domain Owner considers messages
       that fail to authenticate to be suspicious ("p=quarantine")
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 57]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    *  Aggregate feedback reports should be sent via email to the
       addresses "dmarc-feedback@example.com" and "example-tld-
@@ -3212,7 +3106,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
      % dig +short TXT _dmarc.test.example.com
      "v=DMARC1; p=quarantine; rua=mailto:dmarc-feedback@example.com,
-      mailto:tld-test@thirdparty.example.net t=y"
+      mailto:tld-test@thirdparty.example.net; t=y"
 
    To publish such a record, the DNS administrator for the Domain Owner
    might create an entry like the following in the appropriate zone
@@ -3232,24 +3126,22 @@ Internet-Draft                  DMARCbis                   November 2021
    it considers authentication failures to be a clear indication that
    use of the subdomain is not valid.  It would do this by altering the
    DNS record to advise receivers of its position on such messages
-   ("p=reject").
+   ("p=reject") and removing the testing flag ("t=y").
 
    After alteration, the DMARC policy record might look like this when
    retrieved using a common command-line tool (the output shown would
    appear on a single line but is wrapped here for publication):
 
-     % dig +short TXT _dmarc.test.example.com
-     "v=DMARC1; p=reject; rua=mailto:dmarc-feedback@example.com,
-      mailto:tld-test@thirdparty.example.net"
 
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 58]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 56]
 
 Internet-Draft                  DMARCbis                   November 2021
 
+
+     % dig +short TXT _dmarc.test.example.com
+     "v=DMARC1; p=reject; rua=mailto:dmarc-feedback@example.com,
+      mailto:tld-test@thirdparty.example.net"
 
    To publish such a record, the DNS administrator for the Domain Owner
    might create an entry like the following in the appropriate zone
@@ -3268,7 +3160,7 @@ B.3.  Mail Receiver Example
    from various email-processing stages to provide feedback to Domain
    Owners (possibly via Report Receivers).
 
-B.4.  Processing of SMTP Time
+B.3.1.  SMTP Session Example
 
    An optimal DMARC-enabled Mail Receiver performs authentication and
    Identifier Alignment checking during the SMTP [RFC5321] conversation.
@@ -3298,11 +3190,7 @@ B.4.  Processing of SMTP Time
 
 
 
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 59]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 57]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3324,11 +3212,10 @@ Internet-Draft                  DMARCbis                   November 2021
    the Mail Receiver applies the DMARC-record-specified policy.
    However, before this action is taken, the Mail Receiver can consult
    external information to override the Domain Owner's Assessment
-   Policy.
-   For example, if the Mail Receiver knows that this particular email
-   came from a known and trusted forwarder (that happens to break both
-   SPF and DKIM), then the Mail Receiver may choose to ignore the Domain
-   Owner's policy.
+   Policy.  For example, if the Mail Receiver knows that this particular
+   email came from a known and trusted forwarder (that happens to break
+   both SPF and DKIM), then the Mail Receiver may choose to ignore the
+   Domain Owner's policy.
 
    The Mail Receiver is now ready to reply to the DATA command.  If the
    DMARC check yields that the message is to be rejected, then the Mail
@@ -3358,12 +3245,13 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 60]
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 58]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-B.5.  Utilization of Aggregate Feedback: Example
+B.4.  Utilization of Aggregate Feedback: Example
 
    Aggregate feedback is consumed by Domain Owners to verify their
    understanding of how a given domain is being processed by the Mail
@@ -3394,318 +3282,6 @@ B.5.  Utilization of Aggregate Feedback: Example
    regarding failing authentication checks can also allow the Domain
    Owner to come to an understanding of how its domain is being misused.
 
-   (Aggregate report example should be moved to
-   [DMARC-Aggregate-Reporting])
-
-Appendix C.  Change Log
-
-C.1.  January 5, 2021
-
-C.1.1.  Ticket 80 - DMARCbis SHould Have Clear and Concise Defintion of
-        DMARC
-
-   *  Updated text for Abstract and Introduction sections.
-
-   *  Diffs are recorded here - https://github.com/ietf-wg-dmarc/draft-
-      ietf-dmarc-dmarcbis/pull/1/files (https://github.com/ietf-wg-
-      dmarc/draft-ietf-dmarc-dmarcbis/pull/1/files)
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 61]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-C.2.  February 4, 2021
-
-C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208
-
-   *  Some rearranging of text in the "SPF-Authenticated Identifiers"
-      section
-
-   *  Clarification of the term "in alignment" in that same section
-
-   *  Diffs are here - https://github.com/ietf-wg-dmarc/draft-ietf-
-      dmarc-dmarcbis/pull/3/files (https://github.com/ietf-wg-dmarc/
-      draft-ietf-dmarc-dmarcbis/pull/3/files)
-
-C.3.  February 10, 2021
-
-C.3.1.  Ticket 84 - Remove Erroneous References to RFC3986
-
-   *  Several references to RFC3986 changed to RFC7208
-
-   *  Diffs are here - https://github.com/ietf-wg-dmarc/draft-ietf-
-      dmarc-dmarcbis/pull/4/files (https://github.com/ietf-wg-dmarc/
-      draft-ietf-dmarc-dmarcbis/pull/4/files)
-
-C.4.  March 1, 2021
-
-C.4.1.  Design Team Work Begins
-
-   *  Added change log section to document
-
-C.5.  March 8, 2021
-
-C.5.1.  Removed E.  Gustafsson as editor
-
-   *  He withdrew as editor after a job change.
-
-C.5.2.  Ticket 3 - Two tiny nits
-
-   *  Changes to wording in section 6.6.2, Determine Handling Policy,
-      steps 3 and 4.
-
-   *  New text documented here - https://trac.ietf.org/trac/dmarc/
-      ticket/3#comment:6 (https://trac.ietf.org/trac/dmarc/
-      ticket/3#comment:6)
-
-   *  No change to section 6.6.3, Policy Discovery; ticket seems to pre-
-      date current text, which appears to have answered the concern
-      raised.
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 62]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-C.5.3.  Ticket 4 - Definition of "fo" parameter
-
-   *  Changes to wording in section 6.3, to bring clarity to use of
-      colon-separated list as possible value to "fo"
-
-   *  New text documented here - https://trac.ietf.org/trac/dmarc/
-      ticket/4#comment:4 (https://trac.ietf.org/trac/dmarc/
-      ticket/4#comment:4)
-
-C.6.  March 16, 2021
-
-C.6.1.  Ticket 7 - ABNF for dmarc-record is slightly wrong
-
-   *  New text documented here - https://trac.ietf.org/trac/dmarc/
-      ticket/7 (https://trac.ietf.org/trac/dmarc/ticket/7)
-
-C.6.2.  Ticket 26 - ABNF for pct allows "999"
-
-   *  Updated ABNF for dmarc-percent
-
-   *  New text documented here - https://trac.ietf.org/trac/dmarc/
-      ticket/26#comment:6 (https://trac.ietf.org/trac/dmarc/
-      ticket/26#comment:6)
-
-   *  Ticket 47, Remove pct= tag, rendered change obsolete
-
-C.7.  March 23, 2021
-
-C.7.1.  Ticket 75 - Using wording alternatives to 'disposition',
-        'dispose', and the like
-
-   *  Changed disposition/dispose to "handling"
-
-   *  Diffs documented here - https://trac.ietf.org/trac/dmarc/
-      ticket/75#comment:3 (https://trac.ietf.org/trac/dmarc/
-      ticket/75#comment:3)
-
-C.7.2.  Ticket 72 - Remove absolute requirement for p= tag in DMARC
-        record
-
-   *  Changed from REQUIRED to RECOMMENDED, noted default with forward
-      reference to discussion
-
-   *  Diffs documented here - https://trac.ietf.org/trac/dmarc/
-      ticket/72#comment:3 (https://trac.ietf.org/trac/dmarc/
-      ticket/72#comment:3)
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 63]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-C.8.  March 29, 2021
-
-C.8.1.  Ticket 54 - Remove or expand limits on number of recipients per
-        report
-
-   *  Removed limit
-
-   *  Diffs documented here - https://trac.ietf.org/trac/dmarc/
-      ticket/54#comment:5 (https://trac.ietf.org/trac/dmarc/
-      ticket/54#comment:5)
-
-C.9.  April 12, 2021
-
-C.9.1.  Ticket 50 - Remove ri= tag
-
-   *  Updated text to recommend against its usage, a la the ptr
-      mechanism in RFC 7208
-
-   *  Diffs documented here - https://trac.ietf.org/trac/dmarc/
-      ticket/50#comment:5 (https://trac.ietf.org/trac/dmarc/
-      ticket/50#comment:5)
-
-C.9.2.  Ticket 66 - Define what it means to have implemented DMARC
-
-   *  Proposed new text (taken straight from
-      https://trac.ietf.org/trac/dmarc/ticket/66
-      (https://trac.ietf.org/trac/dmarc/ticket/66) as replacement for
-      current text in "Minimum Implemenatations"
-
-C.9.3.  Ticket 96 - Tweaks to Abstract and Introduction
-
-   *  Changed phrase in Abstract to "an email author's domain name"
-
-   *  Changed phrase in Introduction to "reports about email use of the
-      domain name"
-
-C.10.  April 13, 2021
-
-C.10.1.  Ticket 53 - Remove reporting message size chunking
-
-   *  Proposed text to remove all references to message size chunking
-
-   *  Data demonstrating lack of use of feature entered into ticket -
-      https://trac.ietf.org/trac/dmarc/ticket/53#comment:4
-      (https://trac.ietf.org/trac/dmarc/ticket/53#comment:4)
-
-C.10.2.  Ticket 52 - Remove strict alignment (and adkim and aspf tags)
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 64]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-   *  Proposed text to remove all references to strict alignment
-
-   *  Data demonstrating lack of use of feature entered into ticket -
-      https://trac.ietf.org/trac/dmarc/ticket/52#comment:2
-      (https://trac.ietf.org/trac/dmarc/ticket/52#comment:2)
-
-C.10.3.  Ticket 47 - Remove pct= tag
-
-   *  Proposed text to remove all references to pct and message sampling
-
-   *  Data demonstrating lack of use of feature entered into ticket -
-      https://trac.ietf.org/trac/dmarc/ticket/47#comment:4
-      (https://trac.ietf.org/trac/dmarc/ticket/47#comment:4)
-
-C.10.4.  Ticket 2 - Flow of operations text in dmarc-base
-
-   *  Update ASCII Art
-
-   *  Proposed text to replace description of ASCII Art
-
-   *  Proposed text to update Domain Owner Actions section
-
-C.11.  April 14, 2021
-
-C.11.1.  Ticket 107 - DMARCbis should take a stand on multi-valued From
-         fields
-
-   *  Proposed text that limits processing to only those times when all
-      domains are the same.
-
-C.11.2.  Ticket 82 - Deprecate rf= and maybe fo= tag
-
-   *  Proposed text to deprecate rf= tag, while leaving fo= tag as is
-
-C.11.3.  Ticket 85 - Proposed change to wording describing 'p' tag and
-         values
-
-   *  The language expressing the semantics is proposed to be changed to
-      be, in a sense, egocentric.  How do I, the domain owner feel about
-      (assess) the meaning of a DMARC failure?
-
-C.12.  April 15, 2021
-
-C.12.1.  Ticket 86 - A-R results for DMARC
-
-   *  Proposed text to add for polrec.p and polrec.domain methods for
-      registry update.
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 65]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-   *  Did not include polrec.pct due to proposal to remove pct tag
-      (Ticket 47)
-
-C.12.2.  Ticket 62 - Make aggregate reporting a normative MUST
-
-   *  Proposed text to do just that in Mail Receiver Actions, section
-      titled "Send Aggregate Reports"
-
-C.13.  April 19, 2021
-
-C.13.1.  Ticket 109 - Sanity Check DMARCbis Document
-
-   *  Updated document to remove all "original text"/"proposed text"
-      couplets in favor of one (hopefully coherent) document full of
-      proposed text changes.
-
-   *  Noted which tickets were the cause of whatever rfcdiff output will
-      show in tracker
-
-C.14.  April 20, 2021
-
-C.14.1.  Ticket 108 - Changes to DMARCbis for PSD
-
-   *  Incorporating requests for changes to DMARCbis made in text of
-      "Experimental DMARC Extension for Public Suffix Domains"
-      (https://datatracker.ietf.org/doc/draft-ietf-dmarc-psd/
-      (https://datatracker.ietf.org/doc/draft-ietf-dmarc-psd/))
-
-C.15.  April 22, 2021
-
-C.15.1.  Ticket 104 - Update the Security Considerations section 11.3 on
-         DNS
-
-   *  Updated text.  Diffs are here - https://github.com/ietf-wg-dmarc/
-      draft-ietf-dmarc-dmarcbis/pull/31/files (https://github.com/ietf-
-      wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/31/files)
-
-C.16.  June 16, 2021
-
-C.16.1.  Publication of draft-ietf-dmarc-dmarcbis-02
-
-   *  Includes final resolution for tickets 4, 47, 50, 52, 53, 54, and
-      82
-
-C.17.  August 12, 2021
-
-C.17.1.  Publication of draft-ietf-dmarc-dmarcbis-03
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 66]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-   *  Removal of "pct" tag
-
-   *  Addition of "t" tag
-
-   *  Rearranging of some text and formatting for better readability and
-      consistency.
-
 Acknowledgements
 
    DMARC and the draft version of this document submitted to the
@@ -3721,6 +3297,15 @@ Acknowledgements
    Draegen, Steve Jones, Franck Martin, Brett McDowell, and Paul Midgen.
    The contributors would also like to recognize the invaluable input
    and guidance that was provided early on by J.D.  Falk.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 59]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    Additional contributions within the IETF context were made by Kurt
    Anderson, Michael Jack Assels, Les Barstow, Anne Bennett, Jim Fenton,
@@ -3750,5 +3335,28 @@ Authors' Addresses
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 67]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 60]
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ DMARC                                                       T. Herr (ed)
 Internet-Draft                                                  Valimail
 Obsoletes: 7489 (if approved)                             J. Levine (ed)
 Intended status: Standards Track                           Standcore LLC
-Expires: 22 May 2022                                    18 November 2021
+Expires: 26 May 2022                                    22 November 2021
 
 
 Domain-based Message Authentication, Reporting, and Conformance (DMARC)
@@ -42,7 +42,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 22 May 2022.
+   This Internet-Draft will expire on 26 May 2022.
 
 Copyright Notice
 
@@ -54,7 +54,7 @@ Copyright Notice
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 1]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 1]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -91,108 +91,107 @@ Table of Contents
        3.2.10. Public Suffix Operator (PSO)  . . . . . . . . . . . .  10
        3.2.11. PSO Controlled Domain Names . . . . . . . . . . . . .  10
        3.2.12. Report Receiver . . . . . . . . . . . . . . . . . . .  11
-     3.3.  More on Identifier Alignment  . . . . . . . . . . . . . .  11
-       3.3.1.  DKIM-Authenticated Identifiers  . . . . . . . . . . .  12
-       3.3.2.  SPF-Authenticated Identifiers . . . . . . . . . . . .  12
-       3.3.3.  Alignment and Extension Technologies  . . . . . . . .  13
-     3.4.  Determining The Organizational Domain . . . . . . . . . .  13
-   4.  Overview  . . . . . . . . . . . . . . . . . . . . . . . . . .  14
-     4.1.  Authentication Mechanisms . . . . . . . . . . . . . . . .  14
-     4.2.  Key Concepts  . . . . . . . . . . . . . . . . . . . . . .  15
-     4.3.  Flow Diagram  . . . . . . . . . . . . . . . . . . . . . .  16
-   5.  Use of RFC5322.From . . . . . . . . . . . . . . . . . . . . .  17
-   6.  Policy  . . . . . . . . . . . . . . . . . . . . . . . . . . .  17
-     6.1.  DMARC Policy Record . . . . . . . . . . . . . . . . . . .  18
-     6.2.  DMARC URIs  . . . . . . . . . . . . . . . . . . . . . . .  19
-     6.3.  General Record Format . . . . . . . . . . . . . . . . . .  19
-     6.4.  Formal Definition . . . . . . . . . . . . . . . . . . . .  23
-     6.5.  Domain Owner Actions  . . . . . . . . . . . . . . . . . .  24
+   4.  Overview and Key Concepts . . . . . . . . . . . . . . . . . .  11
+     4.1.  Use of RFC5322.From . . . . . . . . . . . . . . . . . . .  12
+     4.2.  Authentication Mechanisms . . . . . . . . . . . . . . . .  13
+     4.3.  Flow Diagram  . . . . . . . . . . . . . . . . . . . . . .  13
+     4.4.  Identifier Alignment Explained  . . . . . . . . . . . . .  15
+       4.4.1.  DKIM-Authenticated Identifiers  . . . . . . . . . . .  15
+       4.4.2.  SPF-Authenticated Identifiers . . . . . . . . . . . .  16
+       4.4.3.  Alignment and Extension Technologies  . . . . . . . .  16
+     4.5.  Determining The Organizational Domain . . . . . . . . . .  17
+   5.  Policy  . . . . . . . . . . . . . . . . . . . . . . . . . . .  18
+     5.1.  DMARC Policy Record . . . . . . . . . . . . . . . . . . .  19
+     5.2.  DMARC URIs  . . . . . . . . . . . . . . . . . . . . . . .  19
+     5.3.  General Record Format . . . . . . . . . . . . . . . . . .  19
+     5.4.  Formal Definition . . . . . . . . . . . . . . . . . . . .  24
+     5.5.  Domain Owner Actions  . . . . . . . . . . . . . . . . . .  25
+       5.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  25
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 2]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 2]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-       6.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  24
-       6.5.2.  Configure Sending System for DKIM Signing Using an
-               Aligned Domain  . . . . . . . . . . . . . . . . . . .  24
-       6.5.3.  Setup a Mailbox to Receive Aggregate Reports  . . . .  25
-       6.5.4.  Publish a DMARC Policy for the Author Domain  . . . .  25
-       6.5.5.  Collect and Analyze Reports and Adjust
-               Authentication  . . . . . . . . . . . . . . . . . . .  25
-       6.5.6.  Decide If and When to Update DMARC Policy . . . . . .  26
-     6.6.  PSO Actions . . . . . . . . . . . . . . . . . . . . . . .  26
-     6.7.  Mail Receiver Actions . . . . . . . . . . . . . . . . . .  26
-       6.7.1.  Extract Author Domain . . . . . . . . . . . . . . . .  26
-       6.7.2.  Determine Handling Policy . . . . . . . . . . . . . .  27
-       6.7.3.  Policy Discovery  . . . . . . . . . . . . . . . . . .  28
-       6.7.4.  Store Results of DMARC Processing . . . . . . . . . .  30
-       6.7.5.  Send Aggregate Reports  . . . . . . . . . . . . . . .  30
-     6.8.  Policy Enforcement Considerations . . . . . . . . . . . .  31
-   7.  DMARC Feedback  . . . . . . . . . . . . . . . . . . . . . . .  32
-   8.  Other Topics  . . . . . . . . . . . . . . . . . . . . . . . .  32
-     8.1.  Issues Specific to SPF  . . . . . . . . . . . . . . . . .  32
-     8.2.  DNS Load and Caching  . . . . . . . . . . . . . . . . . .  33
-     8.3.  Rejecting Messages  . . . . . . . . . . . . . . . . . . .  33
-     8.4.  Identifier Alignment Considerations . . . . . . . . . . .  34
-     8.5.  Interoperability Issues . . . . . . . . . . . . . . . . .  34
-   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  35
-     9.1.  Authentication-Results Method Registry Update . . . . . .  35
-     9.2.  Authentication-Results Result Registry Update . . . . . .  36
-     9.3.  Feedback Report Header Fields Registry Update . . . . . .  37
-     9.4.  DMARC Tag Registry  . . . . . . . . . . . . . . . . . . .  37
-     9.5.  DMARC Report Format Registry  . . . . . . . . . . . . . .  39
-     9.6.  Underscored and Globally Scoped DNS Node Names
-           Registry  . . . . . . . . . . . . . . . . . . . . . . . .  39
-   10. Security Considerations . . . . . . . . . . . . . . . . . . .  39
-     10.1.  Authentication Methods . . . . . . . . . . . . . . . . .  40
-     10.2.  Attacks on Reporting URIs  . . . . . . . . . . . . . . .  40
-     10.3.  DNS Security . . . . . . . . . . . . . . . . . . . . . .  40
-     10.4.  Display Name Attacks . . . . . . . . . . . . . . . . . .  41
-     10.5.  External Reporting Addresses . . . . . . . . . . . . . .  42
-     10.6.  Secure Protocols . . . . . . . . . . . . . . . . . . . .  42
-   11. Normative References  . . . . . . . . . . . . . . . . . . . .  42
-   12. Informative References  . . . . . . . . . . . . . . . . . . .  44
+       5.5.2.  Configure Sending System for DKIM Signing Using an
+               Aligned Domain  . . . . . . . . . . . . . . . . . . .  25
+       5.5.3.  Setup a Mailbox to Receive Aggregate Reports  . . . .  25
+       5.5.4.  Publish a DMARC Policy for the Author Domain  . . . .  26
+       5.5.5.  Collect and Analyze Reports and Adjust
+               Authentication  . . . . . . . . . . . . . . . . . . .  26
+       5.5.6.  Decide If and When to Update DMARC Policy . . . . . .  26
+     5.6.  PSO Actions . . . . . . . . . . . . . . . . . . . . . . .  26
+     5.7.  Mail Receiver Actions . . . . . . . . . . . . . . . . . .  27
+       5.7.1.  Extract Author Domain . . . . . . . . . . . . . . . .  27
+       5.7.2.  Determine Handling Policy . . . . . . . . . . . . . .  27
+       5.7.3.  Policy Discovery  . . . . . . . . . . . . . . . . . .  29
+       5.7.4.  Store Results of DMARC Processing . . . . . . . . . .  31
+       5.7.5.  Send Aggregate Reports  . . . . . . . . . . . . . . .  31
+     5.8.  Policy Enforcement Considerations . . . . . . . . . . . .  31
+   6.  DMARC Feedback  . . . . . . . . . . . . . . . . . . . . . . .  32
+   7.  Other Topics  . . . . . . . . . . . . . . . . . . . . . . . .  33
+     7.1.  Issues Specific to SPF  . . . . . . . . . . . . . . . . .  33
+     7.2.  DNS Load and Caching  . . . . . . . . . . . . . . . . . .  33
+     7.3.  Rejecting Messages  . . . . . . . . . . . . . . . . . . .  34
+     7.4.  Identifier Alignment Considerations . . . . . . . . . . .  35
+     7.5.  Interoperability Issues . . . . . . . . . . . . . . . . .  35
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  35
+     8.1.  Authentication-Results Method Registry Update . . . . . .  35
+     8.2.  Authentication-Results Result Registry Update . . . . . .  36
+     8.3.  Feedback Report Header Fields Registry Update . . . . . .  37
+     8.4.  DMARC Tag Registry  . . . . . . . . . . . . . . . . . . .  38
+     8.5.  DMARC Report Format Registry  . . . . . . . . . . . . . .  39
+     8.6.  Underscored and Globally Scoped DNS Node Names
+           Registry  . . . . . . . . . . . . . . . . . . . . . . . .  40
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  40
+     9.1.  Authentication Methods  . . . . . . . . . . . . . . . . .  40
+     9.2.  Attacks on Reporting URIs . . . . . . . . . . . . . . . .  41
+     9.3.  DNS Security  . . . . . . . . . . . . . . . . . . . . . .  41
+     9.4.  Display Name Attacks  . . . . . . . . . . . . . . . . . .  42
+     9.5.  External Reporting Addresses  . . . . . . . . . . . . . .  42
+     9.6.  Secure Protocols  . . . . . . . . . . . . . . . . . . . .  43
+   10. Normative References  . . . . . . . . . . . . . . . . . . . .  43
+   11. Informative References  . . . . . . . . . . . . . . . . . . .  45
    Appendix A.  Technology Considerations  . . . . . . . . . . . . .  46
-     A.1.  S/MIME  . . . . . . . . . . . . . . . . . . . . . . . . .  46
-     A.2.  Method Exclusion  . . . . . . . . . . . . . . . . . . . .  46
-     A.3.  Sender Header Field . . . . . . . . . . . . . . . . . . .  47
+     A.1.  S/MIME  . . . . . . . . . . . . . . . . . . . . . . . . .  47
+     A.2.  Method Exclusion  . . . . . . . . . . . . . . . . . . . .  47
+     A.3.  Sender Header Field . . . . . . . . . . . . . . . . . . .  48
      A.4.  Domain Existence Test . . . . . . . . . . . . . . . . . .  48
-     A.5.  Issues with ADSP in Operation . . . . . . . . . . . . . .  48
-     A.6.  Organizational Domain Discovery Issues  . . . . . . . . .  49
+     A.5.  Issues with ADSP in Operation . . . . . . . . . . . . . .  49
+     A.6.  Organizational Domain Discovery Issues  . . . . . . . . .  50
        A.6.1.  Public Suffix Lists . . . . . . . . . . . . . . . . .  50
+     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  51
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 3]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 3]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  50
-   Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  51
-     B.1.  Identifier Alignment Examples . . . . . . . . . . . . . .  51
-       B.1.1.  SPF . . . . . . . . . . . . . . . . . . . . . . . . .  51
-       B.1.2.  DKIM  . . . . . . . . . . . . . . . . . . . . . . . .  52
-     B.2.  Domain Owner Example  . . . . . . . . . . . . . . . . . .  53
-       B.2.1.  Entire Domain, Monitoring Only  . . . . . . . . . . .  53
+   Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  52
+     B.1.  Identifier Alignment Examples . . . . . . . . . . . . . .  52
+       B.1.1.  SPF . . . . . . . . . . . . . . . . . . . . . . . . .  52
+       B.1.2.  DKIM  . . . . . . . . . . . . . . . . . . . . . . . .  53
+     B.2.  Domain Owner Example  . . . . . . . . . . . . . . . . . .  54
+       B.2.1.  Entire Domain, Monitoring Only  . . . . . . . . . . .  54
        B.2.2.  Entire Domain, Monitoring Only, Per-Message
-               Reports . . . . . . . . . . . . . . . . . . . . . . .  54
+               Reports . . . . . . . . . . . . . . . . . . . . . . .  55
        B.2.3.  Per-Message Failure Reports Directed to Third
-               Party . . . . . . . . . . . . . . . . . . . . . . . .  55
+               Party . . . . . . . . . . . . . . . . . . . . . . . .  56
        B.2.4.  Subdomain, Testing, and Multiple Aggregate Report
                URIs  . . . . . . . . . . . . . . . . . . . . . . . .  57
-     B.3.  Mail Receiver Example . . . . . . . . . . . . . . . . . .  58
+     B.3.  Mail Receiver Example . . . . . . . . . . . . . . . . . .  59
      B.4.  Processing of SMTP Time . . . . . . . . . . . . . . . . .  59
-     B.5.  Utilization of Aggregate Feedback: Example  . . . . . . .  60
+     B.5.  Utilization of Aggregate Feedback: Example  . . . . . . .  61
    Appendix C.  Change Log . . . . . . . . . . . . . . . . . . . . .  61
      C.1.  January 5, 2021 . . . . . . . . . . . . . . . . . . . . .  61
        C.1.1.  Ticket 80 - DMARCbis SHould Have Clear and Concise
                Defintion of DMARC  . . . . . . . . . . . . . . . . .  61
-     C.2.  February 4, 2021  . . . . . . . . . . . . . . . . . . . .  61
-       C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208 . . . . . . . . . . .  61
+     C.2.  February 4, 2021  . . . . . . . . . . . . . . . . . . . .  62
+       C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208 . . . . . . . . . . .  62
      C.3.  February 10, 2021 . . . . . . . . . . . . . . . . . . . .  62
        C.3.1.  Ticket 84 - Remove Erroneous References to RFC3986  .  62
      C.4.  March 1, 2021 . . . . . . . . . . . . . . . . . . . . . .  62
@@ -200,38 +199,37 @@ Internet-Draft                  DMARCbis                   November 2021
      C.5.  March 8, 2021 . . . . . . . . . . . . . . . . . . . . . .  62
        C.5.1.  Removed E.  Gustafsson as editor  . . . . . . . . . .  62
        C.5.2.  Ticket 3 - Two tiny nits  . . . . . . . . . . . . . .  62
-       C.5.3.  Ticket 4 - Definition of "fo" parameter . . . . . . .  62
-     C.6.  March 16, 2021  . . . . . . . . . . . . . . . . . . . . .  62
-       C.6.1.  Ticket 7 - ABNF for dmarc-record is slightly wrong  .  62
+       C.5.3.  Ticket 4 - Definition of "fo" parameter . . . . . . .  63
+     C.6.  March 16, 2021  . . . . . . . . . . . . . . . . . . . . .  63
+       C.6.1.  Ticket 7 - ABNF for dmarc-record is slightly wrong  .  63
        C.6.2.  Ticket 26 - ABNF for pct allows "999" . . . . . . . .  63
      C.7.  March 23, 2021  . . . . . . . . . . . . . . . . . . . . .  63
        C.7.1.  Ticket 75 - Using wording alternatives to
                'disposition', 'dispose', and the like  . . . . . . .  63
        C.7.2.  Ticket 72 - Remove absolute requirement for p= tag in
                DMARC record  . . . . . . . . . . . . . . . . . . . .  63
-     C.8.  March 29, 2021  . . . . . . . . . . . . . . . . . . . . .  63
+     C.8.  March 29, 2021  . . . . . . . . . . . . . . . . . . . . .  64
        C.8.1.  Ticket 54 - Remove or expand limits on number of
-               recipients per report . . . . . . . . . . . . . . . .  63
+               recipients per report . . . . . . . . . . . . . . . .  64
      C.9.  April 12, 2021  . . . . . . . . . . . . . . . . . . . . .  64
        C.9.1.  Ticket 50 - Remove ri= tag  . . . . . . . . . . . . .  64
        C.9.2.  Ticket 66 - Define what it means to have implemented
                DMARC . . . . . . . . . . . . . . . . . . . . . . . .  64
        C.9.3.  Ticket 96 - Tweaks to Abstract and Introduction . . .  64
      C.10. April 13, 2021  . . . . . . . . . . . . . . . . . . . . .  64
+       C.10.1.  Ticket 53 - Remove reporting message size
+               chunking  . . . . . . . . . . . . . . . . . . . . . .  64
 
 
 
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 4]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 4]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-       C.10.1.  Ticket 53 - Remove reporting message size
-               chunking  . . . . . . . . . . . . . . . . . . . . . .  64
        C.10.2.  Ticket 52 - Remove strict alignment (and adkim and
                aspf tags)  . . . . . . . . . . . . . . . . . . . . .  64
-       C.10.3.  Ticket 47 - Remove pct= tag  . . . . . . . . . . . .  64
+       C.10.3.  Ticket 47 - Remove pct= tag  . . . . . . . . . . . .  65
        C.10.4.  Ticket 2 - Flow of operations text in dmarc-base . .  65
      C.11. April 14, 2021  . . . . . . . . . . . . . . . . . . . . .  65
        C.11.1.  Ticket 107 - DMARCbis should take a stand on
@@ -242,8 +240,8 @@ Internet-Draft                  DMARCbis                   November 2021
      C.12. April 15, 2021  . . . . . . . . . . . . . . . . . . . . .  65
        C.12.1.  Ticket 86 - A-R results for DMARC  . . . . . . . . .  65
        C.12.2.  Ticket 62 - Make aggregate reporting a normative
-               MUST  . . . . . . . . . . . . . . . . . . . . . . . .  65
-     C.13. April 19, 2021  . . . . . . . . . . . . . . . . . . . . .  65
+               MUST  . . . . . . . . . . . . . . . . . . . . . . . .  66
+     C.13. April 19, 2021  . . . . . . . . . . . . . . . . . . . . .  66
        C.13.1.  Ticket 109 - Sanity Check DMARCbis Document  . . . .  66
      C.14. April 20, 2021  . . . . . . . . . . . . . . . . . . . . .  66
        C.14.1.  Ticket 108 - Changes to DMARCbis for PSD . . . . . .  66
@@ -278,7 +276,9 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 5]
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 5]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -334,7 +334,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 6]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 6]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -342,7 +342,7 @@ Internet-Draft                  DMARCbis                   November 2021
    Use of DMARC creates some interoperability challenges that require
    due consideration before deployment, particularly with configurations
    that can cause mail to be rejected.  These are discussed in
-   Section 8.
+   Section 7.
 
 2.  Requirements
 
@@ -390,7 +390,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 7]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 7]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -446,7 +446,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 8]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 8]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -477,7 +477,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    Domain-level identifiers that are verified using authentication
    technologies are referred to as "Authenticated Identifiers".  See
-   Section 4.1 for details about the supported mechanisms.
+   Section 4.2 for details about the supported mechanisms.
 
 3.2.2.  Author Domain
 
@@ -502,7 +502,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 9]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 9]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -532,10 +532,10 @@ Internet-Draft                  DMARCbis                   November 2021
 3.2.8.  Organizational Domain
 
    The Organizational Domain is typically a domain that was registered
-   with a domain name registrar.  More formally, it is a Public Suffix
+   with a domain name registrar.  More formally, it is any Public Suffix
    Domain plus one label.  The Organizational Domain for the domain in
    the RFC5322.From domain is determined by applying the algorithm found
-   in Section 3.4.
+   in Section 4.5.
 
 3.2.9.  Public Suffix Domain (PSD)
 
@@ -558,7 +558,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 10]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 10]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -574,218 +574,119 @@ Internet-Draft                  DMARCbis                   November 2021
    collectively to the system components that receive and process these
    reports and the organizations that operate them.
 
-3.3.  More on Identifier Alignment
-
-   Email authentication technologies authenticate various (and
-   disparate) aspects of an individual message.  For example, DKIM
-   [RFC6376] authenticates the domain that affixed a signature to the
-   message, while SPF [RFC7208] can authenticate either the domain that
-   appears in the RFC5321.MailFrom (MAIL FROM) portion of an SMTP
-   [RFC5321] conversation or the RFC5321.EHLO/HELO domain, or both.
-   These may be different domains, and they are typically not visible to
-   the end user.
-
-   DMARC authenticates use of the RFC5322.From domain by requiring that
-   it have the same Organizational Domain as (i.e., be aligned with) an
-   Authenticated Identifier.  Domain names in this context are to be
-   compared in a case-insensitive manner, per [RFC4343].  The
-   RFC5322.From domain was selected as the central identity of the DMARC
-   mechanism because it is a required message header field and therefore
-   guaranteed to be present in compliant messages, and most Mail User
-   Agents (MUAs) represent the RFC5322.From header field as the
-   originator of the message and render some or all of this header
-   field's content to end users.
-
-   It is important to note that Identifier Alignment cannot occur with a
-   message that is not valid per [RFC5322], particularly one with a
-   malformed, absent, or repeated RFC5322.From header field, since in
-   that case there is no reliable way to determine a DMARC policy that
-   applies to the message.  Accordingly, DMARC operation is predicated
-   on the input being a valid RFC5322 message object, and handling of
-   such non-compliant cases is outside of the scope of this
-   specification.  Further discussion of this can be found in
-   Section 6.7.1.
-
-   Each of the underlying authentication technologies that DMARC takes
-   as input yields authenticated domains as their outputs when they
-   succeed.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 11]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-3.3.1.  DKIM-Authenticated Identifiers
-
-   DMARC requires Identifier Alignment based on the result of a DKIM
-   authentication because a message can bear a valid signature from any
-   domain, including domains used by a mailing list or even a bad actor.
-   Therefore, merely bearing a valid signature is not enough to infer
-   authenticity of the Author Domain.
-
-   DMARC permits Identifier Alignment based on the result of a DKIM
-   authentication to be strict or relaxed.  (Note that these terms are
-   not related to DKIM's "simple" and "relaxed" canonicalization modes.)
-
-   In relaxed mode, the Organizational Domains of both the DKIM-
-   authenticated signing domain (taken from the value of the d= tag in
-   the signature) and that of the RFC5322.From domain must be equal if
-   the identifiers are to be considered to be aligned.  In strict mode,
-   only an exact match between both Fully Qualified Domain Names (FQDNs)
-   is considered to produce Identifier Alignment.
-
-   To illustrate, in relaxed mode, if a verified DKIM signature
-   successfully verifies with a "d=" domain of "example.com", and the
-   RFC5322.From address is "alerts@news.example.com", the DKIM "d="
-   domain and the RFC5322.From domain are considered to be "in
-   alignment", because both domains have the same Organizational Domain
-   of "example.com".  In strict mode, this test would fail because the
-   d= domain does not exactly match the RFC5322.From domain.
-
-   However, a DKIM signature bearing a value of "d=com" would never
-   allow an "in alignment" result, as "com" should be identified as a
-   PSD and therefore cannot be an Organizational Domain.
-
-   Note that a single email can contain multiple DKIM signatures, and it
-   is considered to produce a DMARC "pass" result if any DKIM signature
-   is aligned and verifies.
-
-3.3.2.  SPF-Authenticated Identifiers
-
-   DMARC permits Identifier Alignment based on the result of an SPF
-   authentication.  As with DKIM, Identifier Alignement can be either
-   strict or relaxed.
-
-   In relaxed mode, the Organizational Domains of the SPF-authenticated
-   domain and RFC5322.From domain must be equal if the identifiers are
-   to be considered to be aligned.  In strict mode, the two FQDNs must
-   match exactly in order from them to be considered to be aligned.
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 12]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-   For example, in relaxed mode, if a message passes an SPF check with
-   an RFC5321.MailFrom domain of "cbg.bounces.example.com", and the
-   address portion of the RFC5322.From header field contains
-   "payments@example.com", the Authenticated RFC5321.MailFrom domain
-   identifier and the RFC5322.From domain are considered to be "in
-   alignment" because they have the same Organizational Domain
-   ("example.com").  In strict mode, this test would fail because the
-   two domains are not identical.
-
-   The reader should note that SPF alignment checks in DMARC rely solely
-   on the RFC5321.MailFrom domain.  This differs from section 2.3 of
-   [RFC7208], which recommends that SPF checks be done on not only the
-   "MAIL FROM" but also on a separate check of the "HELO" identity.
-
-3.3.3.  Alignment and Extension Technologies
-
-   If in the future DMARC is extended to include the use of other
-   authentication mechanisms, the extensions will need to allow for
-   domain identifier extraction so that alignment with the RFC5322.From
-   domain can be verified.
-
-3.4.  Determining The Organizational Domain
-
-   The Organizational Domain for a subject DNS domain name is defined as
-   the domain that is found in the DNS hierarchy one level below the PSD
-   in the subject DNS domain name.  The Organizational Domain is
-   determined using the following algorithm, similar to the one
-   described in Section 6.7.3
-
-   1.  Query the DNS for a DMARC TXT record at the DNS domain matching
-       the one found in the RFC5322.From domain in the message.  A
-       possibly empty set of records is returned.
-
-   2.  Records that do not start with a "v=" tag that identifies the
-       current version of DMARC are discarded.
-
-   3.  If the set is now empty, or the set contains one valid DMARC
-       record that does not include a psd tag with a value of 'y', then
-       determine the target for additional queries, using steps 4
-       through 8 below.
-
-   4.  Break the subject DNS domain name into a set of "n" ordered
-       labels.  Number these labels from right to left; e.g., for
-       "example.com", "com" would be label 1 and "example" would be
-       label 2.
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 13]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-   5.  Count the number of labels found in the subject DNS domain.  Let
-       that number be "x".  If x < 5, remove the left-most (highest-
-       numbered) label from the subject domain.  If x >= 5, remove the
-       left-most (highest-numbered) labels from the subject domain until
-       4 labels remain.  The resulting DNS domain name is the new target
-       for subsequent lookups.
-
-   6.  Query the DNS for a DMARC TXT record at the DNS domain matching
-       this new target in place of the RFC5322.From domain in the
-       message.  A possibly empty set of records is returned.
-
-   7.  Records that do not start with a "v=" tag that identifies the
-       current version of DMARC are discarded.
-
-   8.  If the set is now empty, or the set contains one valid DMARC
-       record that does not include a psd tag with the value of 'y',
-       then determine the target for additional queries by removing a
-       single label from the target domain as described in step 5 and
-       repeating steps 6 and 7 until there are no more labels remaining
-       or a record containing a psd tag with a value of 'y' is found.
-
-   9.  Once a valid DMARC record containing a psd tag with a value of
-       'y' has been found, the Organizational Domain for the DNS domain
-       matching the one found in the RFC5322.From domain can be declared
-       to be the target domain queried for in the step prior to the
-       query that found the PSD domain.
-
-   For example, given the RFC5322.From domain "a.mail.example.com", a
-   series of DNS queries for DMARC records would be executed starting
-   with "_dmarc.a.mail.example.com" and finishing with "_dmarc.com".
-   The "_dmarc.com" record would contain a psd tag with a value of 'y',
-   and so the Organizational Domain for this RFC5322.From domain would
-   be determined to be "example.com", the domain of the DMARC query
-   executed prior to the query for "_dmarc.com".
-
-4.  Overview
+4.  Overview and Key Concepts
 
    This section provides a general overview of the design and operation
    of the DMARC environment.
 
-4.1.  Authentication Mechanisms
+   DMARC permits a Domain Owner or PSO to enable verification of a
+   domain's use in an email message, to indicate the Domain Owner's or
+   PSO's message handling preference regarding failed verification, and
+   to request reports about use of the domain name.  All information
+   about a Domain Owner's or PSO's DMARC policy is published and
+   retrieved via the DNS.
+
+   DMARC's verification function is based on whether the RFC5322.From
+   domain is aligned with a domain name used in a supported
+   authentication mechanism.  Section 4.2 When a DMARC policy exists for
+   the domain name found in the RFC5322.From header field, and that
+   domain name is not verified through an aligned supported
+   authentication mechanism, the handling of that message can be
+   affected based on the DMARC policy when delivered to a participating
+   receiver.
+
+   A message satisfies the DMARC checks if at least one of the supported
+   authentication mechanisms:
+
+   1.  produces a "pass" result, and
+
+   2.  produces that result based on an identifier that is in alignment,
+       as described in Section 4.4.
+
+   It is important to note that the authentication mechanisms employed
+   by DMARC authenticate only a DNS domain and do not authenticate the
+   local-part of any email address identifier found in a message, nor do
+   they validate the legitimacy of message content.
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 11]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+   DMARC's feedback component involves the collection of information
+   about received messages claiming to be from the Author Domain for
+   periodic aggregate reports to the Domain Owner or PSO.  The
+   parameters and format for such reports are discussed in
+   [DMARC-Aggregate-Reporting]
+
+   A DMARC-enabled Mail Receiver might also generate per-message reports
+   that contain information related to individual messages that fail
+   authentication checks.  Per-message failure reports are a useful
+   source of information when debugging deployments (if messages can be
+   determined to be legitimate even though failing authentication) or in
+   analyzing attacks.  The capability for such services is enabled by
+   DMARC but defined in other referenced material such as [RFC6591] and
+   [DMARC-Failure-Reporting]
+
+4.1.  Use of RFC5322.From
+
+   One of the most obvious points of security scrutiny for DMARC is the
+   choice to focus on an identifier, namely the RFC5322.From address,
+   which is part of a body of data that has been trivially forged
+   throughout the history of email.  This field is the one used by end
+   users to identify the source of the message, and so it has always
+   been a prime target for abuse through such forgery and other means.
+
+   Several points suggest that it is the most correct and safest thing
+   to do in this context:
+
+   *  Of all the identifiers that are part of the message itself, this
+      is the only one guaranteed to be present.
+
+   *  It seems the best choice of an identifier on which to focus, as
+      most MUAs display some or all of the contents of that field in a
+      manner strongly suggesting those data as reflective of the true
+      originator of the message.
+
+   *  Many high-profile email sources, such as email service providers,
+      require that the sending agent have authenticated before email can
+      be generated.  Thus, for these mailboxes, the mechanism described
+      in this document provides recipient end users with strong evidence
+      that the message was indeed originated by the agent they associate
+      with that mailbox, if the end user knows that these various
+      protections have been provided.
+
+   The absence of a single, properly formed RFC5322.From header field
+   renders the message invalid.  Handling of such a message is outside
+   of the scope of this specification.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 12]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+   Since the sorts of mail typically protected by DMARC participants
+   tend to only have single Authors, DMARC participants generally
+   operate under a slightly restricted profile of RFC5322 with respect
+   to the expected syntax of this field.  See Section 5.7 for details.
+
+4.2.  Authentication Mechanisms
 
    The following mechanisms for determining Authenticated Identifiers
    are supported in this version of DMARC:
 
    *  DKIM, [RFC6376], which provides a domain-level identifier in the
       content of the "d=" tag of a verified DKIM-Signature header field.
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 14]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    *  SPF, [RFC7208], which can authenticate both the domain found in an
       [RFC5321] HELO/EHLO command (the HELO identity) and the domain
@@ -795,55 +696,40 @@ Internet-Draft                  DMARCbis                   November 2021
       describes MAIL FROM processing for cases in which the MAIL command
       has a null path.
 
-4.2.  Key Concepts
-
-   DMARC policies are published by the Domain Owner or PSO, and
-   retrieved by the Mail Receiver during the SMTP session, via the DNS.
-
-   DMARC's verification function is based on whether the RFC5322.From
-   domain is aligned with an authenticated domain name from SPF or DKIM.
-   When a DMARC policy is published for the domain name found in the
-   RFC5322.From header field, and that domain name is not verified
-   through SPF or DKIM, the handling of that message can be affected by
-   that DMARC policy when delivered to a participating receiver.
-
-   It is important to note that the authentication mechanisms employed
-   by DMARC authenticate only a DNS domain and do not authenticate the
-   local-part of any email address identifier found in a message, nor do
-   they validate the legitimacy of message content.
-
-   DMARC's feedback component involves the collection of information
-   about received messages claiming to be from the Author Domain for
-   periodic aggregate reports to the Domain Owner or PSO.  The
-   parameters and format for such reports are discussed in
-   [DMARC-Aggregate-Reporting]
-
-   A DMARC-enabled Mail Receiver might also generate per-message reports
-   that contain information related to individual messages that fail SPF
-   and/or DKIM.  Per-message failure reports are a useful source of
-   information when debugging deployments (if messages can be determined
-   to be legitimate even though failing authentication) or in analyzing
-   attacks.  The capability for such services is enabled by DMARC but
-   defined in other referenced material such as [RFC6591] and
-   [DMARC-Failure-Reporting]
-
-   A message satisfies the DMARC checks if at least one of the supported
-   authentication mechanisms:
-
-   1.  produces a "pass" result, and
-
-   2.  produces that result based on an identifier that is in alignment,
-       as defined in Section 3.
+4.3.  Flow Diagram
 
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 15]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 13]
 
 Internet-Draft                  DMARCbis                   November 2021
 
-
-4.3.  Flow Diagram
 
     +---------------+                             +--------------------+
     | Author Domain |< . . . . . . . . . . . .    | Return-Path Domain |
@@ -883,78 +769,217 @@ Internet-Draft                  DMARCbis                   November 2021
    receiving MTA.
 
    Put simply, when a message reaches a DMARC-aware rMTA, a DNS query
-   will be initiated to determine if the author domain has published a
-   DMARC policy.  If a policy is found, the rMTA will use the results of
-   SPF and DKIM verification checks to determine the ultimate DMARC
-   authentication status.  The DMARC status can then factor into the
-   message handling decision made by the recipient's mail sytsem.
+   will be initiated to determine if a DMARC policy exists that applies
+   to the author domain.  If a policy is found, the rMTA will use the
+   results of SPF and DKIM verification checks to determine the ultimate
+   DMARC authentication status.  The DMARC status can then factor into
+   the message handling decision made by the recipient's mail sytsem.
 
    More details on specific actions for the parties involved can be
-   found in Section 6.5 and Section 6.7.
+   found in Section 5.5 and Section 5.7.
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 16]
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 14]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-5.  Use of RFC5322.From
+4.4.  Identifier Alignment Explained
 
-   One of the most obvious points of security scrutiny for DMARC is the
-   choice to focus on an identifier, namely the RFC5322.From address,
-   which is part of a body of data that has been trivially forged
-   throughout the history of email.  This field is the one used by end
-   users to identify the source of the message, and so it has always
-   been a prime target for abuse through such forgery and other means.
+   Email authentication technologies authenticate various (and
+   disparate) aspects of an individual message.  For example, DKIM
+   [RFC6376] authenticates the domain that affixed a signature to the
+   message, while SPF [RFC7208] can authenticate either the domain that
+   appears in the RFC5321.MailFrom (MAIL FROM) portion of an SMTP
+   [RFC5321] conversation or the RFC5321.EHLO/HELO domain, or both.
+   These may be different domains, and they are typically not visible to
+   the end user.
 
-   Several points suggest that it is the most correct and safest thing
-   to do in this context:
+   DMARC authenticates use of the RFC5322.From domain by requiring that
+   it have the same Organizational Domain as (i.e., be aligned with) an
+   Authenticated Identifier.  Domain names in this context are to be
+   compared in a case-insensitive manner, per [RFC4343].
 
-   *  Of all the identifiers that are part of the message itself, this
-      is the only one guaranteed to be present.
+   It is important to note that Identifier Alignment cannot occur with a
+   message that is not valid per [RFC5322], particularly one with a
+   malformed, absent, or repeated RFC5322.From header field, since in
+   that case there is no reliable way to determine a DMARC policy that
+   applies to the message.  Accordingly, DMARC operation is predicated
+   on the input being a valid RFC5322 message object, and handling of
+   such non-compliant cases is outside of the scope of this
+   specification.  Further discussion of this can be found in
+   Section 5.7.1.
 
-   *  It seems the best choice of an identifier on which to focus, as
-      most MUAs display some or all of the contents of that field in a
-      manner strongly suggesting those data as reflective of the true
-      originator of the message.
+   Each of the underlying authentication technologies that DMARC takes
+   as input yields authenticated domains as their outputs when they
+   succeed.
 
-   *  Many high-profile email sources, such as email service providers,
-      require that the sending agent have authenticated before email can
-      be generated.  Thus, for these mailboxes, the mechanism described
-      in this document provides recipient end users with strong evidence
-      that the message was indeed originated by the agent they associate
-      with that mailbox, if the end user knows that these various
-      protections have been provided.
+4.4.1.  DKIM-Authenticated Identifiers
 
-   The absence of a single, properly formed RFC5322.From header field
-   renders the message invalid.  Handling of such a message is outside
-   of the scope of this specification.
+   DMARC requires Identifier Alignment based on the result of a DKIM
+   authentication because a message can bear a valid signature from any
+   domain, including domains used by a mailing list or even a bad actor.
+   Therefore, merely bearing a valid signature is not enough to infer
+   authenticity of the Author Domain.
 
-   Since the sorts of mail typically protected by DMARC participants
-   tend to only have single Authors, DMARC participants generally
-   operate under a slightly restricted profile of RFC5322 with respect
-   to the expected syntax of this field.  See Section 6.7 for details.
+   DMARC permits Identifier Alignment based on the result of a DKIM
+   authentication to be strict or relaxed.  (Note that these terms are
+   not related to DKIM's "simple" and "relaxed" canonicalization modes.)
 
-6.  Policy
+   In relaxed mode, the Organizational Domains of both the DKIM-
+   authenticated signing domain (taken from the value of the d= tag in
+   the signature) and that of the RFC5322.From domain must be equal if
+   the identifiers are to be considered to be aligned.  In strict mode,
+   only an exact match between both Fully Qualified Domain Names (FQDNs)
+   is considered to produce Identifier Alignment.
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 15]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+   To illustrate, in relaxed mode, if a verified DKIM signature
+   successfully verifies with a "d=" domain of "example.com", and the
+   RFC5322.From address is "alerts@news.example.com", the DKIM "d="
+   domain and the RFC5322.From domain are considered to be "in
+   alignment", because both domains have the same Organizational Domain
+   of "example.com".  In strict mode, this test would fail because the
+   d= domain does not exactly match the RFC5322.From domain.
+
+   However, a DKIM signature bearing a value of "d=com" would never
+   allow an "in alignment" result, as "com" should be identified as a
+   PSD and therefore cannot be an Organizational Domain.
+
+   Note that a single email can contain multiple DKIM signatures, and it
+   is considered to produce a DMARC "pass" result if any DKIM signature
+   is aligned and verifies.
+
+4.4.2.  SPF-Authenticated Identifiers
+
+   DMARC permits Identifier Alignment based on the result of an SPF
+   authentication.  As with DKIM, Identifier Alignement can be either
+   strict or relaxed.
+
+   In relaxed mode, the Organizational Domains of the SPF-authenticated
+   domain and RFC5322.From domain must be equal if the identifiers are
+   to be considered to be aligned.  In strict mode, the two FQDNs must
+   match exactly in order from them to be considered to be aligned.
+
+   For example, in relaxed mode, if a message passes an SPF check with
+   an RFC5321.MailFrom domain of "cbg.bounces.example.com", and the
+   address portion of the RFC5322.From header field contains
+   "payments@example.com", the Authenticated RFC5321.MailFrom domain
+   identifier and the RFC5322.From domain are considered to be "in
+   alignment" because they have the same Organizational Domain
+   ("example.com").  In strict mode, this test would fail because the
+   two domains are not identical.
+
+   The reader should note that SPF alignment checks in DMARC rely solely
+   on the RFC5321.MailFrom domain.  This differs from section 2.3 of
+   [RFC7208], which recommends that SPF checks be done on not only the
+   "MAIL FROM" but also on a separate check of the "HELO" identity.
+
+4.4.3.  Alignment and Extension Technologies
+
+   If in the future DMARC is extended to include the use of other
+   authentication mechanisms, the extensions will need to allow for
+   domain identifier extraction so that alignment with the RFC5322.From
+   domain can be verified.
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 16]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+4.5.  Determining The Organizational Domain
+
+   The DMARC protocol defines a method for a Public Suffix Domain to
+   identify itself as such using a tag in its published DMARC policy
+   record.  An Organizational Domain is any subdomain of a PSD that
+   includes exactly one more label than the PSD in its name.
+
+   For any email message, the Organizational Domain of the RFC5322.From
+   domain is determined using the following algorithm, similar to the
+   one described in Section 5.7.3
+
+   1.  Query the DNS for a DMARC TXT record at the DNS domain matching
+       the one found in the RFC5322.From domain in the message.  A
+       possibly empty set of records is returned.
+
+   2.  Records that do not start with a "v=" tag that identifies the
+       current version of DMARC are discarded.
+
+   3.  If the set is now empty, or the set contains one valid DMARC
+       record that does not include a psd tag with a value of 'y', then
+       determine the target for additional queries, using steps 4
+       through 8 below.
+
+   4.  Break the subject DNS domain name into a set of "n" ordered
+       labels.  Number these labels from right to left; e.g., for
+       "a.mail.example.com", "com" would be label 1 and "example" would
+       be label 2 and so forth.
+
+   5.  Count the number of labels found in the subject DNS domain.  Let
+       that number be "x".  If x < 5, remove the left-most (highest-
+       numbered) label from the subject domain.  If x >= 5, remove the
+       left-most (highest-numbered) labels from the subject domain until
+       4 labels remain.  The resulting DNS domain name is the new target
+       for subsequent lookups.
+
+   6.  Query the DNS for a DMARC TXT record at the DNS domain matching
+       this new target in place of the RFC5322.From domain in the
+       message.  A possibly empty set of records is returned.
+
+   7.  Records that do not start with a "v=" tag that identifies the
+       current version of DMARC are discarded.
+
+   8.  If the set is now empty, or the set contains one valid DMARC
+       record that does not include a psd tag with the value of 'y',
+       then determine the target for additional queries by removing a
+       single label from the target domain as described in step 5 and
+       repeating steps 6 and 7 until there are no more labels remaining
+       or a record containing a psd tag with a value of 'y' is found.
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 17]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+   9.  Once a valid DMARC record containing a psd tag with a value of
+       'y' has been found, the Organizational Domain for the DNS domain
+       matching the one found in the RFC5322.From domain can be declared
+       to be the target domain queried for in the step prior to the
+       query that found the PSD domain.
+
+   For example, given the RFC5322.From domain "a.mail.example.com", a
+   series of DNS queries for DMARC records would be executed starting
+   with "_dmarc.a.mail.example.com" and finishing with "_dmarc.com".
+   The "_dmarc.com" record would contain a psd tag with a value of 'y',
+   and so the Organizational Domain for this RFC5322.From domain would
+   be determined to be "example.com", the domain of the DMARC query
+   executed prior to the query for "_dmarc.com".
+
+5.  Policy
 
    DMARC policies are published by Domain Owners and PSOs and can be
    used by Mail Receivers to inform their message handling decisions.
 
    A Domain Owner or PSO advertises DMARC participation of one or more
-   of its domains by adding a DNS TXT record (described in Section 6.1)
+   of its domains by adding a DNS TXT record (described in Section 5.1)
    to those domains.  In doing so, Domain Owners and PSOs indicate their
    handling preference regarding failed authentication for email
    messages making use of their domain in the RFC5322.From header field
    as well as the provision of feedback about those messages.  Mail
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 17]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    Receivers in turn can take into account the Domain Owner's stated
    preference when making handling decisions about email messages that
    fail DMARC authentication checks.
@@ -979,7 +1004,14 @@ Internet-Draft                  DMARCbis                   November 2021
    specifically using the "PolicyOverride" feature of the aggregate
    report defined in [DMARC-Aggregate-Reporting]
 
-6.1.  DMARC Policy Record
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 18]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+5.1.  DMARC Policy Record
 
    Domain Owner and PSO DMARC preferences are stored as DNS TXT records
    in subdomains named "_dmarc".  For example, the Domain Owner of
@@ -1000,42 +1032,42 @@ Internet-Draft                  DMARCbis                   November 2021
    well-established operations, administration, and management
    infrastructure, rather than creating a new one.
 
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 18]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    Per [RFC1035], a TXT record can comprise several "character-string"
    objects.  Where this is the case, the module performing DMARC
    evaluation MUST concatenate these strings by joining together the
    objects in order and parsing the result as a single string.
 
-6.2.  DMARC URIs
+5.2.  DMARC URIs
 
    [RFC3986] defines a generic syntax for identifying a resource.  The
    DMARC mechanism uses this as the format by which a Domain Owner or
    PSO specifies the destination for the two report types that are
    supported.
 
-   The place such URIs are specified (see Section 6.3) allows a list of
+   The place such URIs are specified (see Section 5.3) allows a list of
    these to be provided.  The list of URIs is separated by commas (ASCII
    0x2c).  A report SHOULD be sent to each listed URI provided in the
    DMARC record.
 
-   A formal definition is provided in Section 6.4.
+   A formal definition is provided in Section 5.4.
 
-6.3.  General Record Format
+5.3.  General Record Format
 
    DMARC records follow the extensible "tag-value" syntax for DNS-based
    key records defined in DKIM [RFC6376].
 
-   Section 9 creates a registry for known DMARC tags and registers the
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 19]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+   Section 8 creates a registry for known DMARC tags and registers the
    initial set defined in this document.  Only tags defined in this
    document or in later extensions, and thus added to that registry, are
    to be processed; unknown tags MUST be ignored.
@@ -1044,7 +1076,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    adkim:  (plain-text; OPTIONAL; default is "r".)  Indicates whether
       strict or relaxed DKIM Identifier Alignment mode is required by
-      the Domain Owner.  See Section 3.3.1 for details.  Valid values
+      the Domain Owner.  See Section 4.4.1 for details.  Valid values
       are as follows:
 
       r:  relaxed mode
@@ -1053,19 +1085,12 @@ Internet-Draft                  DMARCbis                   November 2021
 
    aspf:  (plain-text; OPTIONAL; default is "r".)  Indicates whether
       strict or relaxed SPF Identifier Alignment mode is required by the
-      Domain Owner.  See Section 3.3.2 for details.  Valid values are as
+      Domain Owner.  See Section 4.4.2 for details.  Valid values are as
       follows:
 
       r:  relaxed mode
 
       s:  strict mode
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 19]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    fo:  Failure reporting options (plain-text; OPTIONAL; default is "0")
       Provides requested options for generation of failure reports.
@@ -1076,6 +1101,27 @@ Internet-Draft                  DMARCbis                   November 2021
       the options represented by alphabetic characters.
 
    The valid values and their meanings are:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 20]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    0:
    :  Generate a DMARC failure report if all underlying
@@ -1109,20 +1155,12 @@ Internet-Draft                  DMARCbis                   November 2021
       present, MUST be applied for non-existent subdomains.  Note that
       "np" will be ignored for DMARC records published on subdomains of
       Organizational Domains and PSDs due to the effect of the DMARC
-      policy discovery mechanism described in Section 6.7.3.
+      policy discovery mechanism described in Section 5.7.3.
 
    p:  Domain Owner Assessment Policy (plain-text; RECOMMENDED for
       policy records).  Indicates the message handling preference the
       Domain Owner or PSO has for mail using its domain but not passing
       DMARC verification.  Policy applies to the domain queried and to
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 20]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
       subdomains, unless subdomain policy is explicitly described using
       the "sp" or "np" tags.  This tag is mandatory for policy records
       only, but not for third-party reporting records (see
@@ -1133,11 +1171,19 @@ Internet-Draft                  DMARCbis                   November 2021
 
       quarantine:  The Domain Owner considers such mail to be
          suspicious.  It is possible the mail is valid, although the
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 21]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
          failure creates a significant concern.
 
       reject:  The Domain Owner considers all such failures to be a
          clear indication that the use of the domain name is not valid.
-         See Section 8.3 for some discussion of SMTP rejection methods
+         See Section 7.3 for some discussion of SMTP rejection methods
          and their implications.
 
    psd:  A flag indicating whether the domain is a PSD. (plain-text;
@@ -1156,7 +1202,7 @@ Internet-Draft                  DMARCbis                   November 2021
       separated plain-text list of DMARC URIs; OPTIONAL).  Section 3 of
       [DMARC-Aggregate-Reporting] discusses considerations that apply
       when the domain name of a URI differs from that of the domain
-      advertising the policy.  See Section 10.5 for additional
+      advertising the policy.  See Section 9.5 for additional
       considerations.  Any valid URI can be specified.
          A Mail Receiver MUST implement support for a "mailto:" URI,
       i.e., the ability to send a DMARC report via electronic mail.  If
@@ -1171,22 +1217,23 @@ Internet-Draft                  DMARCbis                   November 2021
       Receivers to send detailed failure reports about messages that
       fail the DMARC evaluation in specific ways (see the "fo" tag
       above).  The format of the message to be generated MUST follow the
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 21]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
       format specified for the "rf" tag.  Section 3 of
       [DMARC-Aggregate-Reporting] discusses considerations that apply
       when the domain name of a URI differs from that of the domain
       advertising the policy.  A Mail Receiver MUST implement support
       for a "mailto:" URI, i.e., the ability to send a DMARC report via
       electronic mail.  If not provided, Mail Receivers MUST NOT
-      generate failure reports.  See Section 10.5 for additional
+      generate failure reports.  See Section 9.5 for additional
       considerations.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 22]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    sp:  Domain Owner Assessment Policy for all subdomains (plain-text;
       OPTIONAL).  Indicates the message handling preference the Domain
@@ -1199,7 +1246,7 @@ Internet-Draft                  DMARCbis                   November 2021
       be applied for subdomains.  Note that "sp" will be ignored for
       DMARC records published on subdomains of Organizational Domains
       due to the effect of the DMARC policy discovery mechanism
-      described in Section 6.7.3.
+      described in Section 5.7.3.
 
    t:  DMARC policy test mode (plain-text; OPTIONAL; default is 'n').
       For the RFC5322.From domain to which the DMARC record applies, the
@@ -1224,19 +1271,8 @@ Internet-Draft                  DMARCbis                   November 2021
       the entire retrieved record MUST be ignored.  It MUST be the first
       tag in the list.
 
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 22]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    A DMARC policy record MUST comply with the formal specification found
-   in Section 6.4 in that the "v" tag MUST be present and MUST appear
+   in Section 5.4 in that the "v" tag MUST be present and MUST appear
    first.  Unknown tags MUST be ignored.  Syntax errors in the remainder
    of the record SHOULD be discarded in favor of default values (if any)
    or ignored outright.
@@ -1247,7 +1283,15 @@ Internet-Draft                  DMARCbis                   November 2021
    the "v" tag's value), but a change to any existing tags does require
    a new version of DMARC.
 
-6.4.  Formal Definition
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 23]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+5.4.  Formal Definition
 
    The formal definition of the DMARC format, using [RFC5234], is as
    follows:
@@ -1284,13 +1328,6 @@ Internet-Draft                  DMARCbis                   November 2021
      dmarc-srequest  = "sp" *WSP "=" *WSP
                        ( "none" / "quarantine" / "reject" )
 
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 23]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
      dmarc-nprequest  = "np" *WSP "=" *WSP
                        ( "none" / "quarantine" / "reject" )
 
@@ -1302,6 +1339,14 @@ Internet-Draft                  DMARCbis                   November 2021
                        dmarc-uri *(*WSP "," *WSP dmarc-uri)
 
      dmarc-furi      = "ruf" *WSP "=" *WSP
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 24]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
                        dmarc-uri *(*WSP "," *WSP dmarc-uri)
 
      dmarc-fo        = "fo" *WSP "=" *WSP
@@ -1312,12 +1357,12 @@ Internet-Draft                  DMARCbis                   November 2021
 
    "Keyword" is imported from Section 4.1.2 of [RFC5321].
 
-6.5.  Domain Owner Actions
+5.5.  Domain Owner Actions
 
    This section describes Domain Owner actions to fully implement the
    DMARC mechanism.
 
-6.5.1.  Publish an SPF Policy for an Aligned Domain
+5.5.1.  Publish an SPF Policy for an Aligned Domain
 
    Because DMARC relies on SPF [RFC7208] and DKIM [RFC6376], in order to
    take full advantage of DMARC, a Domain Owner SHOULD first ensure that
@@ -1327,7 +1372,7 @@ Internet-Draft                  DMARCbis                   November 2021
    with the Author Domain, and then publish an SPF policy in DNS for
    that domain.
 
-6.5.2.  Configure Sending System for DKIM Signing Using an Aligned
+5.5.2.  Configure Sending System for DKIM Signing Using an Aligned
         Domain
 
    While it is possible to secure a DMARC pass verdict based on only SPF
@@ -1338,16 +1383,7 @@ Internet-Draft                  DMARCbis                   November 2021
    that aligns with the Author Domain and configure its system to sign
    using that domain.
 
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 24]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-6.5.3.  Setup a Mailbox to Receive Aggregate Reports
+5.5.3.  Setup a Mailbox to Receive Aggregate Reports
 
    Proper consumption and analysis of DMARC aggregate reports is the key
    to any successful DMARC deployment for a Domain Owner.  DMARC
@@ -1358,6 +1394,15 @@ Internet-Draft                  DMARCbis                   November 2021
    could be legitimate ones that were overlooked during the intial
    deployment of SPF and/or DKIM.
 
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 25]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    Because the aggregate reports are XML documents, it is strongly
    advised that they be machine-parsed, so setting up a mailbox involves
    more than just the physical creation of the mailbox.  Many third-
@@ -1367,14 +1412,14 @@ Internet-Draft                  DMARCbis                   November 2021
    data contained in them will go a long way to ensuring a successful
    deployment.
 
-6.5.4.  Publish a DMARC Policy for the Author Domain
+5.5.4.  Publish a DMARC Policy for the Author Domain
 
    Once SPF, DKIM, and the aggregate reports mailbox are all in place,
    it's time to publish a DMARC record.  For best results, Domain Owners
    SHOULD start with "p=none", with the rua tag containg the mailbox
    created in the previous step.
 
-6.5.5.  Collect and Analyze Reports and Adjust Authentication
+5.5.5.  Collect and Analyze Reports and Adjust Authentication
 
    The reason for starting at "p=none" is to ensure that nothing's been
    missed in the initial SPF and DKIM deployments.  In all but the most
@@ -1386,24 +1431,7 @@ Internet-Draft                  DMARCbis                   November 2021
    reports, the Domain Owner can adjust the SPF record and/or configure
    DKIM signing for those systems.
 
-
-
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 25]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-6.5.6.  Decide If and When to Update DMARC Policy
+5.5.6.  Decide If and When to Update DMARC Policy
 
    Once the Domain Owner is satisfied that it is properly authenticating
    all of its mail, then it is time to decide if it is appropriate to
@@ -1414,7 +1442,7 @@ Internet-Draft                  DMARCbis                   November 2021
    mail, and the decision on which p= value to use will depend on its
    needs.
 
-6.6.  PSO Actions
+5.6.  PSO Actions
 
    In addition to the DMARC Domain Owner actions, PSOs that require use
    of DMARC and participate in PSD DMARC ought to make that information
@@ -1422,11 +1450,20 @@ Internet-Draft                  DMARCbis                   November 2021
    for doing so, and the experiment is described in Appendix B of that
    document.
 
-6.7.  Mail Receiver Actions
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 26]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+5.7.  Mail Receiver Actions
 
    This section describes receiver actions in the DMARC environment.
 
-6.7.1.  Extract Author Domain
+5.7.1.  Extract Author Domain
 
    The domain in the RFC5322.From header field is extracted as the
    domain to be evaluated by DMARC.  If the domain is encoded with UTF-
@@ -1451,15 +1488,7 @@ Internet-Draft                  DMARCbis                   November 2021
    Note that domain names that appear on a public suffix list are not
    exempt from DMARC policy application and reporting.
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 26]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-6.7.2.  Determine Handling Policy
+5.7.2.  Determine Handling Policy
 
    To arrive at a policy for an individual message, Mail Receivers MUST
    perform the following actions or their semantic equivalents.  Steps
@@ -1472,7 +1501,19 @@ Internet-Draft                  DMARCbis                   November 2021
 
    2.  Query the DNS for a DMARC policy record.  Continue if one is
        found, or terminate DMARC evaluation otherwise.  See
-       Section 6.7.3 for details.
+       Section 5.7.3 for details.
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 27]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    3.  Perform DKIM signature verification checks.  A single email could
        contain multiple DKIM signatures.  The results of this step are
@@ -1499,21 +1540,13 @@ Internet-Draft                  DMARCbis                   November 2021
    6.  Apply policy.  Emails that fail the DMARC mechanism check are
        handled in accordance with the discovered DMARC policy of the
        Domain Owner and any local policy rules enforced by the Mail
-       Receiver.  See Section 6.3 for details.
+       Receiver.  See Section 5.3 for details.
 
    Heuristics applied in the absence of use by a Domain Owner of either
    SPF or DKIM (e.g., [Best-Guess-SPF]) SHOULD NOT be used, as it may be
    the case that the Domain Owner wishes a Message Receiver not to
    consider the results of that underlying authentication protocol at
    all.
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 27]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    DMARC evaluation can only yield a "pass" result after one of the
    underlying authentication mechanisms passes for an aligned
@@ -1527,7 +1560,18 @@ Internet-Draft                  DMARCbis                   November 2021
    Handling of messages for which SPF and/or DKIM evaluation encounter a
    permanent DNS error is left to the discretion of the Mail Receiver.
 
-6.7.3.  Policy Discovery
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 28]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+5.7.3.  Policy Discovery
 
    As stated above, the DMARC mechanism uses DNS TXT records to
    advertise policy.  Policy discovery is accomplished via a method
@@ -1561,16 +1605,6 @@ Internet-Draft                  DMARCbis                   November 2021
         until 4 labels remain.  The resulting DNS domain name is the new
         target for subsequent lookups.
 
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 28]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    6.   The Mail Receiver MUST query the DNS for a DMARC TXT record at
         the DNS domain matching this new target in place of the
         RFC5322.From domain in the message.  This record can contain
@@ -1584,6 +1618,14 @@ Internet-Draft                  DMARCbis                   November 2021
         for additional queries by removing a single label from the
         target domain as described in step 5 and repeating steps 6 and 7
         until there are no more labels remaining.
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 29]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    9.   If the remaining set contains multiple records or no records,
         policy discovery terminates and DMARC processing is not applied
@@ -1614,20 +1656,7 @@ Internet-Draft                  DMARCbis                   November 2021
    cleared, allowing a definite DMARC conclusion to be reached ("fail
    closed").
 
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 29]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-6.7.3.1.  Longest PSD Example
+5.7.3.1.  Longest PSD Example
 
    As an example of step 5 above, for a message with the Organizational
    Domain of "example.compute.cloudcompany.com.example", the query for
@@ -1642,14 +1671,26 @@ Internet-Draft                  DMARCbis                   November 2021
    not a mechanism to provide feedback addresses (RUA/RUF) when an
    Organizational Domain has declined to do so.
 
-6.7.4.  Store Results of DMARC Processing
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 30]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+5.7.4.  Store Results of DMARC Processing
 
    The results of Mail Receiver-based DMARC processing should be stored
    for eventual presentation back to the Domain Owner in the form of
-   aggregate feedback reports.  Section 6.3 and
+   aggregate feedback reports.  Section 5.3 and
    [DMARC-Aggregate-Reporting] discuss aggregate feedback.
 
-6.7.5.  Send Aggregate Reports
+5.7.5.  Send Aggregate Reports
 
    For a Domain Owner, DMARC aggregate reports provide data about all
    mailstreams making use of its domain in email, to include not only
@@ -1668,22 +1709,7 @@ Internet-Draft                  DMARCbis                   November 2021
    ecosystem, then, Mail Receivers MUST generate and send aggregate
    reports with a frequency of at least once every 24 hours.
 
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 30]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-6.8.  Policy Enforcement Considerations
+5.8.  Policy Enforcement Considerations
 
    Mail Receivers MAY choose to reject or quarantine email even if email
    passes the DMARC mechanism check.  The DMARC mechanism does not
@@ -1702,6 +1728,16 @@ Internet-Draft                  DMARCbis                   November 2021
    is RECOMMENDED when delivery of failing mail is done.  When this is
    done, the DNS domain name thus recorded MUST be encoded as an
    A-label.
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 31]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    Mail Receivers are only obligated to report reject or quarantine
    policy actions in aggregate feedback reports that are due to
@@ -1731,20 +1767,12 @@ Internet-Draft                  DMARCbis                   November 2021
    existing mail processing, discovered policies of "p=none" SHOULD NOT
    modify existing mail handling processes.
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 31]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    Mail Receivers MUST also implement reporting instructions of DMARC,
    even in the absence of a request for DKIM reporting [RFC6651] or SPF
    reporting [RFC6652].  Furthermore, the presence of such requests
    SHOULD NOT affect DMARC reporting.
 
-7.  DMARC Feedback
+6.  DMARC Feedback
 
    Providing Domain Owners with visibility into how Mail Receivers
    implement and enforce the DMARC mechanism in the form of feedback is
@@ -1756,17 +1784,28 @@ Internet-Draft                  DMARCbis                   November 2021
    The details of this feedback are described in
    [DMARC-Aggregate-Reporting]
 
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 32]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    Operational note for PSD DMARC: For PSOs, feedback for non-existent
    domains is desirable and useful, just as it is for org-level DMARC
    operators.  See Section 4 of [RFC9091] for discussion of Privacy
    Considerations for PSD DMARC
 
-8.  Other Topics
+7.  Other Topics
 
    This section discusses some topics regarding choices made in the
    development of DMARC, largely to commit the history to record.
 
-8.1.  Issues Specific to SPF
+7.1.  Issues Specific to SPF
 
    Though DMARC does not inherently change the semantics of an SPF
    policy record, historically lax enforcement of such policies has led
@@ -1782,20 +1821,7 @@ Internet-Draft                  DMARCbis                   November 2021
    processing takes place.  Operators choosing to use "-all" should be
    aware of this.
 
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 32]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-8.2.  DNS Load and Caching
+7.2.  DNS Load and Caching
 
    DMARC policies are communicated using the DNS and therefore inherit a
    number of considerations related to DNS caching.  The inherent
@@ -1817,7 +1843,15 @@ Internet-Draft                  DMARCbis                   November 2021
    responsiveness of DMARC preference changes while preserving the
    benefits of DNS caching.
 
-8.3.  Rejecting Messages
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 33]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+7.3.  Rejecting Messages
 
    This protocol calls for rejection of a message during the SMTP
    session under certain circumstances.  This is preferable to
@@ -1843,14 +1877,6 @@ Internet-Draft                  DMARCbis                   November 2021
    server has to be programmed to give a false result, which can
    confound external debugging efforts.
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 33]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    Similarly, the text portion of the SMTP reply may be important to
    consider.  For example, when rejecting a message, revealing the
    reason for the rejection might give an attacker enough information to
@@ -1873,7 +1899,15 @@ Internet-Draft                  DMARCbis                   November 2021
    retrieve or apply DMARC policy, this is best done with a 4xy SMTP
    reply code.
 
-8.4.  Identifier Alignment Considerations
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 34]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+7.4.  Identifier Alignment Considerations
 
    The DMARC mechanism allows both DKIM and SPF-authenticated
    identifiers to authenticate email on behalf of a Domain Owner and,
@@ -1891,21 +1925,12 @@ Internet-Draft                  DMARCbis                   November 2021
    delegate control of subdomains if this is an issue, and to consider
    using the "strict" Identifier Alignment option if appropriate.
 
-8.5.  Interoperability Issues
+7.5.  Interoperability Issues
 
    DMARC limits which end-to-end scenarios can achieve a "pass" result.
 
    Because DMARC relies on SPF [RFC7208] and/or DKIM [RFC6376] to
    achieve a "pass", their limitations also apply.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 34]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    Additional DMARC constraints occur when a message is processed by
    some Mediators, such as mailing lists.  Transiting a Mediator often
@@ -1920,14 +1945,23 @@ Internet-Draft                  DMARCbis                   November 2021
    Issues specific to the use of policy mechanisms alongside DKIM are
    further discussed in [RFC6377], particularly Section 5.2.
 
-9.  IANA Considerations
+8.  IANA Considerations
 
    This section describes actions completed by IANA.
 
-9.1.  Authentication-Results Method Registry Update
+8.1.  Authentication-Results Method Registry Update
 
    IANA has added the following to the "Email Authentication Methods"
    registry:
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 35]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    +------+-----------+------+----------+--------------+------+--------+
    |Method| Defined   |ptype | Property | Value        |Status|Version |
@@ -1955,15 +1989,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
           Table 1: "Authentication-Results Method Registry Update"
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 35]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-9.2.  Authentication-Results Result Registry Update
+8.2.  Authentication-Results Result Registry Update
 
    IANA has added the following in the "Email Authentication Result
    Names" registry:
@@ -1985,6 +2011,14 @@ Internet-Draft                  DMARCbis                   November 2021
    |           |           |           |(added)| record was     |      |
    |           |           |           |       | published for  |      |
    |           |           |           |       | the aligned    |      |
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 36]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    |           |           |           |       |identifier, and |      |
    |           |           |           |       |at least one of |      |
    |           |           |           |       | the            |      |
@@ -2011,14 +2045,6 @@ Internet-Draft                  DMARCbis                   November 2021
    |           |           |           |       | final result.  |      |
    +-----------+-----------+-----------+-------+----------------+------+
    | permerror | existing  | [RFC8601] | dmarc | A permanent    |active|
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 36]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    |           |           |           |(added)| error occurred |      |
    |           |           |           |       | during DMARC   |      |
    |           |           |           |       |evaluation, such|      |
@@ -2034,12 +2060,20 @@ Internet-Draft                  DMARCbis                   November 2021
 
           Table 2: "Authentication-Results Result Registry Update"
 
-9.3.  Feedback Report Header Fields Registry Update
+8.3.  Feedback Report Header Fields Registry Update
 
    The following has been added to the "Feedback Report Header Fields"
    registry:
 
    Field Name: Identity-Alignment
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 37]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    Description:  indicates whether the message about which a report is
       being generated had any identifiers in alignment as defined in RFC
@@ -2053,7 +2087,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    Status: current
 
-9.4.  DMARC Tag Registry
+8.4.  DMARC Tag Registry
 
    A new registry tree called "Domain-based Message Authentication,
    Reporting, and Conformance (DMARC) Parameters" has been created.
@@ -2067,14 +2101,6 @@ Internet-Draft                  DMARCbis                   November 2021
    name; the specification that defines it; a brief description; and its
    status, which must be one of "current", "experimental", or
    "historic".  The Designated Expert needs to confirm that the provided
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 37]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    specification adequately describes the new tag and clearly presents
    how it would be used within the DMARC context by Domain Owners and
    Mail Receivers.
@@ -2084,6 +2110,26 @@ Internet-Draft                  DMARCbis                   November 2021
    when processed by implementations conforming to prior specifications.
 
    The initial set of entries in this registry is as follows:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 38]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    +----------+-----------+----------+------------------------------+
    | Tag Name | Reference | Status   | Description                  |
@@ -2119,23 +2165,27 @@ Internet-Draft                  DMARCbis                   November 2021
 
                      Table 3: "DMARC Tag Registry"
 
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 38]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-9.5.  DMARC Report Format Registry
+8.5.  DMARC Report Format Registry
 
    Also within "Domain-based Message Authentication, Reporting, and
    Conformance (DMARC) Parameters", a new sub-registry called "DMARC
    Report Format Registry" has been created.
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 39]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    Names of DMARC failure reporting formats must be registered with IANA
    in this registry.  New entries are assigned only for values that
@@ -2160,7 +2210,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
                  Table 4: "DMARC Report Format Registry"
 
-9.6.  Underscored and Globally Scoped DNS Node Names Registry
+8.6.  Underscored and Globally Scoped DNS Node Names Registry
 
    Per [RFC8552], please add the following entry to the "Underscored and
    Globally Scoped DNS Node Names" registry:
@@ -2175,24 +2225,25 @@ Internet-Draft                  DMARCbis                   November 2021
      Globally Scoped DNS Node Names"
                  registry
 
-10.  Security Considerations
+9.  Security Considerations
 
    This section discusses security issues and possible remediations
    (where available) for DMARC.
 
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 39]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-10.1.  Authentication Methods
+9.1.  Authentication Methods
 
    Security considerations from the authentication methods used by DMARC
    are incorporated here by reference.
 
-10.2.  Attacks on Reporting URIs
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 40]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+9.2.  Attacks on Reporting URIs
 
    URIs published in DNS TXT records are well-understood possible
    targets for attack.  Specifications such as [RFC1035] and [RFC2142]
@@ -2215,7 +2266,7 @@ Internet-Draft                  DMARCbis                   November 2021
       Submitter or Reported-Domain fields, including the possibility of
       false data from compromised but known Mail Receivers.
 
-10.3.  DNS Security
+9.3.  DNS Security
 
    The DMARC mechanism and its underlying technologies (SPF, DKIM)
    depend on the security of the DNS.  Examples of how hostile parties
@@ -2235,18 +2286,20 @@ Internet-Draft                  DMARCbis                   November 2021
    *  Signing DNS records with DNSSEC [RFC4033], which enables
       recipients to detect and discard forged responses.
 
+   *  DNS over TLS [RFC7858] or DNS over HTTPS [RFC8484] can mitigate
+      snooping and forged responses.
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 40]
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 41]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-   *  DNS over TLS [RFC7858] or DNS over HTTPS [RFC8484] can mitigate
-      snooping and forged responses.
-
-10.4.  Display Name Attacks
+9.4.  Display Name Attacks
 
    A common attack in messaging abuse is the presentation of false
    information in the display-name portion of the RFC5322.From header
@@ -2286,20 +2339,7 @@ Internet-Draft                  DMARCbis                   November 2021
       passes and the email address thus verified matches one found in
       the receiving user's list of known addresses.
 
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 41]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-10.5.  External Reporting Addresses
+9.5.  External Reporting Addresses
 
    To avoid abuse by bad actors, reporting addresses generally have to
    be inside the domains about which reports are requested.  In order to
@@ -2307,6 +2347,13 @@ Internet-Draft                  DMARCbis                   November 2021
    that cannot actually receive mail, Section 3 of
    [DMARC-Aggregate-Reporting] describes a DNS-based mechanism for
    verifying approved external reporting.
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 42]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    The obvious consideration here is an increased DNS load against
    domains that are claimed as external recipients.  Negative caching
@@ -2326,7 +2373,7 @@ Internet-Draft                  DMARCbis                   November 2021
    routed fraudulently to an attacker's systems may be an attractive
    prospect.  Deployment of [RFC4033] is advisable if this is a concern.
 
-10.6.  Secure Protocols
+9.6.  Secure Protocols
 
    This document encourages use of secure transport mechanisms to
    prevent loss of private data to third parties that may be able to
@@ -2337,23 +2384,12 @@ Internet-Draft                  DMARCbis                   November 2021
    secured might appear in a report that is not sent securely, which
    could reveal private information.
 
-11.  Normative References
+10.  Normative References
 
    [DMARC-Aggregate-Reporting]
               Brotman, A., Ed., "DMARC Aggregate Reporting", February
               2021, <https://datatracker.ietf.org/doc/draft-ietf-dmarc-
               aggregate-reporting/>.
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 42]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    [DMARC-Failure-Reporting]
               Jones, S.M., Ed. and A. Vesely, Ed., "DMARC Failure
@@ -2364,6 +2400,16 @@ Internet-Draft                  DMARCbis                   November 2021
    [RFC1035]  Mockapetris, P., "Domain names - implementation and
               specification", STD 13, RFC 1035, DOI 10.17487/RFC1035,
               November 1987, <https://www.rfc-editor.org/info/rfc1035>.
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 43]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
@@ -2403,14 +2449,6 @@ Internet-Draft                  DMARCbis                   November 2021
               RFC 6376, DOI 10.17487/RFC6376, September 2011,
               <https://www.rfc-editor.org/info/rfc6376>.
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 43]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    [RFC6591]  Fontana, H., "Authentication Failure Reporting Using the
               Abuse Reporting Format", RFC 6591, DOI 10.17487/RFC6591,
               April 2012, <https://www.rfc-editor.org/info/rfc6591>.
@@ -2419,6 +2457,15 @@ Internet-Draft                  DMARCbis                   November 2021
               (DKIM) for Failure Reporting", RFC 6651,
               DOI 10.17487/RFC6651, June 2012,
               <https://www.rfc-editor.org/info/rfc6651>.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 44]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    [RFC6652]  Kitterman, S., "Sender Policy Framework (SPF)
               Authentication Failure Reporting Using the Abuse Reporting
@@ -2446,7 +2493,7 @@ Internet-Draft                  DMARCbis                   November 2021
               DOI 10.17487/RFC9091, July 2021,
               <https://www.rfc-editor.org/info/rfc9091>.
 
-12.  Informative References
+11.  Informative References
 
    [Best-Guess-SPF]
               Kitterman, S., "Sender Policy Framework: Best guess record
@@ -2457,16 +2504,6 @@ Internet-Draft                  DMARCbis                   November 2021
               Functions", RFC 2142, DOI 10.17487/RFC2142, May 1997,
               <https://www.rfc-editor.org/info/rfc2142>.
 
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 44]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    [RFC3464]  Moore, K. and G. Vaudreuil, "An Extensible Message Format
               for Delivery Status Notifications", RFC 3464,
               DOI 10.17487/RFC3464, January 2003,
@@ -2476,6 +2513,15 @@ Internet-Draft                  DMARCbis                   November 2021
               Rose, "DNS Security Introduction and Requirements",
               RFC 4033, DOI 10.17487/RFC4033, March 2005,
               <https://www.rfc-editor.org/info/rfc4033>.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 45]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    [RFC5598]  Crocker, D., "Internet Mail Architecture", RFC 5598,
               DOI 10.17487/RFC5598, July 2009,
@@ -2512,17 +2558,6 @@ Internet-Draft                  DMARCbis                   November 2021
               (DoH)", RFC 8484, DOI 10.17487/RFC8484, October 2018,
               <https://www.rfc-editor.org/info/rfc8484>.
 
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 45]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    [RFC8601]  Kucherawy, M., "Message Header Field for Indicating
               Message Authentication Status", RFC 8601,
               DOI 10.17487/RFC8601, May 2019,
@@ -2535,6 +2570,14 @@ Appendix A.  Technology Considerations
    suggestions that were considered but not included in the design.
    This text is included to explain why they were considered and not
    included in this version.
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 46]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 A.1.  S/MIME
 
@@ -2572,13 +2615,6 @@ A.2.  Method Exclusion
    Owner could tell Message Receivers not to attempt verification by one
    of the supported methods (e.g., "check DKIM, but not SPF").
 
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 46]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    Specifically, consider a Domain Owner that has deployed one of the
    technologies, and that technology fails for some messages, but such
    failures don't cause enforcement action.  Deploying DMARC would cause
@@ -2591,6 +2627,13 @@ Internet-Draft                  DMARCbis                   November 2021
    target audience for DMARC does not appear to have concerns about the
    failure modes of one or the other being a barrier to DMARC's
    adoption.
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 47]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    In the scenario described above, the Domain Owner has a few options:
 
@@ -2627,14 +2670,6 @@ A.3.  Sender Header Field
        is for, its use in this way is also unreliable, making it a poor
        candidate for inclusion in the DMARC evaluation algorithm.
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 47]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    3.  Allowing multiple ways to discover policy introduces unacceptable
        ambiguity into the DMARC evaluation algorithm in terms of which
        policy is to be applied and when.
@@ -2647,6 +2682,14 @@ A.4.  Domain Existence Test
    MX, A, or AAAA resource records for the name being evaluated and
    assuming that the domain is nonexistent if it could be determined
    that no such records were published for that domain name.
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 48]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    The original pre-standardization version of this protocol included a
    mandatory check of this nature.  It was ultimately removed, as the
@@ -2684,13 +2727,6 @@ A.5.  Issues with ADSP in Operation
    4.  ADSP has no support for using SPF as an auxiliary mechanism to
        DKIM.
 
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 48]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    5.  ADSP has no support for a slow rollout, i.e., no way to configure
        a percentage of email on which the receiver should apply the
        policy.  This is important for large-volume senders.
@@ -2701,6 +2737,15 @@ Internet-Draft                  DMARCbis                   November 2021
 
    7.  The binding between the "From" header domain and DKIM is too
        tight for ADSP; they must match exactly.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 49]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 A.6.  Organizational Domain Discovery Issues
 
@@ -2731,21 +2776,12 @@ A.6.  Organizational Domain Discovery Issues
    constitutes an amplified denial-of-service attack.
 
    The Organizational Domain mechanism is a necessary component to the
-   goals of DMARC.  The method described in Section 3.4 is far from
+   goals of DMARC.  The method described in Section 4.5 is far from
    perfect but serves this purpose reasonably well without adding undue
    burden or semantics to the DNS.  If a method is created to do so that
    is more reliable and secure than the use of a public suffix list,
    DMARC should be amended to use that method as soon as it is generally
    available.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 49]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 A.6.1.  Public Suffix Lists
 
@@ -2757,6 +2793,15 @@ A.6.1.  Public Suffix Lists
 
    Note that if operators use a variety of public suffix lists,
    interoperability will be difficult or impossible to guarantee.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 50]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 A.7.  Removal of the "pct" Tag
 
@@ -2781,27 +2826,6 @@ A.7.  Removal of the "pct" Tag
    deviate from standard handling of the message, usually by rewriting
    the RFC5322.From header in an effort to avoid DMARC failures
    downstream.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 50]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    These custom actions when the pct= tag was set to "0" proved valuable
    to the email community.  In particular, header rewriting by an
@@ -2828,6 +2852,13 @@ Internet-Draft                  DMARCbis                   November 2021
    application by mailbox providers and intermediaries to the "pct" tag
    values "0" and "100", respectively.
 
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 51]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 Appendix B.  Examples
 
    This section illustrates both the Domain Owner side and the Mail
@@ -2846,18 +2877,6 @@ B.1.1.  SPF
    Alignment cannot exist if SPF does not produce a passing result.
 
    Example 1: SPF in alignment:
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 51]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
         MAIL FROM: <sender@example.com>
 
@@ -2886,6 +2905,16 @@ Internet-Draft                  DMARCbis                   November 2021
 
    Example 3: SPF not in alignment:
 
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 52]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
         MAIL FROM: <sender@example.net>
 
         From: sender@child.example.com
@@ -2903,17 +2932,6 @@ B.1.2.  DKIM
    Alignment cannot exist with a DKIM signature that does not verify.
 
    Example 1: DKIM in alignment:
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 52]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
         DKIM-Signature: v=1; ...; d=example.com; ...
         From: sender@example.com
@@ -2946,6 +2964,13 @@ Internet-Draft                  DMARCbis                   November 2021
         To: receiver@example.org
         Subject: here's a sample
 
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 53]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    In this case, the DKIM signature's "d=" parameter includes a DNS
    domain that is neither the same as, a parent of, nor a child of the
    RFC5322.From domain.  Thus, the identifiers are not in alignment.
@@ -2963,13 +2988,6 @@ B.2.1.  Entire Domain, Monitoring Only
    its messaging infrastructure.  The owner wishes to begin using DMARC
    with a policy that will solicit aggregate feedback from receivers
    without affecting how the messages are processed, in order to:
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 53]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    *  Confirm that its legitimate messages are authenticating correctly
 
@@ -3000,6 +3018,15 @@ Internet-Draft                  DMARCbis                   November 2021
      % dig +short TXT _dmarc.example.com.
      "v=DMARC1; p=none; rua=mailto:dmarc-feedback@example.com"
 
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 54]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    To publish such a record, the DNS administrator for the Domain Owner
    creates an entry like the following in the appropriate zone file
    (following the conventional zone file format):
@@ -3017,15 +3044,6 @@ B.2.2.  Entire Domain, Monitoring Only, Per-Message Reports
    authentication failures.  In order to diagnose these intermittent
    problems, they wish to request per-message failure reports when
    authentication failures occur.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 54]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    Not all Receivers will honor such a request, but the Domain Owner
    feels that any reports it does receive will be helpful enough to
@@ -3057,6 +3075,14 @@ Internet-Draft                  DMARCbis                   November 2021
                        "rua=mailto:dmarc-feedback@example.com; "
                        "ruf=mailto:auth-reports@example.com" )
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 55]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 B.2.3.  Per-Message Failure Reports Directed to Third Party
 
    The Domain Owner from the previous example is maintaining the same
@@ -3072,16 +3098,6 @@ B.2.3.  Per-Message Failure Reports Directed to Third Party
    *  Per-message failure reports should be sent via email to the
       address "auth-reports@thirdparty.example.net" ("ruf=mailto:auth-
       reports@thirdparty.example.net")
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 55]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    The DMARC policy record might look like this when retrieved using a
    common command-line tool (the output shown would appear on a single
@@ -3114,6 +3130,15 @@ Internet-Draft                  DMARCbis                   November 2021
       "example.com._report._dmarc.thirdparty.example.net" with the value
       "v=DMARC1;".
 
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 56]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    The resulting DNS record might look like this when retrieved using a
    common command-line tool (the output shown would appear on a single
    line but is wrapped here for publication):
@@ -3129,15 +3154,6 @@ Internet-Draft                  DMARCbis                   November 2021
      ; Accept DMARC failure reports on behalf of example.com
 
      example.com._report._dmarc   IN   TXT    "v=DMARC1;"
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 56]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    Mediators and other third parties should refer to Section 3 of
    [DMARC-Aggregate-Reporting] for the full details of this mechanism.
@@ -3170,6 +3186,15 @@ B.2.4.  Subdomain, Testing, and Multiple Aggregate Report URIs
    *  Receivers are advised that the Domain Owner considers messages
       that fail to authenticate to be suspicious ("p=quarantine")
 
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 57]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    *  Aggregate feedback reports should be sent via email to the
       addresses "dmarc-feedback@example.com" and "example-tld-
       test@thirdparty.example.net" ("rua=mailto:dmarc-
@@ -3184,16 +3209,6 @@ B.2.4.  Subdomain, Testing, and Multiple Aggregate Report URIs
    The DMARC policy record might look like this when retrieved using a
    common command-line tool (the output shown would appear on a single
    line but is wrapped here for publication):
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 57]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
      % dig +short TXT _dmarc.test.example.com
      "v=DMARC1; p=quarantine; rua=mailto:dmarc-feedback@example.com,
@@ -3227,6 +3242,15 @@ Internet-Draft                  DMARCbis                   November 2021
      "v=DMARC1; p=reject; rua=mailto:dmarc-feedback@example.com,
       mailto:tld-test@thirdparty.example.net"
 
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 58]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    To publish such a record, the DNS administrator for the Domain Owner
    might create an entry like the following in the appropriate zone
    file:
@@ -3243,13 +3267,6 @@ B.3.  Mail Receiver Example
    SPF and DKIM, and possess the ability to collect relevant information
    from various email-processing stages to provide feedback to Domain
    Owners (possibly via Report Receivers).
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 58]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 B.4.  Processing of SMTP Time
 
@@ -3278,6 +3295,18 @@ B.4.  Processing of SMTP Time
    For example, the following sample data is considered to be from a
    piece of email originating from the Domain Owner of "example.com":
 
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 59]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
      Author Domain: example.com
      SPF-authenticated Identifier: mail.example.com
      DKIM-authenticated Identifier: example.com
@@ -3290,22 +3319,6 @@ B.4.  Processing of SMTP Time
    Receiver considers the above email to pass the DMARC check, avoiding
    the "reject" policy that is requested to be applied to email that
    fails to pass the DMARC check.
-
-
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 59]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    If no Authenticated Identifiers align with the Author Domain, then
    the Mail Receiver applies the DMARC-record-specified policy.
@@ -3340,6 +3353,16 @@ Internet-Draft                  DMARCbis                   November 2021
    has not requested aggregate reports, i.e., no "rua" tag was found in
    the policy record.
 
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 60]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 B.5.  Utilization of Aggregate Feedback: Example
 
    Aggregate feedback is consumed by Domain Owners to verify their
@@ -3355,14 +3378,6 @@ B.5.  Utilization of Aggregate Feedback: Example
    checks provides visibility into problems that need to be addressed by
    the Domain Owner.  For example, if either SPF or DKIM fails to pass,
    the Domain Owner is provided with enough information to either
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 60]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    directly correct the problem or understand where authentication-
    breaking changes are being introduced in the email transmission path.
    If authentication-breaking changes due to email transmission path
@@ -3395,6 +3410,15 @@ C.1.1.  Ticket 80 - DMARCbis SHould Have Clear and Concise Defintion of
       ietf-dmarc-dmarcbis/pull/1/files (https://github.com/ietf-wg-
       dmarc/draft-ietf-dmarc-dmarcbis/pull/1/files)
 
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 61]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 C.2.  February 4, 2021
 
 C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208
@@ -3407,17 +3431,6 @@ C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208
    *  Diffs are here - https://github.com/ietf-wg-dmarc/draft-ietf-
       dmarc-dmarcbis/pull/3/files (https://github.com/ietf-wg-dmarc/
       draft-ietf-dmarc-dmarcbis/pull/3/files)
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 61]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 C.3.  February 10, 2021
 
@@ -3454,6 +3467,14 @@ C.5.2.  Ticket 3 - Two tiny nits
       date current text, which appears to have answered the concern
       raised.
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 62]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 C.5.3.  Ticket 4 - Definition of "fo" parameter
 
    *  Changes to wording in section 6.3, to bring clarity to use of
@@ -3466,14 +3487,6 @@ C.5.3.  Ticket 4 - Definition of "fo" parameter
 C.6.  March 16, 2021
 
 C.6.1.  Ticket 7 - ABNF for dmarc-record is slightly wrong
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 62]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    *  New text documented here - https://trac.ietf.org/trac/dmarc/
       ticket/7 (https://trac.ietf.org/trac/dmarc/ticket/7)
@@ -3509,6 +3522,15 @@ C.7.2.  Ticket 72 - Remove absolute requirement for p= tag in DMARC
       ticket/72#comment:3 (https://trac.ietf.org/trac/dmarc/
       ticket/72#comment:3)
 
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 63]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 C.8.  March 29, 2021
 
 C.8.1.  Ticket 54 - Remove or expand limits on number of recipients per
@@ -3519,17 +3541,6 @@ C.8.1.  Ticket 54 - Remove or expand limits on number of recipients per
    *  Diffs documented here - https://trac.ietf.org/trac/dmarc/
       ticket/54#comment:5 (https://trac.ietf.org/trac/dmarc/
       ticket/54#comment:5)
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 63]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 C.9.  April 12, 2021
 
@@ -3568,6 +3579,14 @@ C.10.1.  Ticket 53 - Remove reporting message size chunking
 
 C.10.2.  Ticket 52 - Remove strict alignment (and adkim and aspf tags)
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 64]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    *  Proposed text to remove all references to strict alignment
 
    *  Data demonstrating lack of use of feature entered into ticket -
@@ -3577,15 +3596,6 @@ C.10.2.  Ticket 52 - Remove strict alignment (and adkim and aspf tags)
 C.10.3.  Ticket 47 - Remove pct= tag
 
    *  Proposed text to remove all references to pct and message sampling
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 64]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    *  Data demonstrating lack of use of feature entered into ticket -
       https://trac.ietf.org/trac/dmarc/ticket/47#comment:4
@@ -3625,6 +3635,14 @@ C.12.1.  Ticket 86 - A-R results for DMARC
    *  Proposed text to add for polrec.p and polrec.domain methods for
       registry update.
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 65]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    *  Did not include polrec.pct due to proposal to remove pct tag
       (Ticket 47)
 
@@ -3634,14 +3652,6 @@ C.12.2.  Ticket 62 - Make aggregate reporting a normative MUST
       titled "Send Aggregate Reports"
 
 C.13.  April 19, 2021
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 65]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 C.13.1.  Ticket 109 - Sanity Check DMARCbis Document
 
@@ -3681,23 +3691,20 @@ C.17.  August 12, 2021
 
 C.17.1.  Publication of draft-ietf-dmarc-dmarcbis-03
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 66]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    *  Removal of "pct" tag
 
    *  Addition of "t" tag
 
    *  Rearranging of some text and formatting for better readability and
       consistency.
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 66]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 Acknowledgements
 
@@ -3743,12 +3750,5 @@ Authors' Addresses
 
 
 
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 67]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 67]
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ DMARC                                                       T. Herr (ed)
 Internet-Draft                                                  Valimail
 Obsoletes: 7489 (if approved)                             J. Levine (ed)
 Intended status: Standards Track                           Standcore LLC
-Expires: 26 May 2022                                    22 November 2021
+Expires: 27 May 2022                                    23 November 2021
 
 
 Domain-based Message Authentication, Reporting, and Conformance (DMARC)
@@ -42,7 +42,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 26 May 2022.
+   This Internet-Draft will expire on 27 May 2022.
 
 Copyright Notice
 
@@ -54,7 +54,7 @@ Copyright Notice
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 1]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 1]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -92,43 +92,44 @@ Table of Contents
        3.2.11. PSO Controlled Domain Names . . . . . . . . . . . . .  10
        3.2.12. Report Receiver . . . . . . . . . . . . . . . . . . .  11
    4.  Overview and Key Concepts . . . . . . . . . . . . . . . . . .  11
-     4.1.  Use of RFC5322.From . . . . . . . . . . . . . . . . . . .  12
-     4.2.  Authentication Mechanisms . . . . . . . . . . . . . . . .  13
-     4.3.  Flow Diagram  . . . . . . . . . . . . . . . . . . . . . .  13
-     4.4.  Identifier Alignment Explained  . . . . . . . . . . . . .  15
-       4.4.1.  DKIM-Authenticated Identifiers  . . . . . . . . . . .  15
-       4.4.2.  SPF-Authenticated Identifiers . . . . . . . . . . . .  16
-       4.4.3.  Alignment and Extension Technologies  . . . . . . . .  16
-     4.5.  Determining The Organizational Domain . . . . . . . . . .  17
-   5.  Policy  . . . . . . . . . . . . . . . . . . . . . . . . . . .  18
-     5.1.  DMARC Policy Record . . . . . . . . . . . . . . . . . . .  19
-     5.2.  DMARC URIs  . . . . . . . . . . . . . . . . . . . . . . .  19
-     5.3.  General Record Format . . . . . . . . . . . . . . . . . .  19
-     5.4.  Formal Definition . . . . . . . . . . . . . . . . . . . .  24
-     5.5.  Domain Owner Actions  . . . . . . . . . . . . . . . . . .  25
-       5.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  25
+     4.1.  DMARC Basics  . . . . . . . . . . . . . . . . . . . . . .  11
+     4.2.  Use of RFC5322.From . . . . . . . . . . . . . . . . . . .  12
+     4.3.  Authentication Mechanisms . . . . . . . . . . . . . . . .  13
+     4.4.  Flow Diagram  . . . . . . . . . . . . . . . . . . . . . .  13
+     4.5.  DNS Tree Walk . . . . . . . . . . . . . . . . . . . . . .  15
+     4.6.  Determining the Organizational Domain . . . . . . . . . .  16
+     4.7.  Identifier Alignment Explained  . . . . . . . . . . . . .  17
+       4.7.1.  DKIM-Authenticated Identifiers  . . . . . . . . . . .  17
+       4.7.2.  SPF-Authenticated Identifiers . . . . . . . . . . . .  18
+       4.7.3.  Alignment and Extension Technologies  . . . . . . . .  19
+   5.  Policy  . . . . . . . . . . . . . . . . . . . . . . . . . . .  19
+     5.1.  DMARC Policy Record . . . . . . . . . . . . . . . . . . .  20
+     5.2.  DMARC URIs  . . . . . . . . . . . . . . . . . . . . . . .  20
+     5.3.  General Record Format . . . . . . . . . . . . . . . . . .  20
+     5.4.  Formal Definition . . . . . . . . . . . . . . . . . . . .  25
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 2]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 2]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
+     5.5.  Domain Owner Actions  . . . . . . . . . . . . . . . . . .  26
+       5.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  26
        5.5.2.  Configure Sending System for DKIM Signing Using an
-               Aligned Domain  . . . . . . . . . . . . . . . . . . .  25
-       5.5.3.  Setup a Mailbox to Receive Aggregate Reports  . . . .  25
-       5.5.4.  Publish a DMARC Policy for the Author Domain  . . . .  26
+               Aligned Domain  . . . . . . . . . . . . . . . . . . .  26
+       5.5.3.  Setup a Mailbox to Receive Aggregate Reports  . . . .  27
+       5.5.4.  Publish a DMARC Policy for the Author Domain  . . . .  27
        5.5.5.  Collect and Analyze Reports and Adjust
-               Authentication  . . . . . . . . . . . . . . . . . . .  26
-       5.5.6.  Decide If and When to Update DMARC Policy . . . . . .  26
-     5.6.  PSO Actions . . . . . . . . . . . . . . . . . . . . . . .  26
-     5.7.  Mail Receiver Actions . . . . . . . . . . . . . . . . . .  27
-       5.7.1.  Extract Author Domain . . . . . . . . . . . . . . . .  27
-       5.7.2.  Determine Handling Policy . . . . . . . . . . . . . .  27
-       5.7.3.  Policy Discovery  . . . . . . . . . . . . . . . . . .  29
-       5.7.4.  Store Results of DMARC Processing . . . . . . . . . .  31
-       5.7.5.  Send Aggregate Reports  . . . . . . . . . . . . . . .  31
+               Authentication  . . . . . . . . . . . . . . . . . . .  27
+       5.5.6.  Decide If and When to Update DMARC Policy . . . . . .  28
+     5.6.  PSO Actions . . . . . . . . . . . . . . . . . . . . . . .  28
+     5.7.  Mail Receiver Actions . . . . . . . . . . . . . . . . . .  28
+       5.7.1.  Extract Author Domain . . . . . . . . . . . . . . . .  28
+       5.7.2.  Determine Handling Policy . . . . . . . . . . . . . .  29
+       5.7.3.  Store Results of DMARC Processing . . . . . . . . . .  31
+       5.7.4.  Send Aggregate Reports  . . . . . . . . . . . . . . .  31
      5.8.  Policy Enforcement Considerations . . . . . . . . . . . .  31
    6.  DMARC Feedback  . . . . . . . . . . . . . . . . . . . . . . .  32
    7.  Other Topics  . . . . . . . . . . . . . . . . . . . . . . . .  33
@@ -162,15 +163,15 @@ Internet-Draft                  DMARCbis                   November 2021
      A.5.  Issues with ADSP in Operation . . . . . . . . . . . . . .  49
      A.6.  Organizational Domain Discovery Issues  . . . . . . . . .  50
        A.6.1.  Public Suffix Lists . . . . . . . . . . . . . . . . .  50
-     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  51
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 3]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 3]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
+     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  51
    Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  52
      B.1.  Identifier Alignment Examples . . . . . . . . . . . . . .  52
        B.1.1.  SPF . . . . . . . . . . . . . . . . . . . . . . . . .  52
@@ -217,16 +218,17 @@ Internet-Draft                  DMARCbis                   November 2021
                DMARC . . . . . . . . . . . . . . . . . . . . . . . .  64
        C.9.3.  Ticket 96 - Tweaks to Abstract and Introduction . . .  64
      C.10. April 13, 2021  . . . . . . . . . . . . . . . . . . . . .  64
-       C.10.1.  Ticket 53 - Remove reporting message size
-               chunking  . . . . . . . . . . . . . . . . . . . . . .  64
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 4]
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 4]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
+       C.10.1.  Ticket 53 - Remove reporting message size
+               chunking  . . . . . . . . . . . . . . . . . . . . . .  64
        C.10.2.  Ticket 52 - Remove strict alignment (and adkim and
                aspf tags)  . . . . . . . . . . . . . . . . . . . . .  64
        C.10.3.  Ticket 47 - Remove pct= tag  . . . . . . . . . . . .  65
@@ -276,9 +278,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 5]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 5]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -334,7 +334,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 6]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 6]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -390,7 +390,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 7]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 7]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -446,7 +446,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 8]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 8]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -477,7 +477,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    Domain-level identifiers that are verified using authentication
    technologies are referred to as "Authenticated Identifiers".  See
-   Section 4.2 for details about the supported mechanisms.
+   Section 4.3 for details about the supported mechanisms.
 
 3.2.2.  Author Domain
 
@@ -502,7 +502,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 9]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 9]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -510,8 +510,8 @@ Internet-Draft                  DMARCbis                   November 2021
 3.2.4.  Identifier Alignment
 
    When the domain in the address in the From: header field has the same
-   Organizational Domain as a domain verified by SPF or DKIM (or both),
-   it has Identifier Alignment. (see below)
+   Organizational Domain as a domain verified by an authenticated
+   identifier, it has Identifier Alignment. (see below)
 
 3.2.5.  Longest PSD
 
@@ -535,7 +535,7 @@ Internet-Draft                  DMARCbis                   November 2021
    with a domain name registrar.  More formally, it is any Public Suffix
    Domain plus one label.  The Organizational Domain for the domain in
    the RFC5322.From domain is determined by applying the algorithm found
-   in Section 4.5.
+   in Section 4.6.
 
 3.2.9.  Public Suffix Domain (PSD)
 
@@ -558,7 +558,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 10]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 10]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -579,6 +579,8 @@ Internet-Draft                  DMARCbis                   November 2021
    This section provides a general overview of the design and operation
    of the DMARC environment.
 
+4.1.  DMARC Basics
+
    DMARC permits a Domain Owner or PSO to enable verification of a
    domain's use in an email message, to indicate the Domain Owner's or
    PSO's message handling preference regarding failed verification, and
@@ -588,7 +590,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    DMARC's verification function is based on whether the RFC5322.From
    domain is aligned with a domain name used in a supported
-   authentication mechanism.  Section 4.2 When a DMARC policy exists for
+   authentication mechanism.  Section 4.3 When a DMARC policy exists for
    the domain name found in the RFC5322.From header field, and that
    domain name is not verified through an aligned supported
    authentication mechanism, the handling of that message can be
@@ -601,7 +603,7 @@ Internet-Draft                  DMARCbis                   November 2021
    1.  produces a "pass" result, and
 
    2.  produces that result based on an identifier that is in alignment,
-       as described in Section 4.4.
+       as described in Section 4.7.
 
    It is important to note that the authentication mechanisms employed
    by DMARC authenticate only a DNS domain and do not authenticate the
@@ -612,9 +614,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 11]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 11]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -634,7 +634,7 @@ Internet-Draft                  DMARCbis                   November 2021
    DMARC but defined in other referenced material such as [RFC6591] and
    [DMARC-Failure-Reporting]
 
-4.1.  Use of RFC5322.From
+4.2.  Use of RFC5322.From
 
    One of the most obvious points of security scrutiny for DMARC is the
    choice to focus on an identifier, namely the RFC5322.From address,
@@ -670,7 +670,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 12]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 12]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -680,7 +680,7 @@ Internet-Draft                  DMARCbis                   November 2021
    operate under a slightly restricted profile of RFC5322 with respect
    to the expected syntax of this field.  See Section 5.7 for details.
 
-4.2.  Authentication Mechanisms
+4.3.  Authentication Mechanisms
 
    The following mechanisms for determining Authenticated Identifiers
    are supported in this version of DMARC:
@@ -696,7 +696,7 @@ Internet-Draft                  DMARCbis                   November 2021
       describes MAIL FROM processing for cases in which the MAIL command
       has a null path.
 
-4.3.  Flow Diagram
+4.4.  Flow Diagram
 
 
 
@@ -726,7 +726,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 13]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 13]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -782,12 +782,124 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 14]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 14]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-4.4.  Identifier Alignment Explained
+4.5.  DNS Tree Walk
+
+   While the DMARC protocol defines a method for communicating
+   information through publishing records in DNS, it is not necessarily
+   true that a DMARC policy record for a given domain will be found in
+   DNS at the same level as the name label for the domain in question.
+   Instead, some domains will inherit their DNS policy records from
+   parent domains one level or more above them in the DNS hierarchy, and
+   these records can only be discovered through a technique described
+   here, one known colloquially as a "DNS Tree Walk".
+
+   The process for a DNS Tree Walk will always start at the point in the
+   DNS hierarchy that matches the domain in the RFC5322.From header of
+   the message, and will always end at the Public Suffix Domain that
+   terminates the RFC5322.From domain.  To prevent possible abuse of the
+   DNS, a shortcut is built into the process so that RFC5322.From
+   domains that have more than five labels do not result in more than
+   five DNS queries.
+
+   The generic steps for a DNS Tree Walk are as follows:
+
+   1.  Query the DNS for a DMARC TXT record at the DNS domain matching
+       the one found in the RFC5322.From domain in the message.  A
+       possibly empty set of records is returned.
+
+   2.  Records that do not start with a "v=" tag that identifies the
+       current version of DMARC are discarded.
+
+   3.  If the set is now empty, or the set contains one valid DMARC
+       record that does not contain the information sought, then
+       determine the target for additional queries, using steps 4
+       through 8 below.
+
+   4.  Break the subject DNS domain name into a set of "n" ordered
+       labels.  Number these labels from right to left; e.g., for
+       "a.mail.example.com", "com" would be label 1, "example" would be
+       label 2, "mail.example.com" would be label 3, and so forth.
+
+   5.  Count the number of labels found in the subject DNS domain.  Let
+       that number be "x".  If x < 5, remove the left-most (highest-
+       numbered) label from the subject domain.  If x >= 5, remove the
+       left-most (highest-numbered) labels from the subject domain until
+       4 labels remain.  The resulting DNS domain name is the new target
+       for subsequent lookups.
+
+   6.  Query the DNS for a DMARC TXT record at the DNS domain matching
+       this new target in place of the RFC5322.From domain in the
+       message.  A possibly empty set of records is returned.
+
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 15]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+   7.  Records that do not start with a "v=" tag that identifies the
+       current version of DMARC are discarded.
+
+   8.  If the set is now empty, or the set contains one valid DMARC
+       record that does not contain the information sought, then
+       determine the target for additional queries by removing a single
+       label from the target domain as described in step 5 and repeating
+       steps 6 and 7 until there are no more labels remaining or a valid
+       DMARC record containing the information sought has been
+       retrieved.
+
+   To illustrate, for a message with the arbitrary RFC5322.From domain
+   of "a.b.c.d.e.mail.example.com", a full DNS Tree Walk would require
+   the following five queries, in order:
+
+   *  _dmarc.a.b.c.d.e.mail.example.com
+
+   *  _dmarc.e.mail.example.com
+
+   *  _dmarc.mail.example.com
+
+   *  _dmarc.example.com
+
+   *  _dmarc.com
+
+4.6.  Determining the Organizational Domain
+
+   The DMARC protocol defines a method for a Public Suffix Domain to
+   identify itself as such using a tag in its published DMARC policy
+   record.  An Organizational Domain is any subdomain of a PSD that
+   includes exactly one more label than the PSD in its name.
+
+   For any email message, the Organizational Domain of the RFC5322.From
+   domain is determined by performing a DNS Tree Walk as described in
+   Section 4.5.  The target of the search is a valid DMARC record that
+   contains a psd tag with a value of 'y'.  Once such a record has been
+   found, the Organizational Domain for the DNS domain matching the one
+   found in the RFC5322.From domain can be declared to be the target
+   domain queried for in the step just prior to the query that found the
+   PSD domain.
+
+   For example, given the RFC5322.From domain "a.mail.example.com", a
+   series of DNS queries for DMARC records would be executed starting
+   with "_dmarc.a.mail.example.com" and finishing with "_dmarc.com".
+   The "_dmarc.com" record would contain a psd tag with a value of 'y',
+   and so the Organizational Domain for this RFC5322.From domain would
+   be determined to be "example.com", the domain of the DMARC query
+   executed prior to the query for "_dmarc.com".
+
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 16]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+4.7.  Identifier Alignment Explained
 
    Email authentication technologies authenticate various (and
    disparate) aspects of an individual message.  For example, DKIM
@@ -798,9 +910,13 @@ Internet-Draft                  DMARCbis                   November 2021
    These may be different domains, and they are typically not visible to
    the end user.
 
-   DMARC authenticates use of the RFC5322.From domain by requiring that
-   it have the same Organizational Domain as (i.e., be aligned with) an
-   Authenticated Identifier.  Domain names in this context are to be
+   DMARC authenticates use of the RFC5322.From domain by requiring
+   either that it have the same Organizational Domain as an
+   Authenticated Identifier (a condition known as "relaxed alignment")
+   or that it be identical to the domain of the Authenticated Identifier
+   (a condition known as "strict alignment").  The choice of relaxed or
+   strict alignment is left to the domain owner and is expressed in the
+   domain's DMARC policy record.  Domain names in this context are to be
    compared in a case-insensitive manner, per [RFC4343].
 
    It is important to note that Identifier Alignment cannot occur with a
@@ -817,7 +933,7 @@ Internet-Draft                  DMARCbis                   November 2021
    as input yields authenticated domains as their outputs when they
    succeed.
 
-4.4.1.  DKIM-Authenticated Identifiers
+4.7.1.  DKIM-Authenticated Identifiers
 
    DMARC requires Identifier Alignment based on the result of a DKIM
    authentication because a message can bear a valid signature from any
@@ -829,19 +945,22 @@ Internet-Draft                  DMARCbis                   November 2021
    authentication to be strict or relaxed.  (Note that these terms are
    not related to DKIM's "simple" and "relaxed" canonicalization modes.)
 
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 17]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    In relaxed mode, the Organizational Domains of both the DKIM-
    authenticated signing domain (taken from the value of the d= tag in
    the signature) and that of the RFC5322.From domain must be equal if
    the identifiers are to be considered to be aligned.  In strict mode,
    only an exact match between both Fully Qualified Domain Names (FQDNs)
    is considered to produce Identifier Alignment.
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 15]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    To illustrate, in relaxed mode, if a verified DKIM signature
    successfully verifies with a "d=" domain of "example.com", and the
@@ -859,7 +978,7 @@ Internet-Draft                  DMARCbis                   November 2021
    is considered to produce a DMARC "pass" result if any DKIM signature
    is aligned and verifies.
 
-4.4.2.  SPF-Authenticated Identifiers
+4.7.2.  SPF-Authenticated Identifiers
 
    DMARC permits Identifier Alignment based on the result of an SPF
    authentication.  As with DKIM, Identifier Alignement can be either
@@ -884,90 +1003,20 @@ Internet-Draft                  DMARCbis                   November 2021
    [RFC7208], which recommends that SPF checks be done on not only the
    "MAIL FROM" but also on a separate check of the "HELO" identity.
 
-4.4.3.  Alignment and Extension Technologies
+
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 18]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+4.7.3.  Alignment and Extension Technologies
 
    If in the future DMARC is extended to include the use of other
    authentication mechanisms, the extensions will need to allow for
    domain identifier extraction so that alignment with the RFC5322.From
    domain can be verified.
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 16]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-4.5.  Determining The Organizational Domain
-
-   The DMARC protocol defines a method for a Public Suffix Domain to
-   identify itself as such using a tag in its published DMARC policy
-   record.  An Organizational Domain is any subdomain of a PSD that
-   includes exactly one more label than the PSD in its name.
-
-   For any email message, the Organizational Domain of the RFC5322.From
-   domain is determined using the following algorithm, similar to the
-   one described in Section 5.7.3
-
-   1.  Query the DNS for a DMARC TXT record at the DNS domain matching
-       the one found in the RFC5322.From domain in the message.  A
-       possibly empty set of records is returned.
-
-   2.  Records that do not start with a "v=" tag that identifies the
-       current version of DMARC are discarded.
-
-   3.  If the set is now empty, or the set contains one valid DMARC
-       record that does not include a psd tag with a value of 'y', then
-       determine the target for additional queries, using steps 4
-       through 8 below.
-
-   4.  Break the subject DNS domain name into a set of "n" ordered
-       labels.  Number these labels from right to left; e.g., for
-       "a.mail.example.com", "com" would be label 1 and "example" would
-       be label 2 and so forth.
-
-   5.  Count the number of labels found in the subject DNS domain.  Let
-       that number be "x".  If x < 5, remove the left-most (highest-
-       numbered) label from the subject domain.  If x >= 5, remove the
-       left-most (highest-numbered) labels from the subject domain until
-       4 labels remain.  The resulting DNS domain name is the new target
-       for subsequent lookups.
-
-   6.  Query the DNS for a DMARC TXT record at the DNS domain matching
-       this new target in place of the RFC5322.From domain in the
-       message.  A possibly empty set of records is returned.
-
-   7.  Records that do not start with a "v=" tag that identifies the
-       current version of DMARC are discarded.
-
-   8.  If the set is now empty, or the set contains one valid DMARC
-       record that does not include a psd tag with the value of 'y',
-       then determine the target for additional queries by removing a
-       single label from the target domain as described in step 5 and
-       repeating steps 6 and 7 until there are no more labels remaining
-       or a record containing a psd tag with a value of 'y' is found.
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 17]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-   9.  Once a valid DMARC record containing a psd tag with a value of
-       'y' has been found, the Organizational Domain for the DNS domain
-       matching the one found in the RFC5322.From domain can be declared
-       to be the target domain queried for in the step prior to the
-       query that found the PSD domain.
-
-   For example, given the RFC5322.From domain "a.mail.example.com", a
-   series of DNS queries for DMARC records would be executed starting
-   with "_dmarc.a.mail.example.com" and finishing with "_dmarc.com".
-   The "_dmarc.com" record would contain a psd tag with a value of 'y',
-   and so the Organizational Domain for this RFC5322.From domain would
-   be determined to be "example.com", the domain of the DMARC query
-   executed prior to the query for "_dmarc.com".
 
 5.  Policy
 
@@ -995,10 +1044,9 @@ Internet-Draft                  DMARCbis                   November 2021
    A Mail Receiver implementing the DMARC mechanism SHOULD make a best-
    effort attempt to adhere to the Domain Owner's or PSO's published
    DMARC Domain Owner Assessment Policy when a message fails the DMARC
-   test.
-   Since email streams can be complicated (due to forwarding, existing
-   RFC5322.From domain-spoofing services, etc.), Mail Receivers MAY
-   deviate from a published Domain Owner Assessment Policy during
+   test.  Since email streams can be complicated (due to forwarding,
+   existing RFC5322.From domain-spoofing services, etc.), Mail Receivers
+   MAY deviate from a published Domain Owner Assessment Policy during
    message processing and SHOULD make available the fact of and reason
    for the deviation to the Domain Owner via feedback reporting,
    specifically using the "PolicyOverride" feature of the aggregate
@@ -1006,7 +1054,15 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 18]
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 19]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1062,7 +1118,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 19]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 20]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1076,7 +1132,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    adkim:  (plain-text; OPTIONAL; default is "r".)  Indicates whether
       strict or relaxed DKIM Identifier Alignment mode is required by
-      the Domain Owner.  See Section 4.4.1 for details.  Valid values
+      the Domain Owner.  See Section 4.7.1 for details.  Valid values
       are as follows:
 
       r:  relaxed mode
@@ -1085,7 +1141,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    aspf:  (plain-text; OPTIONAL; default is "r".)  Indicates whether
       strict or relaxed SPF Identifier Alignment mode is required by the
-      Domain Owner.  See Section 4.4.2 for details.  Valid values are as
+      Domain Owner.  See Section 4.7.2 for details.  Valid values are as
       follows:
 
       r:  relaxed mode
@@ -1118,7 +1174,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 20]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 21]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1155,7 +1211,7 @@ Internet-Draft                  DMARCbis                   November 2021
       present, MUST be applied for non-existent subdomains.  Note that
       "np" will be ignored for DMARC records published on subdomains of
       Organizational Domains and PSDs due to the effect of the DMARC
-      policy discovery mechanism described in Section 5.7.3.
+      policy discovery mechanism described in Section 5.7.2.1.
 
    p:  Domain Owner Assessment Policy (plain-text; RECOMMENDED for
       policy records).  Indicates the message handling preference the
@@ -1167,14 +1223,14 @@ Internet-Draft                  DMARCbis                   November 2021
       [DMARC-Aggregate-Reporting] and [DMARC-Failure-Reporting])
       Possible values are as follows:
 
-      none:  The Domain Owner offers no expression of concern.
+      none:  The Domain Owner offers no expression of preference.
 
       quarantine:  The Domain Owner considers such mail to be
          suspicious.  It is possible the mail is valid, although the
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 21]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 22]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1199,7 +1255,7 @@ Internet-Draft                  DMARCbis                   November 2021
          published for a domain that is not a PSD.
 
    rua:  Addresses to which aggregate feedback is to be sent (comma-
-      separated plain-text list of DMARC URIs; OPTIONAL).  Section 3 of
+      separated plain-text list of DMARC URIs; OPTIONAL).
       [DMARC-Aggregate-Reporting] discusses considerations that apply
       when the domain name of a URI differs from that of the domain
       advertising the policy.  See Section 9.5 for additional
@@ -1217,20 +1273,20 @@ Internet-Draft                  DMARCbis                   November 2021
       Receivers to send detailed failure reports about messages that
       fail the DMARC evaluation in specific ways (see the "fo" tag
       above).  The format of the message to be generated MUST follow the
-      format specified for the "rf" tag.  Section 3 of
-      [DMARC-Aggregate-Reporting] discusses considerations that apply
-      when the domain name of a URI differs from that of the domain
-      advertising the policy.  A Mail Receiver MUST implement support
-      for a "mailto:" URI, i.e., the ability to send a DMARC report via
-      electronic mail.  If not provided, Mail Receivers MUST NOT
-      generate failure reports.  See Section 9.5 for additional
-      considerations.
+      format specified for the "rf" tag.  [DMARC-Aggregate-Reporting]
+      discusses considerations that apply when the domain name of a URI
+      differs from that of the domain advertising the policy.  A Mail
+      Receiver MUST implement support for a "mailto:" URI, i.e., the
+      ability to send a DMARC report via electronic mail.  If not
+      provided, Mail Receivers MUST NOT generate failure reports.  See
+      Section 9.5 for additional considerations.
 
 
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 22]
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 23]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1246,7 +1302,7 @@ Internet-Draft                  DMARCbis                   November 2021
       be applied for subdomains.  Note that "sp" will be ignored for
       DMARC records published on subdomains of Organizational Domains
       due to the effect of the DMARC policy discovery mechanism
-      described in Section 5.7.3.
+      described in Section 5.7.2.1.
 
    t:  DMARC policy test mode (plain-text; OPTIONAL; default is 'n').
       For the RFC5322.From domain to which the DMARC record applies, the
@@ -1286,7 +1342,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 23]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 24]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1305,6 +1361,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
      dmarc-tag       = dmarc-request /
                        dmarc-test /
+                       dmarc-psd /
                        dmarc-srequest /
                        dmarc-nprequest /
                        dmarc-adkim /
@@ -1325,6 +1382,8 @@ Internet-Draft                  DMARCbis                   November 2021
 
      dmarc-test      = "t" *WSP "=" ( "y" / "n" )
 
+     dmarc-psd       = "psd" *WSP "=" ( "y" / "n" )
+
      dmarc-srequest  = "sp" *WSP "=" *WSP
                        ( "none" / "quarantine" / "reject" )
 
@@ -1336,17 +1395,17 @@ Internet-Draft                  DMARCbis                   November 2021
      dmarc-aspf      = "aspf" *WSP "=" *WSP ( "r" / "s" )
 
      dmarc-auri      = "rua" *WSP "=" *WSP
-                       dmarc-uri *(*WSP "," *WSP dmarc-uri)
-
-     dmarc-furi      = "ruf" *WSP "=" *WSP
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 24]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 25]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
+                       dmarc-uri *(*WSP "," *WSP dmarc-uri)
+
+     dmarc-furi      = "ruf" *WSP "=" *WSP
                        dmarc-uri *(*WSP "," *WSP dmarc-uri)
 
      dmarc-fo        = "fo" *WSP "=" *WSP
@@ -1383,6 +1442,23 @@ Internet-Draft                  DMARCbis                   November 2021
    that aligns with the Author Domain and configure its system to sign
    using that domain.
 
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 26]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 5.5.3.  Setup a Mailbox to Receive Aggregate Reports
 
    Proper consumption and analysis of DMARC aggregate reports is the key
@@ -1393,15 +1469,6 @@ Internet-Draft                  DMARCbis                   November 2021
    how mature the Domain Owner's DMARC rollout is, some of these sources
    could be legitimate ones that were overlooked during the intial
    deployment of SPF and/or DKIM.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 25]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    Because the aggregate reports are XML documents, it is strongly
    advised that they be machine-parsed, so setting up a mailbox involves
@@ -1431,6 +1498,23 @@ Internet-Draft                  DMARCbis                   November 2021
    reports, the Domain Owner can adjust the SPF record and/or configure
    DKIM signing for those systems.
 
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 27]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 5.5.6.  Decide If and When to Update DMARC Policy
 
    Once the Domain Owner is satisfied that it is properly authenticating
@@ -1449,15 +1533,6 @@ Internet-Draft                  DMARCbis                   November 2021
    availablle to Mail Receivers.  [RFC9091] is an experimental method
    for doing so, and the experiment is described in Appendix B of that
    document.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 26]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 5.7.  Mail Receiver Actions
 
@@ -1485,8 +1560,16 @@ Internet-Draft                  DMARCbis                   November 2021
    header field.  Multi-valued RFC5322.From header fields with multiple
    domains MUST be exempt from DMARC checking.
 
-   Note that domain names that appear on a public suffix list are not
-   exempt from DMARC policy application and reporting.
+   Note that Public Suffix Domains are not exempt from DMARC policy
+   application and reporting.
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 28]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 5.7.2.  Determine Handling Policy
 
@@ -1501,19 +1584,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    2.  Query the DNS for a DMARC policy record.  Continue if one is
        found, or terminate DMARC evaluation otherwise.  See
-       Section 5.7.3 for details.
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 27]
-
-Internet-Draft                  DMARCbis                   November 2021
-
+       Section 5.7.2.1 for details.
 
    3.  Perform DKIM signature verification checks.  A single email could
        contain multiple DKIM signatures.  The results of this step are
@@ -1537,16 +1608,24 @@ Internet-Draft                  DMARCbis                   November 2021
        failures, identifier mismatches) are considered to be DMARC
        mechanism check failures.
 
-   6.  Apply policy.  Emails that fail the DMARC mechanism check are
-       handled in accordance with the discovered DMARC policy of the
-       Domain Owner and any local policy rules enforced by the Mail
-       Receiver.  See Section 5.3 for details.
+   6.  Apply policy, if appropriate.  Emails that fail the DMARC
+       mechanism check are handled in accordance with the discovered
+       DMARC policy of the Domain Owner and any local policy rules
+       enforced by the Mail Receiver.  See Section 5.3 for details.
 
    Heuristics applied in the absence of use by a Domain Owner of either
    SPF or DKIM (e.g., [Best-Guess-SPF]) SHOULD NOT be used, as it may be
    the case that the Domain Owner wishes a Message Receiver not to
    consider the results of that underlying authentication protocol at
    all.
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 29]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    DMARC evaluation can only yield a "pass" result after one of the
    underlying authentication mechanisms passes for an aligned
@@ -1560,89 +1639,29 @@ Internet-Draft                  DMARCbis                   November 2021
    Handling of messages for which SPF and/or DKIM evaluation encounter a
    permanent DNS error is left to the discretion of the Mail Receiver.
 
+5.7.2.1.  DMARC Policy Discovery
 
+   Discovery of the applicable DMARC policy for any domain is
+   accomplished via a DNS Tree Walk as described in Section 4.5.  The
+   target of this tree walk is a valid DMARC policy record, and the
+   following rules should be applied to records that are found in this
+   manner:
 
+   1.  If the tree walk ends in the discovery of multiple records or no
+       records, DMARC processing is not applied to this message.
 
+   2.  If a retrieved policy record does not contain a valid "p" tag, or
+       contains an "sp" tag that is not valid, then:
 
+       *  If a "rua" tag is present and contains at least one
+          syntactically valid reporting URI, the Mail Receiver SHOULD
+          act as if a record containing a valid "v" tag and "p=none" was
+          retrieved, and continue processing;
 
+       *  Otherwise, the Mail Receiver applies no DMARC processing to
+          this message.
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 28]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-5.7.3.  Policy Discovery
-
-   As stated above, the DMARC mechanism uses DNS TXT records to
-   advertise policy.  Policy discovery is accomplished via a method
-   similar to the method used for SPF records.  This method, and the
-   important differences between DMARC and SPF mechanisms, are discussed
-   below.
-
-   To balance the conflicting requirements of supporting wildcarding and
-   allowing subdomain policy overrides, the following DNS lookup scheme
-   is employed:
-
-   1.   Mail Receivers MUST query the DNS for a DMARC TXT record at the
-        DNS domain matching the one found in the RFC5322.From domain in
-        the message.  A possibly empty set of records is returned.
-
-   2.   Records that do not start with a "v=" tag that identifies the
-        current version of DMARC are discarded.
-
-   3.   If the set is now empty, the Mail Receiver determines the target
-        for additional queries, using steps 4 through 8 below.
-
-   4.   Break the subject DNS domain name into a set of "n" ordered
-        labels.  Number these lables from right to left; e.g., for
-        "example.com", "com" would be label 1 and "example" would be
-        label 2.
-
-   5.   Count the number of labels found in the subject DNS domain.  Let
-        that number be "x".  If x < 5, remove the left-most (highest-
-        numbered) label from the subject domain.  If x >= 5, remove the
-        left-most (highest-numbered) labels from the subject domain
-        until 4 labels remain.  The resulting DNS domain name is the new
-        target for subsequent lookups.
-
-   6.   The Mail Receiver MUST query the DNS for a DMARC TXT record at
-        the DNS domain matching this new target in place of the
-        RFC5322.From domain in the message.  This record can contain
-        policy to be asserted for subdomains of the target.  A possibly
-        empty set of records is returned.
-
-   7.   Records that do not start with a "v=" tag that identifies the
-        current version of DMARC are discarded.
-
-   8.   If the set is now empty, the Mail Receiver determines the target
-        for additional queries by removing a single label from the
-        target domain as described in step 5 and repeating steps 6 and 7
-        until there are no more labels remaining.
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 29]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-   9.   If the remaining set contains multiple records or no records,
-        policy discovery terminates and DMARC processing is not applied
-        to this message.
-
-   10.  If a retrieved policy record does not contain a valid "p" tag,
-        or contains an "sp" tag that is not valid, then:
-
-        1.  if a "rua" tag is present and contains at least one
-            syntactically valid reporting URI, the Mail Receiver SHOULD
-            act as if a record containing a valid "v" tag and "p=none"
-            was retrieved, and continue processing;
-
-        2.  otherwise, the Mail Receiver applies no DMARC processing to
-            this message.
-
-   If the set produced by the mechanism above contains no DMARC policy
+   If the set produced by the DNS Tree Walk contains no DMARC policy
    record (i.e., any indication that there is no such record as opposed
    to a transient DNS error), Mail Receivers SHOULD NOT apply the DMARC
    mechanism to the message.
@@ -1656,14 +1675,13 @@ Internet-Draft                  DMARCbis                   November 2021
    cleared, allowing a definite DMARC conclusion to be reached ("fail
    closed").
 
-5.7.3.1.  Longest PSD Example
 
-   As an example of step 5 above, for a message with the Organizational
-   Domain of "example.compute.cloudcompany.com.example", the query for
-   PSD DMARC would use "compute.cloudcompany.com.example" as the longest
-   PSD.  The receiver would check to see if that PSD is listed in the
-   DMARC PSD Registry, and if so, perform the policy lookup at
-   "_dmarc.compute.cloudcompany.com.example".
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 30]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    Note: Because the PSD policy query comes after the Organizational
    Domain policy query, PSD policy is not used for Organizational
@@ -1671,26 +1689,14 @@ Internet-Draft                  DMARCbis                   November 2021
    not a mechanism to provide feedback addresses (RUA/RUF) when an
    Organizational Domain has declined to do so.
 
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 30]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-5.7.4.  Store Results of DMARC Processing
+5.7.3.  Store Results of DMARC Processing
 
    The results of Mail Receiver-based DMARC processing should be stored
    for eventual presentation back to the Domain Owner in the form of
    aggregate feedback reports.  Section 5.3 and
    [DMARC-Aggregate-Reporting] discuss aggregate feedback.
 
-5.7.5.  Send Aggregate Reports
+5.7.4.  Send Aggregate Reports
 
    For a Domain Owner, DMARC aggregate reports provide data about all
    mailstreams making use of its domain in email, to include not only
@@ -1706,7 +1712,7 @@ Internet-Draft                  DMARCbis                   November 2021
    'none' cannot.
 
    In order to ensure maximum usefulness for DMARC across the email
-   ecosystem, then, Mail Receivers MUST generate and send aggregate
+   ecosystem, then, Mail Receivers SHOULD generate and send aggregate
    reports with a frequency of at least once every 24 hours.
 
 5.8.  Policy Enforcement Considerations
@@ -1725,19 +1731,17 @@ Internet-Draft                  DMARCbis                   November 2021
    increase the likelihood of accepting abusive mail if they choose not
    to honor the published Domain Owner Assessment Policy.  At a minimum,
    addition of the Authentication-Results header field (see [RFC8601])
-   is RECOMMENDED when delivery of failing mail is done.  When this is
-   done, the DNS domain name thus recorded MUST be encoded as an
-   A-label.
 
 
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 31]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 31]
 
 Internet-Draft                  DMARCbis                   November 2021
 
+
+   is RECOMMENDED when delivery of failing mail is done.  When this is
+   done, the DNS domain name thus recorded MUST be encoded as an
+   A-label.
 
    Mail Receivers are only obligated to report reject or quarantine
    policy actions in aggregate feedback reports that are due to
@@ -1786,11 +1790,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 32]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 32]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1846,7 +1846,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 33]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 33]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1887,13 +1887,14 @@ Internet-Draft                  DMARCbis                   November 2021
    In the latter case, when doing an SMTP rejection, providing a clear
    hint can be useful in resolving issues.  A receiver might indicate in
    plain text the reason for the rejection by using the word "DMARC"
-   somewhere in the reply text.  Many systems are able to scan the SMTP
-   reply text to determine the nature of the rejection.  Thus, providing
-   a machine-detectable reason for rejection allows the problems causing
-   rejections to be properly addressed by automated systems.  For
-   example:
+   somewhere in the reply text.  For example:
 
    550 5.7.1 Email rejected per DMARC policy for example.com
+
+   Many systems are able to scan the SMTP reply text to determine the
+   nature of the rejection.  Thus, providing a machine-detectable reason
+   for rejection allows the problems causing rejections to be properly
+   addressed by automated systems.
 
    If a Mail Receiver elects to defer delivery due to inability to
    retrieve or apply DMARC policy, this is best done with a 4xy SMTP
@@ -1901,8 +1902,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 34]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 34]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1958,7 +1958,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 35]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 35]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2014,7 +2014,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 36]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 36]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2070,7 +2070,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 37]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 37]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2126,44 +2126,53 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 38]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 38]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-   +----------+-----------+----------+------------------------------+
-   | Tag Name | Reference | Status   | Description                  |
-   +==========+===========+==========+==============================+
-   | adkim    | RFC 7489  | current  | DKIM alignment mode          |
-   +----------+-----------+----------+------------------------------+
-   | aspf     | RFC 7489  | current  | SPF alignment mode           |
-   +----------+-----------+----------+------------------------------+
-   | fo       | RFC 7489  | current  | Failure reporting options    |
-   +----------+-----------+----------+------------------------------+
-   | p        | RFC 7489  | current  | Requested handling policy    |
-   +----------+-----------+----------+------------------------------+
-   | pct      | RFC 7489  | historic | Sampling rate                |
-   +----------+-----------+----------+------------------------------+
-   | rf       | RFC 7489  | historic | Failure reporting format(s)  |
-   +----------+-----------+----------+------------------------------+
-   | ri       | RFC 7489  | historic | Aggregate Reporting interval |
-   +----------+-----------+----------+------------------------------+
-   | rua      | RFC 7489  | current  | Reporting URI(s) for         |
-   |          |           |          | aggregate data               |
-   +----------+-----------+----------+------------------------------+
-   | ruf      | RFC 7489  | current  | Reporting URI(s) for failure |
-   |          |           |          | data                         |
-   +----------+-----------+----------+------------------------------+
-   | sp       | RFC 7489  | current  | Requested handling policy    |
-   |          |           |          | for subdomains               |
-   +----------+-----------+----------+------------------------------+
-   | t        | RFC 7489  | current  | Test mode for the specified  |
-   |          |           |          | policy                       |
-   +----------+-----------+----------+------------------------------+
-   | v        | RFC 7489  | current  | Specification version        |
-   +----------+-----------+----------+------------------------------+
+   +-------+-----------+----------+-----------------------------+
+   | Tag   | Reference | Status   | Description                 |
+   | Name  |           |          |                             |
+   +=======+===========+==========+=============================+
+   | adkim | RFC 7489  | current  | DKIM alignment mode         |
+   +-------+-----------+----------+-----------------------------+
+   | aspf  | RFC 7489  | current  | SPF alignment mode          |
+   +-------+-----------+----------+-----------------------------+
+   | fo    | RFC 7489  | current  | Failure reporting options   |
+   +-------+-----------+----------+-----------------------------+
+   | np    | RFC 7489  | current  | Requested handling policy   |
+   |       |           |          | for non-existent subdomains |
+   +-------+-----------+----------+-----------------------------+
+   | p     | RFC 7489  | current  | Requested handling policy   |
+   +-------+-----------+----------+-----------------------------+
+   | pct   | RFC 7489  | historic | Sampling rate               |
+   +-------+-----------+----------+-----------------------------+
+   | psd   | RFC 7489  | current  | Indicates whether policy    |
+   |       |           |          | record is published by a    |
+   |       |           |          | Public Suffix Domain        |
+   +-------+-----------+----------+-----------------------------+
+   | rf    | RFC 7489  | historic | Failure reporting format(s) |
+   +-------+-----------+----------+-----------------------------+
+   | ri    | RFC 7489  | historic | Aggregate Reporting         |
+   |       |           |          | interval                    |
+   +-------+-----------+----------+-----------------------------+
+   | rua   | RFC 7489  | current  | Reporting URI(s) for        |
+   |       |           |          | aggregate data              |
+   +-------+-----------+----------+-----------------------------+
+   | ruf   | RFC 7489  | current  | Reporting URI(s) for        |
+   |       |           |          | failure data                |
+   +-------+-----------+----------+-----------------------------+
+   | sp    | RFC 7489  | current  | Requested handling policy   |
+   |       |           |          | for subdomains              |
+   +-------+-----------+----------+-----------------------------+
+   | t     | RFC 7489  | current  | Test mode for the specified |
+   |       |           |          | policy                      |
+   +-------+-----------+----------+-----------------------------+
+   | v     | RFC 7489  | current  | Specification version       |
+   +-------+-----------+----------+-----------------------------+
 
-                     Table 3: "DMARC Tag Registry"
+                   Table 3: "DMARC Tag Registry"
 
 8.5.  DMARC Report Format Registry
 
@@ -2173,16 +2182,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 39]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 39]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2238,7 +2238,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 40]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 40]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2294,7 +2294,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 41]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 41]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2350,7 +2350,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 42]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 42]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2406,7 +2406,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 43]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 43]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2462,7 +2462,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 44]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 44]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2518,7 +2518,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 45]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 45]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2574,7 +2574,7 @@ Appendix A.  Technology Considerations
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 46]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 46]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2630,7 +2630,7 @@ A.2.  Method Exclusion
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 47]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 47]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2686,7 +2686,7 @@ A.4.  Domain Existence Test
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 48]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 48]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2742,7 +2742,7 @@ A.5.  Issues with ADSP in Operation
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 49]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 49]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2776,7 +2776,7 @@ A.6.  Organizational Domain Discovery Issues
    constitutes an amplified denial-of-service attack.
 
    The Organizational Domain mechanism is a necessary component to the
-   goals of DMARC.  The method described in Section 4.5 is far from
+   goals of DMARC.  The method described in Section 4.6 is far from
    perfect but serves this purpose reasonably well without adding undue
    burden or semantics to the DNS.  If a method is created to do so that
    is more reliable and secure than the use of a public suffix list,
@@ -2798,7 +2798,7 @@ A.6.1.  Public Suffix Lists
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 50]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 50]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2854,7 +2854,7 @@ A.7.  Removal of the "pct" Tag
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 51]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 51]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2910,7 +2910,7 @@ B.1.1.  SPF
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 52]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 52]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2966,7 +2966,7 @@ B.1.2.  DKIM
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 53]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 53]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3022,7 +3022,7 @@ B.2.1.  Entire Domain, Monitoring Only
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 54]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 54]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3078,7 +3078,7 @@ B.2.2.  Entire Domain, Monitoring Only, Per-Message Reports
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 55]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 55]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3134,7 +3134,7 @@ B.2.3.  Per-Message Failure Reports Directed to Third Party
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 56]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 56]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3190,7 +3190,7 @@ B.2.4.  Subdomain, Testing, and Multiple Aggregate Report URIs
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 57]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 57]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3246,7 +3246,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 58]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 58]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3302,7 +3302,7 @@ B.4.  Processing of SMTP Time
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 59]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 59]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3358,7 +3358,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 60]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 60]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3414,7 +3414,7 @@ C.1.1.  Ticket 80 - DMARCbis SHould Have Clear and Concise Defintion of
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 61]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 61]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3470,7 +3470,7 @@ C.5.2.  Ticket 3 - Two tiny nits
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 62]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 62]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3526,7 +3526,7 @@ C.7.2.  Ticket 72 - Remove absolute requirement for p= tag in DMARC
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 63]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 63]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3582,7 +3582,7 @@ C.10.2.  Ticket 52 - Remove strict alignment (and adkim and aspf tags)
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 64]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 64]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3638,7 +3638,7 @@ C.12.1.  Ticket 86 - A-R results for DMARC
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 65]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 65]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3694,7 +3694,7 @@ C.17.1.  Publication of draft-ietf-dmarc-dmarcbis-03
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 66]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 66]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3750,5 +3750,5 @@ Authors' Addresses
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 67]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 67]
 ```

--- a/draft-ietf-dmarc-dmarcbis-04.html
+++ b/draft-ietf-dmarc-dmarcbis-04.html
@@ -1113,7 +1113,7 @@ dd.break {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Herr (ed) &amp; Levine (ed)</td>
-<td class="center">Expires 22 May 2022</td>
+<td class="center">Expires 26 May 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1129,12 +1129,12 @@ dd.break {
 <a href="https://www.rfc-editor.org/rfc/rfc7489" class="eref">7489</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-11-18" class="published">18 November 2021</time>
+<time datetime="2021-11-22" class="published">22 November 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-05-22">22 May 2022</time></dd>
+<dd class="expires"><time datetime="2022-05-26">26 May 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1180,7 +1180,7 @@ handling choices for incoming mail.<a href="#section-abstract-2" class="pilcrow"
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 22 May 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 26 May 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1276,438 +1276,435 @@ handling choices for incoming mail.<a href="#section-abstract-2" class="pilcrow"
 </li>
 </ul>
 </li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.3">
-                <p id="section-toc.1-1.3.2.3.1"><a href="#section-3.3" class="xref">3.3</a>.  <a href="#name-more-on-identifier-alignmen" class="xref">More on Identifier Alignment</a><a href="#section-toc.1-1.3.2.3.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.3.2.1">
-                    <p id="section-toc.1-1.3.2.3.2.1.1"><a href="#section-3.3.1" class="xref">3.3.1</a>.  <a href="#name-dkim-authenticated-identifi" class="xref">DKIM-Authenticated Identifiers</a><a href="#section-toc.1-1.3.2.3.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.3.2.2">
-                    <p id="section-toc.1-1.3.2.3.2.2.1"><a href="#section-3.3.2" class="xref">3.3.2</a>.  <a href="#name-spf-authenticated-identifie" class="xref">SPF-Authenticated Identifiers</a><a href="#section-toc.1-1.3.2.3.2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.3.2.3">
-                    <p id="section-toc.1-1.3.2.3.2.3.1"><a href="#section-3.3.3" class="xref">3.3.3</a>.  <a href="#name-alignment-and-extension-tec" class="xref">Alignment and Extension Technologies</a><a href="#section-toc.1-1.3.2.3.2.3.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.4">
-                <p id="section-toc.1-1.3.2.4.1"><a href="#section-3.4" class="xref">3.4</a>.  <a href="#name-determining-the-organizatio" class="xref">Determining The Organizational Domain</a><a href="#section-toc.1-1.3.2.4.1" class="pilcrow">¶</a></p>
-</li>
 </ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.4">
-            <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-overview" class="xref">Overview</a><a href="#section-toc.1-1.4.1" class="pilcrow">¶</a></p>
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-overview-and-key-concepts" class="xref">Overview and Key Concepts</a><a href="#section-toc.1-1.4.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
 <li class="toc ulEmpty" id="section-toc.1-1.4.2.1">
-                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="xref">4.1</a>.  <a href="#name-authentication-mechanisms" class="xref">Authentication Mechanisms</a><a href="#section-toc.1-1.4.2.1.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="xref">4.1</a>.  <a href="#name-use-of-rfc5322from" class="xref">Use of RFC5322.From</a><a href="#section-toc.1-1.4.2.1.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.4.2.2">
-                <p id="section-toc.1-1.4.2.2.1"><a href="#section-4.2" class="xref">4.2</a>.  <a href="#name-key-concepts" class="xref">Key Concepts</a><a href="#section-toc.1-1.4.2.2.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.4.2.2.1"><a href="#section-4.2" class="xref">4.2</a>.  <a href="#name-authentication-mechanisms" class="xref">Authentication Mechanisms</a><a href="#section-toc.1-1.4.2.2.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.4.2.3">
                 <p id="section-toc.1-1.4.2.3.1"><a href="#section-4.3" class="xref">4.3</a>.  <a href="#name-flow-diagram" class="xref">Flow Diagram</a><a href="#section-toc.1-1.4.2.3.1" class="pilcrow">¶</a></p>
 </li>
+<li class="toc ulEmpty" id="section-toc.1-1.4.2.4">
+                <p id="section-toc.1-1.4.2.4.1"><a href="#section-4.4" class="xref">4.4</a>.  <a href="#name-identifier-alignment-explai" class="xref">Identifier Alignment Explained</a><a href="#section-toc.1-1.4.2.4.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.4.2.4.2.1">
+                    <p id="section-toc.1-1.4.2.4.2.1.1"><a href="#section-4.4.1" class="xref">4.4.1</a>.  <a href="#name-dkim-authenticated-identifi" class="xref">DKIM-Authenticated Identifiers</a><a href="#section-toc.1-1.4.2.4.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.4.2.4.2.2">
+                    <p id="section-toc.1-1.4.2.4.2.2.1"><a href="#section-4.4.2" class="xref">4.4.2</a>.  <a href="#name-spf-authenticated-identifie" class="xref">SPF-Authenticated Identifiers</a><a href="#section-toc.1-1.4.2.4.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.4.2.4.2.3">
+                    <p id="section-toc.1-1.4.2.4.2.3.1"><a href="#section-4.4.3" class="xref">4.4.3</a>.  <a href="#name-alignment-and-extension-tec" class="xref">Alignment and Extension Technologies</a><a href="#section-toc.1-1.4.2.4.2.3.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.4.2.5">
+                <p id="section-toc.1-1.4.2.5.1"><a href="#section-4.5" class="xref">4.5</a>.  <a href="#name-determining-the-organizatio" class="xref">Determining The Organizational Domain</a><a href="#section-toc.1-1.4.2.5.1" class="pilcrow">¶</a></p>
+</li>
 </ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.5">
-            <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-use-of-rfc5322from" class="xref">Use of RFC5322.From</a><a href="#section-toc.1-1.5.1" class="pilcrow">¶</a></p>
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-policy" class="xref">Policy</a><a href="#section-toc.1-1.5.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.1">
+                <p id="section-toc.1-1.5.2.1.1"><a href="#section-5.1" class="xref">5.1</a>.  <a href="#name-dmarc-policy-record" class="xref">DMARC Policy Record</a><a href="#section-toc.1-1.5.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.2">
+                <p id="section-toc.1-1.5.2.2.1"><a href="#section-5.2" class="xref">5.2</a>.  <a href="#name-dmarc-uris" class="xref">DMARC URIs</a><a href="#section-toc.1-1.5.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.3">
+                <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="xref">5.3</a>.  <a href="#name-general-record-format" class="xref">General Record Format</a><a href="#section-toc.1-1.5.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.4">
+                <p id="section-toc.1-1.5.2.4.1"><a href="#section-5.4" class="xref">5.4</a>.  <a href="#name-formal-definition" class="xref">Formal Definition</a><a href="#section-toc.1-1.5.2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.5">
+                <p id="section-toc.1-1.5.2.5.1"><a href="#section-5.5" class="xref">5.5</a>.  <a href="#name-domain-owner-actions" class="xref">Domain Owner Actions</a><a href="#section-toc.1-1.5.2.5.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.5.2.1">
+                    <p id="section-toc.1-1.5.2.5.2.1.1"><a href="#section-5.5.1" class="xref">5.5.1</a>.  <a href="#name-publish-an-spf-policy-for-a" class="xref">Publish an SPF Policy for an Aligned Domain</a><a href="#section-toc.1-1.5.2.5.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.5.2.2">
+                    <p id="section-toc.1-1.5.2.5.2.2.1"><a href="#section-5.5.2" class="xref">5.5.2</a>.  <a href="#name-configure-sending-system-fo" class="xref">Configure Sending System for DKIM Signing Using an Aligned Domain</a><a href="#section-toc.1-1.5.2.5.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.5.2.3">
+                    <p id="section-toc.1-1.5.2.5.2.3.1"><a href="#section-5.5.3" class="xref">5.5.3</a>.  <a href="#name-setup-a-mailbox-to-receive-" class="xref">Setup a Mailbox to Receive Aggregate Reports</a><a href="#section-toc.1-1.5.2.5.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.5.2.4">
+                    <p id="section-toc.1-1.5.2.5.2.4.1"><a href="#section-5.5.4" class="xref">5.5.4</a>.  <a href="#name-publish-a-dmarc-policy-for-" class="xref">Publish a DMARC Policy for the Author Domain</a><a href="#section-toc.1-1.5.2.5.2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.5.2.5">
+                    <p id="section-toc.1-1.5.2.5.2.5.1"><a href="#section-5.5.5" class="xref">5.5.5</a>.  <a href="#name-collect-and-analyze-reports" class="xref">Collect and Analyze Reports and Adjust Authentication</a><a href="#section-toc.1-1.5.2.5.2.5.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.5.2.6">
+                    <p id="section-toc.1-1.5.2.5.2.6.1"><a href="#section-5.5.6" class="xref">5.5.6</a>.  <a href="#name-decide-if-and-when-to-updat" class="xref">Decide If and When to Update DMARC Policy</a><a href="#section-toc.1-1.5.2.5.2.6.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.6">
+                <p id="section-toc.1-1.5.2.6.1"><a href="#section-5.6" class="xref">5.6</a>.  <a href="#name-pso-actions" class="xref">PSO Actions</a><a href="#section-toc.1-1.5.2.6.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.7">
+                <p id="section-toc.1-1.5.2.7.1"><a href="#section-5.7" class="xref">5.7</a>.  <a href="#name-mail-receiver-actions" class="xref">Mail Receiver Actions</a><a href="#section-toc.1-1.5.2.7.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.7.2.1">
+                    <p id="section-toc.1-1.5.2.7.2.1.1"><a href="#section-5.7.1" class="xref">5.7.1</a>.  <a href="#name-extract-author-domain" class="xref">Extract Author Domain</a><a href="#section-toc.1-1.5.2.7.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.7.2.2">
+                    <p id="section-toc.1-1.5.2.7.2.2.1"><a href="#section-5.7.2" class="xref">5.7.2</a>.  <a href="#name-determine-handling-policy" class="xref">Determine Handling Policy</a><a href="#section-toc.1-1.5.2.7.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.7.2.3">
+                    <p id="section-toc.1-1.5.2.7.2.3.1"><a href="#section-5.7.3" class="xref">5.7.3</a>.  <a href="#name-policy-discovery" class="xref">Policy Discovery</a><a href="#section-toc.1-1.5.2.7.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.7.2.4">
+                    <p id="section-toc.1-1.5.2.7.2.4.1"><a href="#section-5.7.4" class="xref">5.7.4</a>.  <a href="#name-store-results-of-dmarc-proc" class="xref">Store Results of DMARC Processing</a><a href="#section-toc.1-1.5.2.7.2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.7.2.5">
+                    <p id="section-toc.1-1.5.2.7.2.5.1"><a href="#section-5.7.5" class="xref">5.7.5</a>.  <a href="#name-send-aggregate-reports" class="xref">Send Aggregate Reports</a><a href="#section-toc.1-1.5.2.7.2.5.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.5.2.8">
+                <p id="section-toc.1-1.5.2.8.1"><a href="#section-5.8" class="xref">5.8</a>.  <a href="#name-policy-enforcement-consider" class="xref">Policy Enforcement Considerations</a><a href="#section-toc.1-1.5.2.8.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.6">
-            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-policy" class="xref">Policy</a><a href="#section-toc.1-1.6.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.1">
-                <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="xref">6.1</a>.  <a href="#name-dmarc-policy-record" class="xref">DMARC Policy Record</a><a href="#section-toc.1-1.6.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.2">
-                <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="xref">6.2</a>.  <a href="#name-dmarc-uris" class="xref">DMARC URIs</a><a href="#section-toc.1-1.6.2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.3">
-                <p id="section-toc.1-1.6.2.3.1"><a href="#section-6.3" class="xref">6.3</a>.  <a href="#name-general-record-format" class="xref">General Record Format</a><a href="#section-toc.1-1.6.2.3.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.4">
-                <p id="section-toc.1-1.6.2.4.1"><a href="#section-6.4" class="xref">6.4</a>.  <a href="#name-formal-definition" class="xref">Formal Definition</a><a href="#section-toc.1-1.6.2.4.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.5">
-                <p id="section-toc.1-1.6.2.5.1"><a href="#section-6.5" class="xref">6.5</a>.  <a href="#name-domain-owner-actions" class="xref">Domain Owner Actions</a><a href="#section-toc.1-1.6.2.5.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.5.2.1">
-                    <p id="section-toc.1-1.6.2.5.2.1.1"><a href="#section-6.5.1" class="xref">6.5.1</a>.  <a href="#name-publish-an-spf-policy-for-a" class="xref">Publish an SPF Policy for an Aligned Domain</a><a href="#section-toc.1-1.6.2.5.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.5.2.2">
-                    <p id="section-toc.1-1.6.2.5.2.2.1"><a href="#section-6.5.2" class="xref">6.5.2</a>.  <a href="#name-configure-sending-system-fo" class="xref">Configure Sending System for DKIM Signing Using an Aligned Domain</a><a href="#section-toc.1-1.6.2.5.2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.5.2.3">
-                    <p id="section-toc.1-1.6.2.5.2.3.1"><a href="#section-6.5.3" class="xref">6.5.3</a>.  <a href="#name-setup-a-mailbox-to-receive-" class="xref">Setup a Mailbox to Receive Aggregate Reports</a><a href="#section-toc.1-1.6.2.5.2.3.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.5.2.4">
-                    <p id="section-toc.1-1.6.2.5.2.4.1"><a href="#section-6.5.4" class="xref">6.5.4</a>.  <a href="#name-publish-a-dmarc-policy-for-" class="xref">Publish a DMARC Policy for the Author Domain</a><a href="#section-toc.1-1.6.2.5.2.4.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.5.2.5">
-                    <p id="section-toc.1-1.6.2.5.2.5.1"><a href="#section-6.5.5" class="xref">6.5.5</a>.  <a href="#name-collect-and-analyze-reports" class="xref">Collect and Analyze Reports and Adjust Authentication</a><a href="#section-toc.1-1.6.2.5.2.5.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.5.2.6">
-                    <p id="section-toc.1-1.6.2.5.2.6.1"><a href="#section-6.5.6" class="xref">6.5.6</a>.  <a href="#name-decide-if-and-when-to-updat" class="xref">Decide If and When to Update DMARC Policy</a><a href="#section-toc.1-1.6.2.5.2.6.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.6">
-                <p id="section-toc.1-1.6.2.6.1"><a href="#section-6.6" class="xref">6.6</a>.  <a href="#name-pso-actions" class="xref">PSO Actions</a><a href="#section-toc.1-1.6.2.6.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.7">
-                <p id="section-toc.1-1.6.2.7.1"><a href="#section-6.7" class="xref">6.7</a>.  <a href="#name-mail-receiver-actions" class="xref">Mail Receiver Actions</a><a href="#section-toc.1-1.6.2.7.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.7.2.1">
-                    <p id="section-toc.1-1.6.2.7.2.1.1"><a href="#section-6.7.1" class="xref">6.7.1</a>.  <a href="#name-extract-author-domain" class="xref">Extract Author Domain</a><a href="#section-toc.1-1.6.2.7.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.7.2.2">
-                    <p id="section-toc.1-1.6.2.7.2.2.1"><a href="#section-6.7.2" class="xref">6.7.2</a>.  <a href="#name-determine-handling-policy" class="xref">Determine Handling Policy</a><a href="#section-toc.1-1.6.2.7.2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.7.2.3">
-                    <p id="section-toc.1-1.6.2.7.2.3.1"><a href="#section-6.7.3" class="xref">6.7.3</a>.  <a href="#name-policy-discovery" class="xref">Policy Discovery</a><a href="#section-toc.1-1.6.2.7.2.3.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.7.2.4">
-                    <p id="section-toc.1-1.6.2.7.2.4.1"><a href="#section-6.7.4" class="xref">6.7.4</a>.  <a href="#name-store-results-of-dmarc-proc" class="xref">Store Results of DMARC Processing</a><a href="#section-toc.1-1.6.2.7.2.4.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.7.2.5">
-                    <p id="section-toc.1-1.6.2.7.2.5.1"><a href="#section-6.7.5" class="xref">6.7.5</a>.  <a href="#name-send-aggregate-reports" class="xref">Send Aggregate Reports</a><a href="#section-toc.1-1.6.2.7.2.5.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.6.2.8">
-                <p id="section-toc.1-1.6.2.8.1"><a href="#section-6.8" class="xref">6.8</a>.  <a href="#name-policy-enforcement-consider" class="xref">Policy Enforcement Considerations</a><a href="#section-toc.1-1.6.2.8.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-dmarc-feedback" class="xref">DMARC Feedback</a><a href="#section-toc.1-1.6.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.7">
-            <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-dmarc-feedback" class="xref">DMARC Feedback</a><a href="#section-toc.1-1.7.1" class="pilcrow">¶</a></p>
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-other-topics" class="xref">Other Topics</a><a href="#section-toc.1-1.7.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.7.2.1">
+                <p id="section-toc.1-1.7.2.1.1"><a href="#section-7.1" class="xref">7.1</a>.  <a href="#name-issues-specific-to-spf" class="xref">Issues Specific to SPF</a><a href="#section-toc.1-1.7.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.7.2.2">
+                <p id="section-toc.1-1.7.2.2.1"><a href="#section-7.2" class="xref">7.2</a>.  <a href="#name-dns-load-and-caching" class="xref">DNS Load and Caching</a><a href="#section-toc.1-1.7.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.7.2.3">
+                <p id="section-toc.1-1.7.2.3.1"><a href="#section-7.3" class="xref">7.3</a>.  <a href="#name-rejecting-messages" class="xref">Rejecting Messages</a><a href="#section-toc.1-1.7.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.7.2.4">
+                <p id="section-toc.1-1.7.2.4.1"><a href="#section-7.4" class="xref">7.4</a>.  <a href="#name-identifier-alignment-consid" class="xref">Identifier Alignment Considerations</a><a href="#section-toc.1-1.7.2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.7.2.5">
+                <p id="section-toc.1-1.7.2.5.1"><a href="#section-7.5" class="xref">7.5</a>.  <a href="#name-interoperability-issues" class="xref">Interoperability Issues</a><a href="#section-toc.1-1.7.2.5.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-other-topics" class="xref">Other Topics</a><a href="#section-toc.1-1.8.1" class="pilcrow">¶</a></p>
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-iana-considerations" class="xref">IANA Considerations</a><a href="#section-toc.1-1.8.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
 <li class="toc ulEmpty" id="section-toc.1-1.8.2.1">
-                <p id="section-toc.1-1.8.2.1.1"><a href="#section-8.1" class="xref">8.1</a>.  <a href="#name-issues-specific-to-spf" class="xref">Issues Specific to SPF</a><a href="#section-toc.1-1.8.2.1.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.8.2.1.1"><a href="#section-8.1" class="xref">8.1</a>.  <a href="#name-authentication-results-meth" class="xref">Authentication-Results Method Registry Update</a><a href="#section-toc.1-1.8.2.1.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.8.2.2">
-                <p id="section-toc.1-1.8.2.2.1"><a href="#section-8.2" class="xref">8.2</a>.  <a href="#name-dns-load-and-caching" class="xref">DNS Load and Caching</a><a href="#section-toc.1-1.8.2.2.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.8.2.2.1"><a href="#section-8.2" class="xref">8.2</a>.  <a href="#name-authentication-results-resu" class="xref">Authentication-Results Result Registry Update</a><a href="#section-toc.1-1.8.2.2.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.8.2.3">
-                <p id="section-toc.1-1.8.2.3.1"><a href="#section-8.3" class="xref">8.3</a>.  <a href="#name-rejecting-messages" class="xref">Rejecting Messages</a><a href="#section-toc.1-1.8.2.3.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.8.2.3.1"><a href="#section-8.3" class="xref">8.3</a>.  <a href="#name-feedback-report-header-fiel" class="xref">Feedback Report Header Fields Registry Update</a><a href="#section-toc.1-1.8.2.3.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.8.2.4">
-                <p id="section-toc.1-1.8.2.4.1"><a href="#section-8.4" class="xref">8.4</a>.  <a href="#name-identifier-alignment-consid" class="xref">Identifier Alignment Considerations</a><a href="#section-toc.1-1.8.2.4.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.8.2.4.1"><a href="#section-8.4" class="xref">8.4</a>.  <a href="#name-dmarc-tag-registry" class="xref">DMARC Tag Registry</a><a href="#section-toc.1-1.8.2.4.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.8.2.5">
-                <p id="section-toc.1-1.8.2.5.1"><a href="#section-8.5" class="xref">8.5</a>.  <a href="#name-interoperability-issues" class="xref">Interoperability Issues</a><a href="#section-toc.1-1.8.2.5.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.8.2.5.1"><a href="#section-8.5" class="xref">8.5</a>.  <a href="#name-dmarc-report-format-registr" class="xref">DMARC Report Format Registry</a><a href="#section-toc.1-1.8.2.5.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.8.2.6">
+                <p id="section-toc.1-1.8.2.6.1"><a href="#section-8.6" class="xref">8.6</a>.  <a href="#name-underscored-and-globally-sc" class="xref">Underscored and Globally Scoped DNS Node Names Registry</a><a href="#section-toc.1-1.8.2.6.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.9">
-            <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-iana-considerations" class="xref">IANA Considerations</a><a href="#section-toc.1-1.9.1" class="pilcrow">¶</a></p>
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-security-considerations" class="xref">Security Considerations</a><a href="#section-toc.1-1.9.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
 <li class="toc ulEmpty" id="section-toc.1-1.9.2.1">
-                <p id="section-toc.1-1.9.2.1.1"><a href="#section-9.1" class="xref">9.1</a>.  <a href="#name-authentication-results-meth" class="xref">Authentication-Results Method Registry Update</a><a href="#section-toc.1-1.9.2.1.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.9.2.1.1"><a href="#section-9.1" class="xref">9.1</a>.  <a href="#name-authentication-methods" class="xref">Authentication Methods</a><a href="#section-toc.1-1.9.2.1.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.9.2.2">
-                <p id="section-toc.1-1.9.2.2.1"><a href="#section-9.2" class="xref">9.2</a>.  <a href="#name-authentication-results-resu" class="xref">Authentication-Results Result Registry Update</a><a href="#section-toc.1-1.9.2.2.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.9.2.2.1"><a href="#section-9.2" class="xref">9.2</a>.  <a href="#name-attacks-on-reporting-uris" class="xref">Attacks on Reporting URIs</a><a href="#section-toc.1-1.9.2.2.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.9.2.3">
-                <p id="section-toc.1-1.9.2.3.1"><a href="#section-9.3" class="xref">9.3</a>.  <a href="#name-feedback-report-header-fiel" class="xref">Feedback Report Header Fields Registry Update</a><a href="#section-toc.1-1.9.2.3.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.9.2.3.1"><a href="#section-9.3" class="xref">9.3</a>.  <a href="#name-dns-security" class="xref">DNS Security</a><a href="#section-toc.1-1.9.2.3.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.9.2.4">
-                <p id="section-toc.1-1.9.2.4.1"><a href="#section-9.4" class="xref">9.4</a>.  <a href="#name-dmarc-tag-registry" class="xref">DMARC Tag Registry</a><a href="#section-toc.1-1.9.2.4.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.9.2.4.1"><a href="#section-9.4" class="xref">9.4</a>.  <a href="#name-display-name-attacks" class="xref">Display Name Attacks</a><a href="#section-toc.1-1.9.2.4.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.9.2.5">
-                <p id="section-toc.1-1.9.2.5.1"><a href="#section-9.5" class="xref">9.5</a>.  <a href="#name-dmarc-report-format-registr" class="xref">DMARC Report Format Registry</a><a href="#section-toc.1-1.9.2.5.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.9.2.5.1"><a href="#section-9.5" class="xref">9.5</a>.  <a href="#name-external-reporting-addresse" class="xref">External Reporting Addresses</a><a href="#section-toc.1-1.9.2.5.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.9.2.6">
-                <p id="section-toc.1-1.9.2.6.1"><a href="#section-9.6" class="xref">9.6</a>.  <a href="#name-underscored-and-globally-sc" class="xref">Underscored and Globally Scoped DNS Node Names Registry</a><a href="#section-toc.1-1.9.2.6.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.9.2.6.1"><a href="#section-9.6" class="xref">9.6</a>.  <a href="#name-secure-protocols" class="xref">Secure Protocols</a><a href="#section-toc.1-1.9.2.6.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.10">
-            <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-security-considerations" class="xref">Security Considerations</a><a href="#section-toc.1-1.10.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.10.2.1">
-                <p id="section-toc.1-1.10.2.1.1"><a href="#section-10.1" class="xref">10.1</a>.  <a href="#name-authentication-methods" class="xref">Authentication Methods</a><a href="#section-toc.1-1.10.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.10.2.2">
-                <p id="section-toc.1-1.10.2.2.1"><a href="#section-10.2" class="xref">10.2</a>.  <a href="#name-attacks-on-reporting-uris" class="xref">Attacks on Reporting URIs</a><a href="#section-toc.1-1.10.2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.10.2.3">
-                <p id="section-toc.1-1.10.2.3.1"><a href="#section-10.3" class="xref">10.3</a>.  <a href="#name-dns-security" class="xref">DNS Security</a><a href="#section-toc.1-1.10.2.3.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.10.2.4">
-                <p id="section-toc.1-1.10.2.4.1"><a href="#section-10.4" class="xref">10.4</a>.  <a href="#name-display-name-attacks" class="xref">Display Name Attacks</a><a href="#section-toc.1-1.10.2.4.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.10.2.5">
-                <p id="section-toc.1-1.10.2.5.1"><a href="#section-10.5" class="xref">10.5</a>.  <a href="#name-external-reporting-addresse" class="xref">External Reporting Addresses</a><a href="#section-toc.1-1.10.2.5.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.10.2.6">
-                <p id="section-toc.1-1.10.2.6.1"><a href="#section-10.6" class="xref">10.6</a>.  <a href="#name-secure-protocols" class="xref">Secure Protocols</a><a href="#section-toc.1-1.10.2.6.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
+            <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-normative-references" class="xref">Normative References</a><a href="#section-toc.1-1.10.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.11">
-            <p id="section-toc.1-1.11.1"><a href="#section-11" class="xref">11</a>. <a href="#name-normative-references" class="xref">Normative References</a><a href="#section-toc.1-1.11.1" class="pilcrow">¶</a></p>
+            <p id="section-toc.1-1.11.1"><a href="#section-11" class="xref">11</a>. <a href="#name-informative-references" class="xref">Informative References</a><a href="#section-toc.1-1.11.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.12">
-            <p id="section-toc.1-1.12.1"><a href="#section-12" class="xref">12</a>. <a href="#name-informative-references" class="xref">Informative References</a><a href="#section-toc.1-1.12.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.13">
-            <p id="section-toc.1-1.13.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-technology-considerations" class="xref">Technology Considerations</a><a href="#section-toc.1-1.13.1" class="pilcrow">¶</a></p>
+            <p id="section-toc.1-1.12.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-technology-considerations" class="xref">Technology Considerations</a><a href="#section-toc.1-1.12.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.13.2.1">
-                <p id="section-toc.1-1.13.2.1.1"><a href="#section-a.1" class="xref">A.1</a>.  <a href="#name-s-mime" class="xref">S/MIME</a><a href="#section-toc.1-1.13.2.1.1" class="pilcrow">¶</a></p>
+<li class="toc ulEmpty" id="section-toc.1-1.12.2.1">
+                <p id="section-toc.1-1.12.2.1.1"><a href="#section-a.1" class="xref">A.1</a>.  <a href="#name-s-mime" class="xref">S/MIME</a><a href="#section-toc.1-1.12.2.1.1" class="pilcrow">¶</a></p>
 </li>
-<li class="toc ulEmpty" id="section-toc.1-1.13.2.2">
-                <p id="section-toc.1-1.13.2.2.1"><a href="#section-a.2" class="xref">A.2</a>.  <a href="#name-method-exclusion" class="xref">Method Exclusion</a><a href="#section-toc.1-1.13.2.2.1" class="pilcrow">¶</a></p>
+<li class="toc ulEmpty" id="section-toc.1-1.12.2.2">
+                <p id="section-toc.1-1.12.2.2.1"><a href="#section-a.2" class="xref">A.2</a>.  <a href="#name-method-exclusion" class="xref">Method Exclusion</a><a href="#section-toc.1-1.12.2.2.1" class="pilcrow">¶</a></p>
 </li>
-<li class="toc ulEmpty" id="section-toc.1-1.13.2.3">
-                <p id="section-toc.1-1.13.2.3.1"><a href="#section-a.3" class="xref">A.3</a>.  <a href="#name-sender-header-field" class="xref">Sender Header Field</a><a href="#section-toc.1-1.13.2.3.1" class="pilcrow">¶</a></p>
+<li class="toc ulEmpty" id="section-toc.1-1.12.2.3">
+                <p id="section-toc.1-1.12.2.3.1"><a href="#section-a.3" class="xref">A.3</a>.  <a href="#name-sender-header-field" class="xref">Sender Header Field</a><a href="#section-toc.1-1.12.2.3.1" class="pilcrow">¶</a></p>
 </li>
-<li class="toc ulEmpty" id="section-toc.1-1.13.2.4">
-                <p id="section-toc.1-1.13.2.4.1"><a href="#section-a.4" class="xref">A.4</a>.  <a href="#name-domain-existence-test" class="xref">Domain Existence Test</a><a href="#section-toc.1-1.13.2.4.1" class="pilcrow">¶</a></p>
+<li class="toc ulEmpty" id="section-toc.1-1.12.2.4">
+                <p id="section-toc.1-1.12.2.4.1"><a href="#section-a.4" class="xref">A.4</a>.  <a href="#name-domain-existence-test" class="xref">Domain Existence Test</a><a href="#section-toc.1-1.12.2.4.1" class="pilcrow">¶</a></p>
 </li>
-<li class="toc ulEmpty" id="section-toc.1-1.13.2.5">
-                <p id="section-toc.1-1.13.2.5.1"><a href="#section-a.5" class="xref">A.5</a>.  <a href="#name-issues-with-adsp-in-operati" class="xref">Issues with ADSP in Operation</a><a href="#section-toc.1-1.13.2.5.1" class="pilcrow">¶</a></p>
+<li class="toc ulEmpty" id="section-toc.1-1.12.2.5">
+                <p id="section-toc.1-1.12.2.5.1"><a href="#section-a.5" class="xref">A.5</a>.  <a href="#name-issues-with-adsp-in-operati" class="xref">Issues with ADSP in Operation</a><a href="#section-toc.1-1.12.2.5.1" class="pilcrow">¶</a></p>
 </li>
-<li class="toc ulEmpty" id="section-toc.1-1.13.2.6">
-                <p id="section-toc.1-1.13.2.6.1"><a href="#section-a.6" class="xref">A.6</a>.  <a href="#name-organizational-domain-disco" class="xref">Organizational Domain Discovery Issues</a><a href="#section-toc.1-1.13.2.6.1" class="pilcrow">¶</a></p>
+<li class="toc ulEmpty" id="section-toc.1-1.12.2.6">
+                <p id="section-toc.1-1.12.2.6.1"><a href="#section-a.6" class="xref">A.6</a>.  <a href="#name-organizational-domain-disco" class="xref">Organizational Domain Discovery Issues</a><a href="#section-toc.1-1.12.2.6.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.13.2.6.2.1">
-                    <p id="section-toc.1-1.13.2.6.2.1.1"><a href="#section-a.6.1" class="xref">A.6.1</a>.  <a href="#name-public-suffix-lists" class="xref">Public Suffix Lists</a><a href="#section-toc.1-1.13.2.6.2.1.1" class="pilcrow">¶</a></p>
+<li class="toc ulEmpty" id="section-toc.1-1.12.2.6.2.1">
+                    <p id="section-toc.1-1.12.2.6.2.1.1"><a href="#section-a.6.1" class="xref">A.6.1</a>.  <a href="#name-public-suffix-lists" class="xref">Public Suffix Lists</a><a href="#section-toc.1-1.12.2.6.2.1.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
-<li class="toc ulEmpty" id="section-toc.1-1.13.2.7">
-                <p id="section-toc.1-1.13.2.7.1"><a href="#section-a.7" class="xref">A.7</a>.  <a href="#name-removal-of-the-pct-tag" class="xref">Removal of the "pct" Tag</a><a href="#section-toc.1-1.13.2.7.1" class="pilcrow">¶</a></p>
+<li class="toc ulEmpty" id="section-toc.1-1.12.2.7">
+                <p id="section-toc.1-1.12.2.7.1"><a href="#section-a.7" class="xref">A.7</a>.  <a href="#name-removal-of-the-pct-tag" class="xref">Removal of the "pct" Tag</a><a href="#section-toc.1-1.12.2.7.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.13">
+            <p id="section-toc.1-1.13.1"><a href="#section-appendix.b" class="xref">Appendix B</a>.  <a href="#name-examples" class="xref">Examples</a><a href="#section-toc.1-1.13.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.1">
+                <p id="section-toc.1-1.13.2.1.1"><a href="#section-b.1" class="xref">B.1</a>.  <a href="#name-identifier-alignment-exampl" class="xref">Identifier Alignment Examples</a><a href="#section-toc.1-1.13.2.1.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.1.2.1">
+                    <p id="section-toc.1-1.13.2.1.2.1.1"><a href="#section-b.1.1" class="xref">B.1.1</a>.  <a href="#name-spf" class="xref">SPF</a><a href="#section-toc.1-1.13.2.1.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.1.2.2">
+                    <p id="section-toc.1-1.13.2.1.2.2.1"><a href="#section-b.1.2" class="xref">B.1.2</a>.  <a href="#name-dkim" class="xref">DKIM</a><a href="#section-toc.1-1.13.2.1.2.2.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.2">
+                <p id="section-toc.1-1.13.2.2.1"><a href="#section-b.2" class="xref">B.2</a>.  <a href="#name-domain-owner-example" class="xref">Domain Owner Example</a><a href="#section-toc.1-1.13.2.2.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.2.2.1">
+                    <p id="section-toc.1-1.13.2.2.2.1.1"><a href="#section-b.2.1" class="xref">B.2.1</a>.  <a href="#name-entire-domain-monitoring-on" class="xref">Entire Domain, Monitoring Only</a><a href="#section-toc.1-1.13.2.2.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.2.2.2">
+                    <p id="section-toc.1-1.13.2.2.2.2.1"><a href="#section-b.2.2" class="xref">B.2.2</a>.  <a href="#name-entire-domain-monitoring-onl" class="xref">Entire Domain, Monitoring Only, Per-Message Reports</a><a href="#section-toc.1-1.13.2.2.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.2.2.3">
+                    <p id="section-toc.1-1.13.2.2.2.3.1"><a href="#section-b.2.3" class="xref">B.2.3</a>.  <a href="#name-per-message-failure-reports" class="xref">Per-Message Failure Reports Directed to Third Party</a><a href="#section-toc.1-1.13.2.2.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.2.2.4">
+                    <p id="section-toc.1-1.13.2.2.2.4.1"><a href="#section-b.2.4" class="xref">B.2.4</a>.  <a href="#name-subdomain-testing-and-multi" class="xref">Subdomain, Testing, and Multiple Aggregate Report URIs</a><a href="#section-toc.1-1.13.2.2.2.4.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.3">
+                <p id="section-toc.1-1.13.2.3.1"><a href="#section-b.3" class="xref">B.3</a>.  <a href="#name-mail-receiver-example" class="xref">Mail Receiver Example</a><a href="#section-toc.1-1.13.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.4">
+                <p id="section-toc.1-1.13.2.4.1"><a href="#section-b.4" class="xref">B.4</a>.  <a href="#name-processing-of-smtp-time" class="xref">Processing of SMTP Time</a><a href="#section-toc.1-1.13.2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.5">
+                <p id="section-toc.1-1.13.2.5.1"><a href="#section-b.5" class="xref">B.5</a>.  <a href="#name-utilization-of-aggregate-fe" class="xref">Utilization of Aggregate Feedback: Example</a><a href="#section-toc.1-1.13.2.5.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.14">
-            <p id="section-toc.1-1.14.1"><a href="#section-appendix.b" class="xref">Appendix B</a>.  <a href="#name-examples" class="xref">Examples</a><a href="#section-toc.1-1.14.1" class="pilcrow">¶</a></p>
+            <p id="section-toc.1-1.14.1"><a href="#section-appendix.c" class="xref">Appendix C</a>.  <a href="#name-change-log" class="xref">Change Log</a><a href="#section-toc.1-1.14.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
 <li class="toc ulEmpty" id="section-toc.1-1.14.2.1">
-                <p id="section-toc.1-1.14.2.1.1"><a href="#section-b.1" class="xref">B.1</a>.  <a href="#name-identifier-alignment-exampl" class="xref">Identifier Alignment Examples</a><a href="#section-toc.1-1.14.2.1.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.14.2.1.1"><a href="#section-c.1" class="xref">C.1</a>.  <a href="#name-january-5-2021" class="xref">January 5, 2021</a><a href="#section-toc.1-1.14.2.1.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
 <li class="toc ulEmpty" id="section-toc.1-1.14.2.1.2.1">
-                    <p id="section-toc.1-1.14.2.1.2.1.1"><a href="#section-b.1.1" class="xref">B.1.1</a>.  <a href="#name-spf" class="xref">SPF</a><a href="#section-toc.1-1.14.2.1.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.1.2.2">
-                    <p id="section-toc.1-1.14.2.1.2.2.1"><a href="#section-b.1.2" class="xref">B.1.2</a>.  <a href="#name-dkim" class="xref">DKIM</a><a href="#section-toc.1-1.14.2.1.2.2.1" class="pilcrow">¶</a></p>
+                    <p id="section-toc.1-1.14.2.1.2.1.1"><a href="#section-c.1.1" class="xref">C.1.1</a>.  <a href="#name-ticket-80-dmarcbis-should-h" class="xref">Ticket 80 - DMARCbis SHould Have Clear and Concise Defintion of DMARC</a><a href="#section-toc.1-1.14.2.1.2.1.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.14.2.2">
-                <p id="section-toc.1-1.14.2.2.1"><a href="#section-b.2" class="xref">B.2</a>.  <a href="#name-domain-owner-example" class="xref">Domain Owner Example</a><a href="#section-toc.1-1.14.2.2.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.14.2.2.1"><a href="#section-c.2" class="xref">C.2</a>.  <a href="#name-february-4-2021" class="xref">February 4, 2021</a><a href="#section-toc.1-1.14.2.2.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
 <li class="toc ulEmpty" id="section-toc.1-1.14.2.2.2.1">
-                    <p id="section-toc.1-1.14.2.2.2.1.1"><a href="#section-b.2.1" class="xref">B.2.1</a>.  <a href="#name-entire-domain-monitoring-on" class="xref">Entire Domain, Monitoring Only</a><a href="#section-toc.1-1.14.2.2.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.2.2.2">
-                    <p id="section-toc.1-1.14.2.2.2.2.1"><a href="#section-b.2.2" class="xref">B.2.2</a>.  <a href="#name-entire-domain-monitoring-onl" class="xref">Entire Domain, Monitoring Only, Per-Message Reports</a><a href="#section-toc.1-1.14.2.2.2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.2.2.3">
-                    <p id="section-toc.1-1.14.2.2.2.3.1"><a href="#section-b.2.3" class="xref">B.2.3</a>.  <a href="#name-per-message-failure-reports" class="xref">Per-Message Failure Reports Directed to Third Party</a><a href="#section-toc.1-1.14.2.2.2.3.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.2.2.4">
-                    <p id="section-toc.1-1.14.2.2.2.4.1"><a href="#section-b.2.4" class="xref">B.2.4</a>.  <a href="#name-subdomain-testing-and-multi" class="xref">Subdomain, Testing, and Multiple Aggregate Report URIs</a><a href="#section-toc.1-1.14.2.2.2.4.1" class="pilcrow">¶</a></p>
+                    <p id="section-toc.1-1.14.2.2.2.1.1"><a href="#section-c.2.1" class="xref">C.2.1</a>.  <a href="#name-ticket-1-spf-rfc-4408-vs-72" class="xref">Ticket 1 - SPF RFC 4408 vs 7208</a><a href="#section-toc.1-1.14.2.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.14.2.3">
-                <p id="section-toc.1-1.14.2.3.1"><a href="#section-b.3" class="xref">B.3</a>.  <a href="#name-mail-receiver-example" class="xref">Mail Receiver Example</a><a href="#section-toc.1-1.14.2.3.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.14.2.3.1"><a href="#section-c.3" class="xref">C.3</a>.  <a href="#name-february-10-2021" class="xref">February 10, 2021</a><a href="#section-toc.1-1.14.2.3.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.3.2.1">
+                    <p id="section-toc.1-1.14.2.3.2.1.1"><a href="#section-c.3.1" class="xref">C.3.1</a>.  <a href="#name-ticket-84-remove-erroneous-" class="xref">Ticket 84 - Remove Erroneous References to RFC3986</a><a href="#section-toc.1-1.14.2.3.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.14.2.4">
-                <p id="section-toc.1-1.14.2.4.1"><a href="#section-b.4" class="xref">B.4</a>.  <a href="#name-processing-of-smtp-time" class="xref">Processing of SMTP Time</a><a href="#section-toc.1-1.14.2.4.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.14.2.4.1"><a href="#section-c.4" class="xref">C.4</a>.  <a href="#name-march-1-2021" class="xref">March 1, 2021</a><a href="#section-toc.1-1.14.2.4.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.4.2.1">
+                    <p id="section-toc.1-1.14.2.4.2.1.1"><a href="#section-c.4.1" class="xref">C.4.1</a>.  <a href="#name-design-team-work-begins" class="xref">Design Team Work Begins</a><a href="#section-toc.1-1.14.2.4.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.14.2.5">
-                <p id="section-toc.1-1.14.2.5.1"><a href="#section-b.5" class="xref">B.5</a>.  <a href="#name-utilization-of-aggregate-fe" class="xref">Utilization of Aggregate Feedback: Example</a><a href="#section-toc.1-1.14.2.5.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.14.2.5.1"><a href="#section-c.5" class="xref">C.5</a>.  <a href="#name-march-8-2021" class="xref">March 8, 2021</a><a href="#section-toc.1-1.14.2.5.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.5.2.1">
+                    <p id="section-toc.1-1.14.2.5.2.1.1"><a href="#section-c.5.1" class="xref">C.5.1</a>.  <a href="#name-removed-e-gustafsson-as-edi" class="xref">Removed E. Gustafsson as editor</a><a href="#section-toc.1-1.14.2.5.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.5.2.2">
+                    <p id="section-toc.1-1.14.2.5.2.2.1"><a href="#section-c.5.2" class="xref">C.5.2</a>.  <a href="#name-ticket-3-two-tiny-nits" class="xref">Ticket 3 - Two tiny nits</a><a href="#section-toc.1-1.14.2.5.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.5.2.3">
+                    <p id="section-toc.1-1.14.2.5.2.3.1"><a href="#section-c.5.3" class="xref">C.5.3</a>.  <a href="#name-ticket-4-definition-of-fo-p" class="xref">Ticket 4 - Definition of "fo" parameter</a><a href="#section-toc.1-1.14.2.5.2.3.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.6">
+                <p id="section-toc.1-1.14.2.6.1"><a href="#section-c.6" class="xref">C.6</a>.  <a href="#name-march-16-2021" class="xref">March 16, 2021</a><a href="#section-toc.1-1.14.2.6.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.6.2.1">
+                    <p id="section-toc.1-1.14.2.6.2.1.1"><a href="#section-c.6.1" class="xref">C.6.1</a>.  <a href="#name-ticket-7-abnf-for-dmarc-rec" class="xref">Ticket 7 - ABNF for dmarc-record is slightly wrong</a><a href="#section-toc.1-1.14.2.6.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.6.2.2">
+                    <p id="section-toc.1-1.14.2.6.2.2.1"><a href="#section-c.6.2" class="xref">C.6.2</a>.  <a href="#name-ticket-26-abnf-for-pct-allo" class="xref">Ticket 26 - ABNF for pct allows "999"</a><a href="#section-toc.1-1.14.2.6.2.2.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.7">
+                <p id="section-toc.1-1.14.2.7.1"><a href="#section-c.7" class="xref">C.7</a>.  <a href="#name-march-23-2021" class="xref">March 23, 2021</a><a href="#section-toc.1-1.14.2.7.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.7.2.1">
+                    <p id="section-toc.1-1.14.2.7.2.1.1"><a href="#section-c.7.1" class="xref">C.7.1</a>.  <a href="#name-ticket-75-using-wording-alt" class="xref">Ticket 75 - Using wording alternatives to 'disposition', 'dispose', and the like</a><a href="#section-toc.1-1.14.2.7.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.7.2.2">
+                    <p id="section-toc.1-1.14.2.7.2.2.1"><a href="#section-c.7.2" class="xref">C.7.2</a>.  <a href="#name-ticket-72-remove-absolute-r" class="xref">Ticket 72 - Remove absolute requirement for p= tag in DMARC record</a><a href="#section-toc.1-1.14.2.7.2.2.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.8">
+                <p id="section-toc.1-1.14.2.8.1"><a href="#section-c.8" class="xref">C.8</a>.  <a href="#name-march-29-2021" class="xref">March 29, 2021</a><a href="#section-toc.1-1.14.2.8.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.8.2.1">
+                    <p id="section-toc.1-1.14.2.8.2.1.1"><a href="#section-c.8.1" class="xref">C.8.1</a>.  <a href="#name-ticket-54-remove-or-expand-" class="xref">Ticket 54 - Remove or expand limits on number of recipients per report</a><a href="#section-toc.1-1.14.2.8.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.9">
+                <p id="section-toc.1-1.14.2.9.1"><a href="#section-c.9" class="xref">C.9</a>.  <a href="#name-april-12-2021" class="xref">April 12, 2021</a><a href="#section-toc.1-1.14.2.9.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.9.2.1">
+                    <p id="section-toc.1-1.14.2.9.2.1.1"><a href="#section-c.9.1" class="xref">C.9.1</a>.  <a href="#name-ticket-50-remove-ri-tag" class="xref">Ticket 50 - Remove ri= tag</a><a href="#section-toc.1-1.14.2.9.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.9.2.2">
+                    <p id="section-toc.1-1.14.2.9.2.2.1"><a href="#section-c.9.2" class="xref">C.9.2</a>.  <a href="#name-ticket-66-define-what-it-me" class="xref">Ticket 66 - Define what it means to have implemented DMARC</a><a href="#section-toc.1-1.14.2.9.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.9.2.3">
+                    <p id="section-toc.1-1.14.2.9.2.3.1"><a href="#section-c.9.3" class="xref">C.9.3</a>.  <a href="#name-ticket-96-tweaks-to-abstrac" class="xref">Ticket 96 - Tweaks to Abstract and Introduction</a><a href="#section-toc.1-1.14.2.9.2.3.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.10">
+                <p id="section-toc.1-1.14.2.10.1"><a href="#section-c.10" class="xref">C.10</a>. <a href="#name-april-13-2021" class="xref">April 13, 2021</a><a href="#section-toc.1-1.14.2.10.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.10.2.1">
+                    <p id="section-toc.1-1.14.2.10.2.1.1"><a href="#section-c.10.1" class="xref">C.10.1</a>.  <a href="#name-ticket-53-remove-reporting-" class="xref">Ticket 53 - Remove reporting message size chunking</a><a href="#section-toc.1-1.14.2.10.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.10.2.2">
+                    <p id="section-toc.1-1.14.2.10.2.2.1"><a href="#section-c.10.2" class="xref">C.10.2</a>.  <a href="#name-ticket-52-remove-strict-ali" class="xref">Ticket 52 - Remove strict alignment (and adkim and aspf tags)</a><a href="#section-toc.1-1.14.2.10.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.10.2.3">
+                    <p id="section-toc.1-1.14.2.10.2.3.1"><a href="#section-c.10.3" class="xref">C.10.3</a>.  <a href="#name-ticket-47-remove-pct-tag" class="xref">Ticket 47 - Remove pct= tag</a><a href="#section-toc.1-1.14.2.10.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.10.2.4">
+                    <p id="section-toc.1-1.14.2.10.2.4.1"><a href="#section-c.10.4" class="xref">C.10.4</a>.  <a href="#name-ticket-2-flow-of-operations" class="xref">Ticket 2 - Flow of operations text in dmarc-base</a><a href="#section-toc.1-1.14.2.10.2.4.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.11">
+                <p id="section-toc.1-1.14.2.11.1"><a href="#section-c.11" class="xref">C.11</a>. <a href="#name-april-14-2021" class="xref">April 14, 2021</a><a href="#section-toc.1-1.14.2.11.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.11.2.1">
+                    <p id="section-toc.1-1.14.2.11.2.1.1"><a href="#section-c.11.1" class="xref">C.11.1</a>.  <a href="#name-ticket-107-dmarcbis-should-" class="xref">Ticket 107 - DMARCbis should take a stand on multi-valued From fields</a><a href="#section-toc.1-1.14.2.11.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.11.2.2">
+                    <p id="section-toc.1-1.14.2.11.2.2.1"><a href="#section-c.11.2" class="xref">C.11.2</a>.  <a href="#name-ticket-82-deprecate-rf-and-" class="xref">Ticket 82 - Deprecate rf= and maybe fo= tag</a><a href="#section-toc.1-1.14.2.11.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.11.2.3">
+                    <p id="section-toc.1-1.14.2.11.2.3.1"><a href="#section-c.11.3" class="xref">C.11.3</a>.  <a href="#name-ticket-85-proposed-change-t" class="xref">Ticket 85 - Proposed change to wording describing 'p' tag and values</a><a href="#section-toc.1-1.14.2.11.2.3.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.12">
+                <p id="section-toc.1-1.14.2.12.1"><a href="#section-c.12" class="xref">C.12</a>. <a href="#name-april-15-2021" class="xref">April 15, 2021</a><a href="#section-toc.1-1.14.2.12.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.12.2.1">
+                    <p id="section-toc.1-1.14.2.12.2.1.1"><a href="#section-c.12.1" class="xref">C.12.1</a>.  <a href="#name-ticket-86-a-r-results-for-d" class="xref">Ticket 86 - A-R results for DMARC</a><a href="#section-toc.1-1.14.2.12.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.12.2.2">
+                    <p id="section-toc.1-1.14.2.12.2.2.1"><a href="#section-c.12.2" class="xref">C.12.2</a>.  <a href="#name-ticket-62-make-aggregate-re" class="xref">Ticket 62 - Make aggregate reporting a normative MUST</a><a href="#section-toc.1-1.14.2.12.2.2.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.13">
+                <p id="section-toc.1-1.14.2.13.1"><a href="#section-c.13" class="xref">C.13</a>. <a href="#name-april-19-2021" class="xref">April 19, 2021</a><a href="#section-toc.1-1.14.2.13.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.13.2.1">
+                    <p id="section-toc.1-1.14.2.13.2.1.1"><a href="#section-c.13.1" class="xref">C.13.1</a>.  <a href="#name-ticket-109-sanity-check-dma" class="xref">Ticket 109 - Sanity Check DMARCbis Document</a><a href="#section-toc.1-1.14.2.13.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.14">
+                <p id="section-toc.1-1.14.2.14.1"><a href="#section-c.14" class="xref">C.14</a>. <a href="#name-april-20-2021" class="xref">April 20, 2021</a><a href="#section-toc.1-1.14.2.14.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.14.2.1">
+                    <p id="section-toc.1-1.14.2.14.2.1.1"><a href="#section-c.14.1" class="xref">C.14.1</a>.  <a href="#name-ticket-108-changes-to-dmarc" class="xref">Ticket 108 - Changes to DMARCbis for PSD</a><a href="#section-toc.1-1.14.2.14.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.15">
+                <p id="section-toc.1-1.14.2.15.1"><a href="#section-c.15" class="xref">C.15</a>. <a href="#name-april-22-2021" class="xref">April 22, 2021</a><a href="#section-toc.1-1.14.2.15.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.15.2.1">
+                    <p id="section-toc.1-1.14.2.15.2.1.1"><a href="#section-c.15.1" class="xref">C.15.1</a>.  <a href="#name-ticket-104-update-the-secur" class="xref">Ticket 104 - Update the Security Considerations section 11.3 on DNS</a><a href="#section-toc.1-1.14.2.15.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.16">
+                <p id="section-toc.1-1.14.2.16.1"><a href="#section-c.16" class="xref">C.16</a>. <a href="#name-june-16-2021" class="xref">June 16, 2021</a><a href="#section-toc.1-1.14.2.16.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.16.2.1">
+                    <p id="section-toc.1-1.14.2.16.2.1.1"><a href="#section-c.16.1" class="xref">C.16.1</a>.  <a href="#name-publication-of-draft-ietf-d" class="xref">Publication of draft-ietf-dmarc-dmarcbis-02</a><a href="#section-toc.1-1.14.2.16.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.17">
+                <p id="section-toc.1-1.14.2.17.1"><a href="#section-c.17" class="xref">C.17</a>. <a href="#name-august-12-2021" class="xref">August 12, 2021</a><a href="#section-toc.1-1.14.2.17.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.17.2.1">
+                    <p id="section-toc.1-1.14.2.17.2.1.1"><a href="#section-c.17.1" class="xref">C.17.1</a>.  <a href="#name-publication-of-draft-ietf-dm" class="xref">Publication of draft-ietf-dmarc-dmarcbis-03</a><a href="#section-toc.1-1.14.2.17.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
 </li>
 </ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.15">
-            <p id="section-toc.1-1.15.1"><a href="#section-appendix.c" class="xref">Appendix C</a>.  <a href="#name-change-log" class="xref">Change Log</a><a href="#section-toc.1-1.15.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.1">
-                <p id="section-toc.1-1.15.2.1.1"><a href="#section-c.1" class="xref">C.1</a>.  <a href="#name-january-5-2021" class="xref">January 5, 2021</a><a href="#section-toc.1-1.15.2.1.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.1.2.1">
-                    <p id="section-toc.1-1.15.2.1.2.1.1"><a href="#section-c.1.1" class="xref">C.1.1</a>.  <a href="#name-ticket-80-dmarcbis-should-h" class="xref">Ticket 80 - DMARCbis SHould Have Clear and Concise Defintion of DMARC</a><a href="#section-toc.1-1.15.2.1.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.2">
-                <p id="section-toc.1-1.15.2.2.1"><a href="#section-c.2" class="xref">C.2</a>.  <a href="#name-february-4-2021" class="xref">February 4, 2021</a><a href="#section-toc.1-1.15.2.2.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.2.2.1">
-                    <p id="section-toc.1-1.15.2.2.2.1.1"><a href="#section-c.2.1" class="xref">C.2.1</a>.  <a href="#name-ticket-1-spf-rfc-4408-vs-72" class="xref">Ticket 1 - SPF RFC 4408 vs 7208</a><a href="#section-toc.1-1.15.2.2.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.3">
-                <p id="section-toc.1-1.15.2.3.1"><a href="#section-c.3" class="xref">C.3</a>.  <a href="#name-february-10-2021" class="xref">February 10, 2021</a><a href="#section-toc.1-1.15.2.3.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.3.2.1">
-                    <p id="section-toc.1-1.15.2.3.2.1.1"><a href="#section-c.3.1" class="xref">C.3.1</a>.  <a href="#name-ticket-84-remove-erroneous-" class="xref">Ticket 84 - Remove Erroneous References to RFC3986</a><a href="#section-toc.1-1.15.2.3.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.4">
-                <p id="section-toc.1-1.15.2.4.1"><a href="#section-c.4" class="xref">C.4</a>.  <a href="#name-march-1-2021" class="xref">March 1, 2021</a><a href="#section-toc.1-1.15.2.4.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.4.2.1">
-                    <p id="section-toc.1-1.15.2.4.2.1.1"><a href="#section-c.4.1" class="xref">C.4.1</a>.  <a href="#name-design-team-work-begins" class="xref">Design Team Work Begins</a><a href="#section-toc.1-1.15.2.4.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.5">
-                <p id="section-toc.1-1.15.2.5.1"><a href="#section-c.5" class="xref">C.5</a>.  <a href="#name-march-8-2021" class="xref">March 8, 2021</a><a href="#section-toc.1-1.15.2.5.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.5.2.1">
-                    <p id="section-toc.1-1.15.2.5.2.1.1"><a href="#section-c.5.1" class="xref">C.5.1</a>.  <a href="#name-removed-e-gustafsson-as-edi" class="xref">Removed E. Gustafsson as editor</a><a href="#section-toc.1-1.15.2.5.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.5.2.2">
-                    <p id="section-toc.1-1.15.2.5.2.2.1"><a href="#section-c.5.2" class="xref">C.5.2</a>.  <a href="#name-ticket-3-two-tiny-nits" class="xref">Ticket 3 - Two tiny nits</a><a href="#section-toc.1-1.15.2.5.2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.5.2.3">
-                    <p id="section-toc.1-1.15.2.5.2.3.1"><a href="#section-c.5.3" class="xref">C.5.3</a>.  <a href="#name-ticket-4-definition-of-fo-p" class="xref">Ticket 4 - Definition of "fo" parameter</a><a href="#section-toc.1-1.15.2.5.2.3.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.6">
-                <p id="section-toc.1-1.15.2.6.1"><a href="#section-c.6" class="xref">C.6</a>.  <a href="#name-march-16-2021" class="xref">March 16, 2021</a><a href="#section-toc.1-1.15.2.6.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.6.2.1">
-                    <p id="section-toc.1-1.15.2.6.2.1.1"><a href="#section-c.6.1" class="xref">C.6.1</a>.  <a href="#name-ticket-7-abnf-for-dmarc-rec" class="xref">Ticket 7 - ABNF for dmarc-record is slightly wrong</a><a href="#section-toc.1-1.15.2.6.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.6.2.2">
-                    <p id="section-toc.1-1.15.2.6.2.2.1"><a href="#section-c.6.2" class="xref">C.6.2</a>.  <a href="#name-ticket-26-abnf-for-pct-allo" class="xref">Ticket 26 - ABNF for pct allows "999"</a><a href="#section-toc.1-1.15.2.6.2.2.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.7">
-                <p id="section-toc.1-1.15.2.7.1"><a href="#section-c.7" class="xref">C.7</a>.  <a href="#name-march-23-2021" class="xref">March 23, 2021</a><a href="#section-toc.1-1.15.2.7.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.7.2.1">
-                    <p id="section-toc.1-1.15.2.7.2.1.1"><a href="#section-c.7.1" class="xref">C.7.1</a>.  <a href="#name-ticket-75-using-wording-alt" class="xref">Ticket 75 - Using wording alternatives to 'disposition', 'dispose', and the like</a><a href="#section-toc.1-1.15.2.7.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.7.2.2">
-                    <p id="section-toc.1-1.15.2.7.2.2.1"><a href="#section-c.7.2" class="xref">C.7.2</a>.  <a href="#name-ticket-72-remove-absolute-r" class="xref">Ticket 72 - Remove absolute requirement for p= tag in DMARC record</a><a href="#section-toc.1-1.15.2.7.2.2.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.8">
-                <p id="section-toc.1-1.15.2.8.1"><a href="#section-c.8" class="xref">C.8</a>.  <a href="#name-march-29-2021" class="xref">March 29, 2021</a><a href="#section-toc.1-1.15.2.8.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.8.2.1">
-                    <p id="section-toc.1-1.15.2.8.2.1.1"><a href="#section-c.8.1" class="xref">C.8.1</a>.  <a href="#name-ticket-54-remove-or-expand-" class="xref">Ticket 54 - Remove or expand limits on number of recipients per report</a><a href="#section-toc.1-1.15.2.8.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.9">
-                <p id="section-toc.1-1.15.2.9.1"><a href="#section-c.9" class="xref">C.9</a>.  <a href="#name-april-12-2021" class="xref">April 12, 2021</a><a href="#section-toc.1-1.15.2.9.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.9.2.1">
-                    <p id="section-toc.1-1.15.2.9.2.1.1"><a href="#section-c.9.1" class="xref">C.9.1</a>.  <a href="#name-ticket-50-remove-ri-tag" class="xref">Ticket 50 - Remove ri= tag</a><a href="#section-toc.1-1.15.2.9.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.9.2.2">
-                    <p id="section-toc.1-1.15.2.9.2.2.1"><a href="#section-c.9.2" class="xref">C.9.2</a>.  <a href="#name-ticket-66-define-what-it-me" class="xref">Ticket 66 - Define what it means to have implemented DMARC</a><a href="#section-toc.1-1.15.2.9.2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.9.2.3">
-                    <p id="section-toc.1-1.15.2.9.2.3.1"><a href="#section-c.9.3" class="xref">C.9.3</a>.  <a href="#name-ticket-96-tweaks-to-abstrac" class="xref">Ticket 96 - Tweaks to Abstract and Introduction</a><a href="#section-toc.1-1.15.2.9.2.3.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.10">
-                <p id="section-toc.1-1.15.2.10.1"><a href="#section-c.10" class="xref">C.10</a>. <a href="#name-april-13-2021" class="xref">April 13, 2021</a><a href="#section-toc.1-1.15.2.10.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.10.2.1">
-                    <p id="section-toc.1-1.15.2.10.2.1.1"><a href="#section-c.10.1" class="xref">C.10.1</a>.  <a href="#name-ticket-53-remove-reporting-" class="xref">Ticket 53 - Remove reporting message size chunking</a><a href="#section-toc.1-1.15.2.10.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.10.2.2">
-                    <p id="section-toc.1-1.15.2.10.2.2.1"><a href="#section-c.10.2" class="xref">C.10.2</a>.  <a href="#name-ticket-52-remove-strict-ali" class="xref">Ticket 52 - Remove strict alignment (and adkim and aspf tags)</a><a href="#section-toc.1-1.15.2.10.2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.10.2.3">
-                    <p id="section-toc.1-1.15.2.10.2.3.1"><a href="#section-c.10.3" class="xref">C.10.3</a>.  <a href="#name-ticket-47-remove-pct-tag" class="xref">Ticket 47 - Remove pct= tag</a><a href="#section-toc.1-1.15.2.10.2.3.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.10.2.4">
-                    <p id="section-toc.1-1.15.2.10.2.4.1"><a href="#section-c.10.4" class="xref">C.10.4</a>.  <a href="#name-ticket-2-flow-of-operations" class="xref">Ticket 2 - Flow of operations text in dmarc-base</a><a href="#section-toc.1-1.15.2.10.2.4.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.11">
-                <p id="section-toc.1-1.15.2.11.1"><a href="#section-c.11" class="xref">C.11</a>. <a href="#name-april-14-2021" class="xref">April 14, 2021</a><a href="#section-toc.1-1.15.2.11.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.11.2.1">
-                    <p id="section-toc.1-1.15.2.11.2.1.1"><a href="#section-c.11.1" class="xref">C.11.1</a>.  <a href="#name-ticket-107-dmarcbis-should-" class="xref">Ticket 107 - DMARCbis should take a stand on multi-valued From fields</a><a href="#section-toc.1-1.15.2.11.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.11.2.2">
-                    <p id="section-toc.1-1.15.2.11.2.2.1"><a href="#section-c.11.2" class="xref">C.11.2</a>.  <a href="#name-ticket-82-deprecate-rf-and-" class="xref">Ticket 82 - Deprecate rf= and maybe fo= tag</a><a href="#section-toc.1-1.15.2.11.2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.11.2.3">
-                    <p id="section-toc.1-1.15.2.11.2.3.1"><a href="#section-c.11.3" class="xref">C.11.3</a>.  <a href="#name-ticket-85-proposed-change-t" class="xref">Ticket 85 - Proposed change to wording describing 'p' tag and values</a><a href="#section-toc.1-1.15.2.11.2.3.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.12">
-                <p id="section-toc.1-1.15.2.12.1"><a href="#section-c.12" class="xref">C.12</a>. <a href="#name-april-15-2021" class="xref">April 15, 2021</a><a href="#section-toc.1-1.15.2.12.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.12.2.1">
-                    <p id="section-toc.1-1.15.2.12.2.1.1"><a href="#section-c.12.1" class="xref">C.12.1</a>.  <a href="#name-ticket-86-a-r-results-for-d" class="xref">Ticket 86 - A-R results for DMARC</a><a href="#section-toc.1-1.15.2.12.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.12.2.2">
-                    <p id="section-toc.1-1.15.2.12.2.2.1"><a href="#section-c.12.2" class="xref">C.12.2</a>.  <a href="#name-ticket-62-make-aggregate-re" class="xref">Ticket 62 - Make aggregate reporting a normative MUST</a><a href="#section-toc.1-1.15.2.12.2.2.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.13">
-                <p id="section-toc.1-1.15.2.13.1"><a href="#section-c.13" class="xref">C.13</a>. <a href="#name-april-19-2021" class="xref">April 19, 2021</a><a href="#section-toc.1-1.15.2.13.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.13.2.1">
-                    <p id="section-toc.1-1.15.2.13.2.1.1"><a href="#section-c.13.1" class="xref">C.13.1</a>.  <a href="#name-ticket-109-sanity-check-dma" class="xref">Ticket 109 - Sanity Check DMARCbis Document</a><a href="#section-toc.1-1.15.2.13.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.14">
-                <p id="section-toc.1-1.15.2.14.1"><a href="#section-c.14" class="xref">C.14</a>. <a href="#name-april-20-2021" class="xref">April 20, 2021</a><a href="#section-toc.1-1.15.2.14.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.14.2.1">
-                    <p id="section-toc.1-1.15.2.14.2.1.1"><a href="#section-c.14.1" class="xref">C.14.1</a>.  <a href="#name-ticket-108-changes-to-dmarc" class="xref">Ticket 108 - Changes to DMARCbis for PSD</a><a href="#section-toc.1-1.15.2.14.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.15">
-                <p id="section-toc.1-1.15.2.15.1"><a href="#section-c.15" class="xref">C.15</a>. <a href="#name-april-22-2021" class="xref">April 22, 2021</a><a href="#section-toc.1-1.15.2.15.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.15.2.1">
-                    <p id="section-toc.1-1.15.2.15.2.1.1"><a href="#section-c.15.1" class="xref">C.15.1</a>.  <a href="#name-ticket-104-update-the-secur" class="xref">Ticket 104 - Update the Security Considerations section 11.3 on DNS</a><a href="#section-toc.1-1.15.2.15.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.16">
-                <p id="section-toc.1-1.15.2.16.1"><a href="#section-c.16" class="xref">C.16</a>. <a href="#name-june-16-2021" class="xref">June 16, 2021</a><a href="#section-toc.1-1.15.2.16.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.16.2.1">
-                    <p id="section-toc.1-1.15.2.16.2.1.1"><a href="#section-c.16.1" class="xref">C.16.1</a>.  <a href="#name-publication-of-draft-ietf-d" class="xref">Publication of draft-ietf-dmarc-dmarcbis-02</a><a href="#section-toc.1-1.15.2.16.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.17">
-                <p id="section-toc.1-1.15.2.17.1"><a href="#section-c.17" class="xref">C.17</a>. <a href="#name-august-12-2021" class="xref">August 12, 2021</a><a href="#section-toc.1-1.15.2.17.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.15.2.17.2.1">
-                    <p id="section-toc.1-1.15.2.17.2.1.1"><a href="#section-c.17.1" class="xref">C.17.1</a>.  <a href="#name-publication-of-draft-ietf-dm" class="xref">Publication of draft-ietf-dmarc-dmarcbis-03</a><a href="#section-toc.1-1.15.2.17.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-</ul>
+            <p id="section-toc.1-1.15.1"><a href="#section-appendix.d" class="xref"></a><a href="#name-acknowledgements" class="xref">Acknowledgements</a><a href="#section-toc.1-1.15.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.16">
-            <p id="section-toc.1-1.16.1"><a href="#section-appendix.d" class="xref"></a><a href="#name-acknowledgements" class="xref">Acknowledgements</a><a href="#section-toc.1-1.16.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.17">
-            <p id="section-toc.1-1.17.1"><a href="#section-appendix.e" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a><a href="#section-toc.1-1.17.1" class="pilcrow">¶</a></p>
+            <p id="section-toc.1-1.16.1"><a href="#section-appendix.e" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a><a href="#section-toc.1-1.16.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </nav>
@@ -1770,7 +1767,7 @@ as with honoring the Domain Owner's stated mail handling preference, a mail-rece
 organization supporting DMARC is under no obligation to send requested reports.<a href="#section-1-7" class="pilcrow">¶</a></p>
 <p id="section-1-8">Use of DMARC creates some interoperability challenges that require due
 consideration before deployment, particularly with configurations that
-can cause mail to be rejected.  These are discussed in <a href="#other-topics" class="xref">Section 8</a>.<a href="#section-1-8" class="pilcrow">¶</a></p>
+can cause mail to be rejected.  These are discussed in <a href="#other-topics" class="xref">Section 7</a>.<a href="#section-1-8" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="requirements">
@@ -1927,7 +1924,7 @@ material before continuing.<a href="#section-3.1-2" class="pilcrow">¶</a></p>
 <a href="#section-3.2.1" class="section-number selfRef">3.2.1. </a><a href="#name-authenticated-identifiers" class="section-name selfRef">Authenticated Identifiers</a>
           </h4>
 <p id="section-3.2.1-1">Domain-level identifiers that are verified using authentication technologies
-are referred to as "Authenticated Identifiers".  See <a href="#authenication-mechanisms" class="xref">Section 4.1</a>
+are referred to as "Authenticated Identifiers".  See <a href="#authentication-mechanisms" class="xref">Section 4.2</a>
 for details about the supported mechanisms.<a href="#section-3.2.1-1" class="pilcrow">¶</a></p>
 </section>
 </div>
@@ -2000,10 +1997,10 @@ is a broader definition than that in <span>[<a href="#RFC8020" class="xref">RFC8
 <a href="#section-3.2.8" class="section-number selfRef">3.2.8. </a><a href="#name-organizational-domain" class="section-name selfRef">Organizational Domain</a>
           </h4>
 <p id="section-3.2.8-1">The Organizational Domain is typically a domain that was registered with
-a domain name registrar.  More formally, it is a Public Suffix Domain
+a domain name registrar.  More formally, it is any Public Suffix Domain
 plus one label. The Organizational Domain for the domain in the
 RFC5322.From domain is determined by applying the algorithm found in
-<a href="#determining-the-organizational-domain" class="xref">Section 3.4</a>.<a href="#section-3.2.8-1" class="pilcrow">¶</a></p>
+<a href="#determining-the-organizational-domain" class="xref">Section 4.5</a>.<a href="#section-3.2.8-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="public-suffix-domain">
@@ -2047,252 +2044,120 @@ that operate them.<a href="#section-3.2.12-1" class="pilcrow">¶</a></p>
 </div>
 </section>
 </div>
-<div id="more-on-identifier-alignment">
-<section id="section-3.3">
-        <h3 id="name-more-on-identifier-alignmen">
-<a href="#section-3.3" class="section-number selfRef">3.3. </a><a href="#name-more-on-identifier-alignmen" class="section-name selfRef">More on Identifier Alignment</a>
-        </h3>
-<p id="section-3.3-1">Email authentication technologies authenticate various (and
-disparate) aspects of an individual message.  For example, DKIM <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>
-authenticates the domain that affixed a signature to the message,
-while SPF <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span> can authenticate either the domain that appears in the
-RFC5321.MailFrom (MAIL FROM) portion of an SMTP <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span> conversation or the
-RFC5321.EHLO/HELO domain, or both.  These may be different domains, and they
-are typically not visible to the end user.<a href="#section-3.3-1" class="pilcrow">¶</a></p>
-<p id="section-3.3-2">DMARC authenticates use of the RFC5322.From domain by requiring that
-it have the same Organizational Domain as (i.e., be aligned with) an
-Authenticated Identifier. Domain names in this context are to be compared
-in a case-insensitive manner, per <span>[<a href="#RFC4343" class="xref">RFC4343</a>]</span>. The RFC5322.From domain
-was selected as the central identity of the DMARC mechanism because it
-is a required message header field and therefore guaranteed to be present
-in compliant messages, and most Mail User Agents (MUAs) represent the
-RFC5322.From header field as the originator of the message and render
-some or all of this header field's content to end users.<a href="#section-3.3-2" class="pilcrow">¶</a></p>
-<p id="section-3.3-3">It is important to note that Identifier Alignment cannot occur with a
-message that is not valid per <span>[<a href="#RFC5322" class="xref">RFC5322</a>]</span>, particularly one with a
-malformed, absent, or repeated RFC5322.From header field, since in that case
-there is no reliable way to determine a DMARC policy that applies to
-the message.  Accordingly, DMARC operation is predicated on the input
-being a valid RFC5322 message object, and handling of such
-non-compliant cases is outside of the scope of this specification.
-Further discussion of this can be found in <a href="#extract-author-domain" class="xref">Section 6.7.1</a>.<a href="#section-3.3-3" class="pilcrow">¶</a></p>
-<p id="section-3.3-4">Each of the underlying authentication technologies that DMARC takes
-as input yields authenticated domains as their outputs when they
-succeed.<a href="#section-3.3-4" class="pilcrow">¶</a></p>
-<div id="dkim-identifiers">
-<section id="section-3.3.1">
-          <h4 id="name-dkim-authenticated-identifi">
-<a href="#section-3.3.1" class="section-number selfRef">3.3.1. </a><a href="#name-dkim-authenticated-identifi" class="section-name selfRef">DKIM-Authenticated Identifiers</a>
-          </h4>
-<p id="section-3.3.1-1">DMARC requires Identifier Alignment based on the result of a DKIM
-authentication because a message can bear a valid signature from any
-domain, including domains used by a mailing list or even a bad actor.
-Therefore, merely bearing a valid signature is not enough to infer
-authenticity of the Author Domain.<a href="#section-3.3.1-1" class="pilcrow">¶</a></p>
-<p id="section-3.3.1-2">DMARC permits Identifier Alignment based on the result of a DKIM
-authentication to be strict or relaxed. (Note that these terms are
-not related to DKIM's "simple" and "relaxed" canonicalization modes.)<a href="#section-3.3.1-2" class="pilcrow">¶</a></p>
-<p id="section-3.3.1-3">In relaxed mode, the Organizational Domains of both the DKIM-authenticated
-signing domain (taken from the value of the d= tag in the signature)
-and that of the RFC5322.From domain must be equal if the identifiers
-are to be considered to be aligned. In strict mode, only an exact match
-between both Fully Qualified Domain Names (FQDNs) is considered to produce
-Identifier Alignment.<a href="#section-3.3.1-3" class="pilcrow">¶</a></p>
-<p id="section-3.3.1-4">To illustrate, in relaxed mode, if a verified DKIM signature
-successfully verifies with a "d=" domain of "example.com", and the
-RFC5322.From address is "alerts@news.example.com", the DKIM "d="
-domain and the RFC5322.From domain are considered to be "in alignment",
-because both domains have the same Organizational Domain of "example.com".
-In strict mode, this test would fail because the d= domain does not
-exactly match the RFC5322.From domain.<a href="#section-3.3.1-4" class="pilcrow">¶</a></p>
-<p id="section-3.3.1-5">However, a DKIM signature bearing a value of "d=com" would never allow
-an "in alignment" result, as "com" should be identified as a PSD and
-therefore cannot be an Organizational Domain.<a href="#section-3.3.1-5" class="pilcrow">¶</a></p>
-<p id="section-3.3.1-6">Note that a single email can contain multiple DKIM signatures, and it
-is considered to produce a DMARC "pass" result if any DKIM signature
-is aligned and verifies.<a href="#section-3.3.1-6" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="spf-identifiers">
-<section id="section-3.3.2">
-          <h4 id="name-spf-authenticated-identifie">
-<a href="#section-3.3.2" class="section-number selfRef">3.3.2. </a><a href="#name-spf-authenticated-identifie" class="section-name selfRef">SPF-Authenticated Identifiers</a>
-          </h4>
-<p id="section-3.3.2-1">DMARC permits Identifier Alignment based on the result of an SPF
-authentication. As with DKIM, Identifier Alignement can be either
-strict or relaxed.<a href="#section-3.3.2-1" class="pilcrow">¶</a></p>
-<p id="section-3.3.2-2">In relaxed mode, the Organizational Domains of the SPF-authenticated
-domain and RFC5322.From domain must be equal if the identifiers are
-to be considered to be aligned. In strict mode, the two FQDNs must
-match exactly in order from them to be considered to be aligned.<a href="#section-3.3.2-2" class="pilcrow">¶</a></p>
-<p id="section-3.3.2-3">For example, in relaxed mode, if a message passes an SPF check with an
-RFC5321.MailFrom domain of "cbg.bounces.example.com", and the address
-portion of the RFC5322.From header field contains
-"payments@example.com", the Authenticated RFC5321.MailFrom domain
-identifier and the RFC5322.From domain are considered to be "in
-alignment" because they have the same Organizational Domain
-("example.com"). In strict mode, this test would fail because the
-two domains are not identical.<a href="#section-3.3.2-3" class="pilcrow">¶</a></p>
-<p id="section-3.3.2-4">The reader should note that SPF alignment checks in DMARC rely solely
-on the RFC5321.MailFrom domain. This differs from section 2.3 of
-<span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span>, which recommends that SPF checks be done on not only the
-"MAIL FROM" but also on a separate check of the "HELO" identity.<a href="#section-3.3.2-4" class="pilcrow">¶</a></p>
-</section>
-</div>
-<div id="alignment-and-extension-technologies">
-<section id="section-3.3.3">
-          <h4 id="name-alignment-and-extension-tec">
-<a href="#section-3.3.3" class="section-number selfRef">3.3.3. </a><a href="#name-alignment-and-extension-tec" class="section-name selfRef">Alignment and Extension Technologies</a>
-          </h4>
-<p id="section-3.3.3-1">If in the future DMARC is extended to include the use of other
-authentication mechanisms, the extensions will need to allow for
-domain identifier extraction so that alignment with the RFC5322.From
-domain can be verified.<a href="#section-3.3.3-1" class="pilcrow">¶</a></p>
-</section>
-</div>
-</section>
-</div>
-<div id="determining-the-organizational-domain">
-<section id="section-3.4">
-        <h3 id="name-determining-the-organizatio">
-<a href="#section-3.4" class="section-number selfRef">3.4. </a><a href="#name-determining-the-organizatio" class="section-name selfRef">Determining The Organizational Domain</a>
-        </h3>
-<p id="section-3.4-1">The Organizational Domain for a subject DNS domain name is defined as
-the domain that is found in the DNS hierarchy one level below the PSD
-in the subject DNS domain name.  The Organizational Domain is determined
-using the following algorithm, similar to the one described in <a href="#policy-discovery" class="xref">Section 6.7.3</a><a href="#section-3.4-1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-3.4-2">
-          <li id="section-3.4-2.1">
-            <p id="section-3.4-2.1.1">Query the DNS for a DMARC TXT record at the DNS domain matching the one
-found in the RFC5322.From domain in the message.  A possibly empty set
-of records is returned.<a href="#section-3.4-2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-3.4-2.2">
-            <p id="section-3.4-2.2.1">Records that do not start with a "v=" tag that identifies the
-current version of DMARC are discarded.<a href="#section-3.4-2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-3.4-2.3">
-            <p id="section-3.4-2.3.1">If the set is now empty, or the set contains one valid DMARC record that
-does not include a psd tag with a value of 'y', then determine the target for
-additional queries, using steps 4 through 8 below.<a href="#section-3.4-2.3.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-3.4-2.4">
-            <p id="section-3.4-2.4.1">Break the subject DNS domain name into a set of "n" ordered
-labels.  Number these labels from right to left; e.g., for
-"example.com", "com" would be label 1 and "example" would be
-label 2.<a href="#section-3.4-2.4.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-3.4-2.5">
-            <p id="section-3.4-2.5.1">Count the number of labels found in the subject DNS domain. Let that
-number be "x". If x &lt; 5, remove the left-most (highest-numbered)
-label from the subject domain. If x &gt;= 5, remove the left-most
-(highest-numbered) labels from the subject domain until 4 labels remain.
-The resulting DNS domain name is the new target for subsequent lookups.<a href="#section-3.4-2.5.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-3.4-2.6">
-            <p id="section-3.4-2.6.1">Query the DNS for a DMARC TXT record at the DNS domain matching this
-new target in place of the RFC5322.From domain in the message.  A possibly
-empty set of records is returned.<a href="#section-3.4-2.6.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-3.4-2.7">
-            <p id="section-3.4-2.7.1">Records that do not start with a "v=" tag that identifies the
-current version of DMARC are discarded.<a href="#section-3.4-2.7.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-3.4-2.8">
-            <p id="section-3.4-2.8.1">If the set is now empty, or the set contains one valid DMARC record that
-does not include a psd tag with the value of 'y', then determine the
-target for additional queries by removing a single label from the target
-domain as described in step 5 and repeating steps 6 and 7 until
-there are no more labels remaining or a record containing a psd tag with
-a value of 'y' is found.<a href="#section-3.4-2.8.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-3.4-2.9">
-            <p id="section-3.4-2.9.1">Once a valid DMARC record containing a psd tag with a value of 'y' has
-been found, the Organizational Domain for the DNS domain matching the
-one found in the RFC5322.From domain can be declared to be the target
-domain queried for in the step prior to the query that found the PSD
-domain.<a href="#section-3.4-2.9.1" class="pilcrow">¶</a></p>
-</li>
-</ol>
-<p id="section-3.4-3">For example, given the RFC5322.From domain "a.mail.example.com", a series
-of DNS queries for DMARC records would be executed starting with
-"<em>dmarc.a.mail.example.com" and finishing with "</em>dmarc.com". The "<em>dmarc.com"
-record would contain a psd tag with a value of 'y', and so the Organizational
-Domain for this RFC5322.From domain would be determined to be "example.com",
-the domain of the DMARC query executed prior to the query for "</em>dmarc.com".<a href="#section-3.4-3" class="pilcrow">¶</a></p>
-</section>
-</div>
-</section>
-</div>
-<div id="overview">
+<div id="overview-and-key-concepts">
 <section id="section-4">
-      <h2 id="name-overview">
-<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-overview" class="section-name selfRef">Overview</a>
+      <h2 id="name-overview-and-key-concepts">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-overview-and-key-concepts" class="section-name selfRef">Overview and Key Concepts</a>
       </h2>
 <p id="section-4-1">This section provides a general overview of the design and operation
 of the DMARC environment.<a href="#section-4-1" class="pilcrow">¶</a></p>
-<div id="authenication-mechanisms">
-<section id="section-4.1">
-        <h3 id="name-authentication-mechanisms">
-<a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-authentication-mechanisms" class="section-name selfRef">Authentication Mechanisms</a>
-        </h3>
-<p id="section-4.1-1">The following mechanisms for determining Authenticated Identifiers
-are supported in this version of DMARC:<a href="#section-4.1-1" class="pilcrow">¶</a></p>
-<ul>
-<li id="section-4.1-2.1">
-            <p id="section-4.1-2.1.1">DKIM, <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>, which provides a domain-level identifier in the content of
-the "d=" tag of a verified DKIM-Signature header field.<a href="#section-4.1-2.1.1" class="pilcrow">¶</a></p>
+<p id="section-4-2">DMARC permits a Domain Owner or PSO to enable verification of a domain's
+use in an email message, to indicate the Domain Owner's or PSO's message
+handling preference regarding failed verification, and to request reports
+about use of the domain name.  All information about a Domain Owner's or
+PSO's DMARC policy is published and retrieved via the DNS.<a href="#section-4-2" class="pilcrow">¶</a></p>
+<p id="section-4-3">DMARC's verification function is based on whether the RFC5322.From
+domain is aligned with a domain name used in a supported authentication
+mechanism. <a href="#authentication-mechanisms" class="xref">Section 4.2</a> When a DMARC policy exists
+for the domain name found in the RFC5322.From header field, and that
+domain name is not verified through an aligned supported authentication
+mechanism, the handling of that message can be affected based on the
+DMARC policy when delivered to a participating receiver.<a href="#section-4-3" class="pilcrow">¶</a></p>
+<p id="section-4-4">A message satisfies the DMARC checks if at least one of the supported
+authentication mechanisms:<a href="#section-4-4" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-4-5">
+        <li id="section-4-5.1">
+          <p id="section-4-5.1.1">produces a "pass" result, and<a href="#section-4-5.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-4.1-2.2">
-            <p id="section-4.1-2.2.1">SPF, <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span>, which can authenticate both the domain found in
+<li id="section-4-5.2">
+          <p id="section-4-5.2.1">produces that result based on an identifier that is in alignment,
+as described in <a href="#identifier-alignment-explained" class="xref">Section 4.4</a>.<a href="#section-4-5.2.1" class="pilcrow">¶</a></p>
+</li>
+</ol>
+<p id="section-4-6">It is important to note that the authentication mechanisms employed
+by DMARC authenticate only a DNS domain and do not authenticate the
+local-part of any email address identifier found in a message, nor do
+they validate the legitimacy of message content.<a href="#section-4-6" class="pilcrow">¶</a></p>
+<p id="section-4-7">DMARC's feedback component involves the collection of information
+about received messages claiming to be from the Author Domain
+for periodic aggregate reports to the Domain Owner or PSO.  The
+parameters and format for such reports are discussed in
+<span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-4-7" class="pilcrow">¶</a></p>
+<p id="section-4-8">A DMARC-enabled Mail Receiver might also generate per-message reports
+that contain information related to individual messages that fail
+authentication checks. Per-message failure reports are a useful source of
+information when debugging deployments (if messages can be determined
+to be legitimate even though failing authentication) or in analyzing
+attacks.  The capability for such services is enabled by DMARC but
+defined in other referenced material such as <span>[<a href="#RFC6591" class="xref">RFC6591</a>]</span> and
+<span>[<a href="#DMARC-Failure-Reporting" class="xref">DMARC-Failure-Reporting</a>]</span><a href="#section-4-8" class="pilcrow">¶</a></p>
+<div id="use-of-rfc5322-from">
+<section id="section-4.1">
+        <h3 id="name-use-of-rfc5322from">
+<a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-use-of-rfc5322from" class="section-name selfRef">Use of RFC5322.From</a>
+        </h3>
+<p id="section-4.1-1">One of the most obvious points of security scrutiny for DMARC is the
+choice to focus on an identifier, namely the RFC5322.From address,
+which is part of a body of data that has been trivially forged
+throughout the history of email. This field is the one used by end
+users to identify the source of the message, and so it has always
+been a prime target for abuse through such forgery and other means.<a href="#section-4.1-1" class="pilcrow">¶</a></p>
+<p id="section-4.1-2">Several points suggest that it is the most correct and safest thing
+to do in this context:<a href="#section-4.1-2" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-4.1-3.1">
+            <p id="section-4.1-3.1.1">Of all the identifiers that are part of the message itself, this
+is the only one guaranteed to be present.<a href="#section-4.1-3.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4.1-3.2">
+            <p id="section-4.1-3.2.1">It seems the best choice of an identifier on which to focus, as
+most MUAs display some or all of the contents of that field in a
+manner strongly suggesting those data as reflective of the true
+originator of the message.<a href="#section-4.1-3.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4.1-3.3">
+            <p id="section-4.1-3.3.1">Many high-profile email sources, such as email service providers,
+require that the sending agent have authenticated before email
+can be generated.  Thus, for these mailboxes, the mechanism
+described in this document provides recipient end users with strong
+evidence that the message was indeed originated by the agent they
+associate with that mailbox, if the end user knows that these
+various protections have been provided.<a href="#section-4.1-3.3.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+<p id="section-4.1-4">The absence of a single, properly formed RFC5322.From header field renders
+the message invalid.  Handling of such a message is outside of the
+scope of this specification.<a href="#section-4.1-4" class="pilcrow">¶</a></p>
+<p id="section-4.1-5">Since the sorts of mail typically protected by DMARC participants
+tend to only have single Authors, DMARC participants generally
+operate under a slightly restricted profile of RFC5322 with respect
+to the expected syntax of this field.  See <a href="#mail-receiver-actions" class="xref">Section 5.7</a>
+for details.<a href="#section-4.1-5" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="authentication-mechanisms">
+<section id="section-4.2">
+        <h3 id="name-authentication-mechanisms">
+<a href="#section-4.2" class="section-number selfRef">4.2. </a><a href="#name-authentication-mechanisms" class="section-name selfRef">Authentication Mechanisms</a>
+        </h3>
+<p id="section-4.2-1">The following mechanisms for determining Authenticated Identifiers
+are supported in this version of DMARC:<a href="#section-4.2-1" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-4.2-2.1">
+            <p id="section-4.2-2.1.1">DKIM, <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>, which provides a domain-level identifier in the content of
+the "d=" tag of a verified DKIM-Signature header field.<a href="#section-4.2-2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4.2-2.2">
+            <p id="section-4.2-2.2.1">SPF, <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span>, which can authenticate both the domain found in
 an <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span> HELO/EHLO command (the HELO identity) and the domain
 found in an SMTP MAIL command (the MAIL FROM identity). As noted earlier,
 however, DMARC relies solely on SPF authentication of the domain found in
 SMTP MAIL FROM command. Section 2.4 of <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span> describes MAIL FROM
-processing for cases in which the MAIL command has a null path.<a href="#section-4.1-2.2.1" class="pilcrow">¶</a></p>
+processing for cases in which the MAIL command has a null path.<a href="#section-4.2-2.2.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
-</section>
-</div>
-<div id="key-concepts">
-<section id="section-4.2">
-        <h3 id="name-key-concepts">
-<a href="#section-4.2" class="section-number selfRef">4.2. </a><a href="#name-key-concepts" class="section-name selfRef">Key Concepts</a>
-        </h3>
-<p id="section-4.2-1">DMARC policies are published by the Domain Owner or PSO, and retrieved by
-the Mail Receiver during the SMTP session, via the DNS.<a href="#section-4.2-1" class="pilcrow">¶</a></p>
-<p id="section-4.2-2">DMARC's verification function is based on whether the RFC5322.From
-domain is aligned with an authenticated domain name from SPF or DKIM.<br>
-When a DMARC policy is published for the domain name found in the
-RFC5322.From header field, and that domain name is not verified
-through SPF or DKIM, the handling of that message can be affected
-by that DMARC policy when delivered to a participating receiver.<a href="#section-4.2-2" class="pilcrow">¶</a></p>
-<p id="section-4.2-3">It is important to note that the authentication mechanisms employed
-by DMARC authenticate only a DNS domain and do not authenticate the
-local-part of any email address identifier found in a message, nor do
-they validate the legitimacy of message content.<a href="#section-4.2-3" class="pilcrow">¶</a></p>
-<p id="section-4.2-4">DMARC's feedback component involves the collection of information
-about received messages claiming to be from the Author Domain
-for periodic aggregate reports to the Domain Owner or PSO.  The
-parameters and format for such reports are discussed in <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-4.2-4" class="pilcrow">¶</a></p>
-<p id="section-4.2-5">A DMARC-enabled Mail Receiver might also generate per-message reports
-that contain information related to individual messages that fail SPF
-and/or DKIM.  Per-message failure reports are a useful source of
-information when debugging deployments (if messages can be determined
-to be legitimate even though failing authentication) or in analyzing
-attacks.  The capability for such services is enabled by DMARC but
-defined in other referenced material such as <span>[<a href="#RFC6591" class="xref">RFC6591</a>]</span> and <span>[<a href="#DMARC-Failure-Reporting" class="xref">DMARC-Failure-Reporting</a>]</span><a href="#section-4.2-5" class="pilcrow">¶</a></p>
-<p id="section-4.2-6">A message satisfies the DMARC checks if at least one of the supported
-authentication mechanisms:<a href="#section-4.2-6" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-4.2-7">
-          <li id="section-4.2-7.1">
-            <p id="section-4.2-7.1.1">produces a "pass" result, and<a href="#section-4.2-7.1.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-4.2-7.2">
-            <p id="section-4.2-7.2.1">produces that result based on an identifier that is in alignment,
-as defined in <a href="#terminology" class="xref">Section 3</a>.<a href="#section-4.2-7.2.1" class="pilcrow">¶</a></p>
-</li>
-</ol>
 </section>
 </div>
 <div id="flow-diagram">
@@ -2331,92 +2196,221 @@ as defined in <a href="#terminology" class="xref">Section 3</a>.<a href="#sectio
   MDA = Mail Delivery Agent
 </pre><a href="#section-4.3-1" class="pilcrow">¶</a>
 </div>
-<p id="section-4.3-2">The above diagram shows a simple flow of messages through a DMARC-
-aware system.  Solid lines denote the actual message flow, dotted
-lines involve DNS queries used to retrieve message policy related to
-the supported message authentication schemes, and asterisk lines
-indicate data exchange between message-handling modules and message
-authentication modules.  "sMTA" is the sending MTA, and "rMTA" is the
-receiving MTA.<a href="#section-4.3-2" class="pilcrow">¶</a></p>
+<p id="section-4.3-2">The above diagram shows a simple flow of messages through a
+DMARC-aware system.  Solid lines denote the actual message flow,
+dotted lines involve DNS queries used to retrieve message policy
+related to the supported message authentication schemes, and asterisk
+lines indicate data exchange between message-handling modules and
+message authentication modules.  "sMTA" is the sending MTA, and "rMTA"
+is the receiving MTA.<a href="#section-4.3-2" class="pilcrow">¶</a></p>
 <p id="section-4.3-3">Put simply, when a message reaches a DMARC-aware rMTA, a DNS query
-will be initiated to determine if the author domain has published
-a DMARC policy. If a policy is found, the rMTA will use the results
+will be initiated to determine if a DMARC policy exists that applies
+to the author domain. If a policy is found, the rMTA will use the results
 of SPF and DKIM verification checks to determine the ultimate DMARC
 authentication status. The DMARC status can then factor into the
 message handling decision made by the recipient's mail sytsem.<a href="#section-4.3-3" class="pilcrow">¶</a></p>
 <p id="section-4.3-4">More details on specific actions for the parties involved can be
-found in <a href="#domain-owner-actions" class="xref">Section 6.5</a> and <a href="#mail-receiver-actions" class="xref">Section 6.7</a>.<a href="#section-4.3-4" class="pilcrow">¶</a></p>
+found in <a href="#domain-owner-actions" class="xref">Section 5.5</a> and <a href="#mail-receiver-actions" class="xref">Section 5.7</a>.<a href="#section-4.3-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="identifier-alignment-explained">
+<section id="section-4.4">
+        <h3 id="name-identifier-alignment-explai">
+<a href="#section-4.4" class="section-number selfRef">4.4. </a><a href="#name-identifier-alignment-explai" class="section-name selfRef">Identifier Alignment Explained</a>
+        </h3>
+<p id="section-4.4-1">Email authentication technologies authenticate various (and
+disparate) aspects of an individual message.  For example, DKIM <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>
+authenticates the domain that affixed a signature to the message,
+while SPF <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span> can authenticate either the domain that appears in the
+RFC5321.MailFrom (MAIL FROM) portion of an SMTP <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span> conversation or the
+RFC5321.EHLO/HELO domain, or both.  These may be different domains, and they
+are typically not visible to the end user.<a href="#section-4.4-1" class="pilcrow">¶</a></p>
+<p id="section-4.4-2">DMARC authenticates use of the RFC5322.From domain by requiring that
+it have the same Organizational Domain as (i.e., be aligned with) an
+Authenticated Identifier. Domain names in this context are to be compared
+in a case-insensitive manner, per <span>[<a href="#RFC4343" class="xref">RFC4343</a>]</span>.<a href="#section-4.4-2" class="pilcrow">¶</a></p>
+<p id="section-4.4-3">It is important to note that Identifier Alignment cannot occur with a
+message that is not valid per <span>[<a href="#RFC5322" class="xref">RFC5322</a>]</span>, particularly one with a
+malformed, absent, or repeated RFC5322.From header field, since in that case
+there is no reliable way to determine a DMARC policy that applies to
+the message.  Accordingly, DMARC operation is predicated on the input
+being a valid RFC5322 message object, and handling of such
+non-compliant cases is outside of the scope of this specification.
+Further discussion of this can be found in <a href="#extract-author-domain" class="xref">Section 5.7.1</a>.<a href="#section-4.4-3" class="pilcrow">¶</a></p>
+<p id="section-4.4-4">Each of the underlying authentication technologies that DMARC takes
+as input yields authenticated domains as their outputs when they
+succeed.<a href="#section-4.4-4" class="pilcrow">¶</a></p>
+<div id="dkim-identifiers">
+<section id="section-4.4.1">
+          <h4 id="name-dkim-authenticated-identifi">
+<a href="#section-4.4.1" class="section-number selfRef">4.4.1. </a><a href="#name-dkim-authenticated-identifi" class="section-name selfRef">DKIM-Authenticated Identifiers</a>
+          </h4>
+<p id="section-4.4.1-1">DMARC requires Identifier Alignment based on the result of a DKIM
+authentication because a message can bear a valid signature from any
+domain, including domains used by a mailing list or even a bad actor.
+Therefore, merely bearing a valid signature is not enough to infer
+authenticity of the Author Domain.<a href="#section-4.4.1-1" class="pilcrow">¶</a></p>
+<p id="section-4.4.1-2">DMARC permits Identifier Alignment based on the result of a DKIM
+authentication to be strict or relaxed. (Note that these terms are
+not related to DKIM's "simple" and "relaxed" canonicalization modes.)<a href="#section-4.4.1-2" class="pilcrow">¶</a></p>
+<p id="section-4.4.1-3">In relaxed mode, the Organizational Domains of both the DKIM-authenticated
+signing domain (taken from the value of the d= tag in the signature)
+and that of the RFC5322.From domain must be equal if the identifiers
+are to be considered to be aligned. In strict mode, only an exact match
+between both Fully Qualified Domain Names (FQDNs) is considered to produce
+Identifier Alignment.<a href="#section-4.4.1-3" class="pilcrow">¶</a></p>
+<p id="section-4.4.1-4">To illustrate, in relaxed mode, if a verified DKIM signature
+successfully verifies with a "d=" domain of "example.com", and the
+RFC5322.From address is "alerts@news.example.com", the DKIM "d="
+domain and the RFC5322.From domain are considered to be "in alignment",
+because both domains have the same Organizational Domain of "example.com".
+In strict mode, this test would fail because the d= domain does not
+exactly match the RFC5322.From domain.<a href="#section-4.4.1-4" class="pilcrow">¶</a></p>
+<p id="section-4.4.1-5">However, a DKIM signature bearing a value of "d=com" would never allow
+an "in alignment" result, as "com" should be identified as a PSD and
+therefore cannot be an Organizational Domain.<a href="#section-4.4.1-5" class="pilcrow">¶</a></p>
+<p id="section-4.4.1-6">Note that a single email can contain multiple DKIM signatures, and it
+is considered to produce a DMARC "pass" result if any DKIM signature
+is aligned and verifies.<a href="#section-4.4.1-6" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="spf-identifiers">
+<section id="section-4.4.2">
+          <h4 id="name-spf-authenticated-identifie">
+<a href="#section-4.4.2" class="section-number selfRef">4.4.2. </a><a href="#name-spf-authenticated-identifie" class="section-name selfRef">SPF-Authenticated Identifiers</a>
+          </h4>
+<p id="section-4.4.2-1">DMARC permits Identifier Alignment based on the result of an SPF
+authentication. As with DKIM, Identifier Alignement can be either
+strict or relaxed.<a href="#section-4.4.2-1" class="pilcrow">¶</a></p>
+<p id="section-4.4.2-2">In relaxed mode, the Organizational Domains of the SPF-authenticated
+domain and RFC5322.From domain must be equal if the identifiers are
+to be considered to be aligned. In strict mode, the two FQDNs must
+match exactly in order from them to be considered to be aligned.<a href="#section-4.4.2-2" class="pilcrow">¶</a></p>
+<p id="section-4.4.2-3">For example, in relaxed mode, if a message passes an SPF check with an
+RFC5321.MailFrom domain of "cbg.bounces.example.com", and the address
+portion of the RFC5322.From header field contains
+"payments@example.com", the Authenticated RFC5321.MailFrom domain
+identifier and the RFC5322.From domain are considered to be "in
+alignment" because they have the same Organizational Domain
+("example.com"). In strict mode, this test would fail because the
+two domains are not identical.<a href="#section-4.4.2-3" class="pilcrow">¶</a></p>
+<p id="section-4.4.2-4">The reader should note that SPF alignment checks in DMARC rely solely
+on the RFC5321.MailFrom domain. This differs from section 2.3 of
+<span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span>, which recommends that SPF checks be done on not only the
+"MAIL FROM" but also on a separate check of the "HELO" identity.<a href="#section-4.4.2-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="alignment-and-extension-technologies">
+<section id="section-4.4.3">
+          <h4 id="name-alignment-and-extension-tec">
+<a href="#section-4.4.3" class="section-number selfRef">4.4.3. </a><a href="#name-alignment-and-extension-tec" class="section-name selfRef">Alignment and Extension Technologies</a>
+          </h4>
+<p id="section-4.4.3-1">If in the future DMARC is extended to include the use of other
+authentication mechanisms, the extensions will need to allow for
+domain identifier extraction so that alignment with the RFC5322.From
+domain can be verified.<a href="#section-4.4.3-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
-<div id="use-of-rfc5322-from">
-<section id="section-5">
-      <h2 id="name-use-of-rfc5322from">
-<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-use-of-rfc5322from" class="section-name selfRef">Use of RFC5322.From</a>
-      </h2>
-<p id="section-5-1">One of the most obvious points of security scrutiny for DMARC is the
-choice to focus on an identifier, namely the RFC5322.From address,
-which is part of a body of data that has been trivially forged
-throughout the history of email. This field is the one used by end
-users to identify the source of the message, and so it has always
-been a prime target for abuse through such forgery and other means.<a href="#section-5-1" class="pilcrow">¶</a></p>
-<p id="section-5-2">Several points suggest that it is the most correct and safest thing
-to do in this context:<a href="#section-5-2" class="pilcrow">¶</a></p>
-<ul>
-<li id="section-5-3.1">
-          <p id="section-5-3.1.1">Of all the identifiers that are part of the message itself, this
-is the only one guaranteed to be present.<a href="#section-5-3.1.1" class="pilcrow">¶</a></p>
+<div id="determining-the-organizational-domain">
+<section id="section-4.5">
+        <h3 id="name-determining-the-organizatio">
+<a href="#section-4.5" class="section-number selfRef">4.5. </a><a href="#name-determining-the-organizatio" class="section-name selfRef">Determining The Organizational Domain</a>
+        </h3>
+<p id="section-4.5-1">The DMARC protocol defines a method for a Public Suffix Domain to identify
+itself as such using a tag in its published DMARC policy record. An Organizational
+Domain is any subdomain of a PSD that includes exactly one more label than
+the PSD in its name.<a href="#section-4.5-1" class="pilcrow">¶</a></p>
+<p id="section-4.5-2">For any email message, the Organizational Domain of the RFC5322.From domain
+is determined using the following algorithm, similar to the one described
+in <a href="#policy-discovery" class="xref">Section 5.7.3</a><a href="#section-4.5-2" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-4.5-3">
+          <li id="section-4.5-3.1">
+            <p id="section-4.5-3.1.1">Query the DNS for a DMARC TXT record at the DNS domain matching the one
+found in the RFC5322.From domain in the message.  A possibly empty set
+of records is returned.<a href="#section-4.5-3.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-5-3.2">
-          <p id="section-5-3.2.1">It seems the best choice of an identifier on which to focus, as
-most MUAs display some or all of the contents of that field in a
-manner strongly suggesting those data as reflective of the true
-originator of the message.<a href="#section-5-3.2.1" class="pilcrow">¶</a></p>
+<li id="section-4.5-3.2">
+            <p id="section-4.5-3.2.1">Records that do not start with a "v=" tag that identifies the
+current version of DMARC are discarded.<a href="#section-4.5-3.2.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-5-3.3">
-          <p id="section-5-3.3.1">Many high-profile email sources, such as email service providers,
-require that the sending agent have authenticated before email
-can be generated.  Thus, for these mailboxes, the mechanism
-described in this document provides recipient end users with strong
-evidence that the message was indeed originated by the agent they
-associate with that mailbox, if the end user knows that these
-various protections have been provided.<a href="#section-5-3.3.1" class="pilcrow">¶</a></p>
+<li id="section-4.5-3.3">
+            <p id="section-4.5-3.3.1">If the set is now empty, or the set contains one valid DMARC record that
+does not include a psd tag with a value of 'y', then determine the target for
+additional queries, using steps 4 through 8 below.<a href="#section-4.5-3.3.1" class="pilcrow">¶</a></p>
 </li>
-</ul>
-<p id="section-5-4">The absence of a single, properly formed RFC5322.From header field renders
-the message invalid.  Handling of such a message is outside of the
-scope of this specification.<a href="#section-5-4" class="pilcrow">¶</a></p>
-<p id="section-5-5">Since the sorts of mail typically protected by DMARC participants
-tend to only have single Authors, DMARC participants generally
-operate under a slightly restricted profile of RFC5322 with respect
-to the expected syntax of this field.  See <a href="#mail-receiver-actions" class="xref">Section 6.7</a>
-for details.<a href="#section-5-5" class="pilcrow">¶</a></p>
+<li id="section-4.5-3.4">
+            <p id="section-4.5-3.4.1">Break the subject DNS domain name into a set of "n" ordered
+labels.  Number these labels from right to left; e.g., for
+"a.mail.example.com", "com" would be label 1 and "example" would be
+label 2 and so forth.<a href="#section-4.5-3.4.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4.5-3.5">
+            <p id="section-4.5-3.5.1">Count the number of labels found in the subject DNS domain. Let that
+number be "x". If x &lt; 5, remove the left-most (highest-numbered)
+label from the subject domain. If x &gt;= 5, remove the left-most
+(highest-numbered) labels from the subject domain until 4 labels remain.
+The resulting DNS domain name is the new target for subsequent lookups.<a href="#section-4.5-3.5.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4.5-3.6">
+            <p id="section-4.5-3.6.1">Query the DNS for a DMARC TXT record at the DNS domain matching this
+new target in place of the RFC5322.From domain in the message.  A possibly
+empty set of records is returned.<a href="#section-4.5-3.6.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4.5-3.7">
+            <p id="section-4.5-3.7.1">Records that do not start with a "v=" tag that identifies the
+current version of DMARC are discarded.<a href="#section-4.5-3.7.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4.5-3.8">
+            <p id="section-4.5-3.8.1">If the set is now empty, or the set contains one valid DMARC record that
+does not include a psd tag with the value of 'y', then determine the
+target for additional queries by removing a single label from the target
+domain as described in step 5 and repeating steps 6 and 7 until
+there are no more labels remaining or a record containing a psd tag with
+a value of 'y' is found.<a href="#section-4.5-3.8.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4.5-3.9">
+            <p id="section-4.5-3.9.1">Once a valid DMARC record containing a psd tag with a value of 'y' has
+been found, the Organizational Domain for the DNS domain matching the
+one found in the RFC5322.From domain can be declared to be the target
+domain queried for in the step prior to the query that found the PSD
+domain.<a href="#section-4.5-3.9.1" class="pilcrow">¶</a></p>
+</li>
+</ol>
+<p id="section-4.5-4">For example, given the RFC5322.From domain "a.mail.example.com", a series
+of DNS queries for DMARC records would be executed starting with
+"<em>dmarc.a.mail.example.com" and finishing with "</em>dmarc.com". The "<em>dmarc.com"
+record would contain a psd tag with a value of 'y', and so the Organizational
+Domain for this RFC5322.From domain would be determined to be "example.com",
+the domain of the DMARC query executed prior to the query for "</em>dmarc.com".<a href="#section-4.5-4" class="pilcrow">¶</a></p>
+</section>
+</div>
 </section>
 </div>
 <div id="policy">
-<section id="section-6">
+<section id="section-5">
       <h2 id="name-policy">
-<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-policy" class="section-name selfRef">Policy</a>
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-policy" class="section-name selfRef">Policy</a>
       </h2>
-<p id="section-6-1">DMARC policies are published by Domain Owners and PSOs and can be
-used by Mail Receivers to inform their message handling decisions.<a href="#section-6-1" class="pilcrow">¶</a></p>
-<p id="section-6-2">A Domain Owner or PSO advertises DMARC participation of one or more of its
-domains by adding a DNS TXT record (described in <a href="#dmarc-policy-record" class="xref">Section 6.1</a>) to
+<p id="section-5-1">DMARC policies are published by Domain Owners and PSOs and can be
+used by Mail Receivers to inform their message handling decisions.<a href="#section-5-1" class="pilcrow">¶</a></p>
+<p id="section-5-2">A Domain Owner or PSO advertises DMARC participation of one or more of its
+domains by adding a DNS TXT record (described in <a href="#dmarc-policy-record" class="xref">Section 5.1</a>) to
 those domains.  In doing so, Domain Owners and PSOs indicate their handling
 preference regarding failed authentication for email messages making use
 of their domain in the RFC5322.From header field as well as the provision
 of feedback about those messages. Mail Receivers in turn can take into
 account the Domain Owner's stated preference when making handling
-decisions about email messages that fail DMARC authentication checks.<a href="#section-6-2" class="pilcrow">¶</a></p>
-<p id="section-6-3">A Domain Owner or PSO may choose not to participate in DMARC evaluation by
+decisions about email messages that fail DMARC authentication checks.<a href="#section-5-2" class="pilcrow">¶</a></p>
+<p id="section-5-3">A Domain Owner or PSO may choose not to participate in DMARC evaluation by
 Mail Receivers.  In this case, the Domain Owner simply declines to
 advertise participation in those schemes.  For example, if the
 results of path authorization checks ought not be considered as part
 of the overall DMARC result for a given Author Domain, then the
 Domain Owner does not publish an SPF policy record that can produce
-an SPF pass result.<a href="#section-6-3" class="pilcrow">¶</a></p>
-<p id="section-6-4">A Mail Receiver implementing the DMARC mechanism SHOULD make a
+an SPF pass result.<a href="#section-5-3" class="pilcrow">¶</a></p>
+<p id="section-5-4">A Mail Receiver implementing the DMARC mechanism SHOULD make a
 best-effort attempt to adhere to the Domain Owner's or PSO's published DMARC
 Domain Owner Assessment Policy when a message fails the DMARC test.<br>
 Since email streams can be complicated (due to forwarding, existing RFC5322.From
@@ -2424,21 +2418,21 @@ domain-spoofing services, etc.), Mail Receivers MAY deviate from a published
 Domain Owner Assessment Policy during message processing and SHOULD
 make available the fact of and reason for the deviation to the Domain
 Owner via feedback reporting, specifically using the "PolicyOverride"
-feature of the aggregate report defined in <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-6-4" class="pilcrow">¶</a></p>
+feature of the aggregate report defined in <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-5-4" class="pilcrow">¶</a></p>
 <div id="dmarc-policy-record">
-<section id="section-6.1">
+<section id="section-5.1">
         <h3 id="name-dmarc-policy-record">
-<a href="#section-6.1" class="section-number selfRef">6.1. </a><a href="#name-dmarc-policy-record" class="section-name selfRef">DMARC Policy Record</a>
+<a href="#section-5.1" class="section-number selfRef">5.1. </a><a href="#name-dmarc-policy-record" class="section-name selfRef">DMARC Policy Record</a>
         </h3>
-<p id="section-6.1-1">Domain Owner and PSO DMARC preferences are stored as DNS TXT records in
+<p id="section-5.1-1">Domain Owner and PSO DMARC preferences are stored as DNS TXT records in
 subdomains named "_dmarc".  For example, the Domain Owner of
 "example.com" would post DMARC preferences in a TXT record at
 "_dmarc.example.com".  Similarly, a Mail Receiver wishing to query
 for DMARC preferences regarding mail with an RFC5322.From domain of
 "example.com" would issue a TXT query to the DNS for the subdomain of
 "_dmarc.example.com".  The DNS-located DMARC preference data will
-hereafter be called the "DMARC record".<a href="#section-6.1-1" class="pilcrow">¶</a></p>
-<p id="section-6.1-2">DMARC's use of the Domain Name Service is driven by DMARC's use of
+hereafter be called the "DMARC record".<a href="#section-5.1-1" class="pilcrow">¶</a></p>
+<p id="section-5.1-2">DMARC's use of the Domain Name Service is driven by DMARC's use of
 domain names and the nature of the query it performs.  The query
 requirement matches with the DNS, for obtaining simple parametric
 information.  It uses an established method of storing the
@@ -2446,91 +2440,91 @@ information, associated with the target domain name, namely an
 isolated TXT record that is restricted to the DMARC context.  Use of
 the DNS as the query service has the benefit of reusing an extremely
 well-established operations, administration, and management
-infrastructure, rather than creating a new one.<a href="#section-6.1-2" class="pilcrow">¶</a></p>
-<p id="section-6.1-3">Per <span>[<a href="#RFC1035" class="xref">RFC1035</a>]</span>, a TXT record can comprise several "character-string"
+infrastructure, rather than creating a new one.<a href="#section-5.1-2" class="pilcrow">¶</a></p>
+<p id="section-5.1-3">Per <span>[<a href="#RFC1035" class="xref">RFC1035</a>]</span>, a TXT record can comprise several "character-string"
 objects.  Where this is the case, the module performing DMARC
 evaluation MUST concatenate these strings by joining together the
-objects in order and parsing the result as a single string.<a href="#section-6.1-3" class="pilcrow">¶</a></p>
+objects in order and parsing the result as a single string.<a href="#section-5.1-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="dmarc-uris">
-<section id="section-6.2">
+<section id="section-5.2">
         <h3 id="name-dmarc-uris">
-<a href="#section-6.2" class="section-number selfRef">6.2. </a><a href="#name-dmarc-uris" class="section-name selfRef">DMARC URIs</a>
+<a href="#section-5.2" class="section-number selfRef">5.2. </a><a href="#name-dmarc-uris" class="section-name selfRef">DMARC URIs</a>
         </h3>
-<p id="section-6.2-1"><span>[<a href="#RFC3986" class="xref">RFC3986</a>]</span> defines a generic syntax for identifying a resource.  The DMARC
+<p id="section-5.2-1"><span>[<a href="#RFC3986" class="xref">RFC3986</a>]</span> defines a generic syntax for identifying a resource.  The DMARC
 mechanism uses this as the format by which a Domain Owner or PSO specifies
-the destination for the two report types that are supported.<a href="#section-6.2-1" class="pilcrow">¶</a></p>
-<p id="section-6.2-2">The place such URIs are specified (see <a href="#general-record-format" class="xref">Section 6.3</a>) allows
+the destination for the two report types that are supported.<a href="#section-5.2-1" class="pilcrow">¶</a></p>
+<p id="section-5.2-2">The place such URIs are specified (see <a href="#general-record-format" class="xref">Section 5.3</a>) allows
 a list of these to be provided.  The list of URIs is separated by commas
 (ASCII 0x2c).  A report SHOULD be sent to each listed URI provided in
-the DMARC record.<a href="#section-6.2-2" class="pilcrow">¶</a></p>
-<p id="section-6.2-3">A formal definition is provided in <a href="#formal-definition" class="xref">Section 6.4</a>.<a href="#section-6.2-3" class="pilcrow">¶</a></p>
+the DMARC record.<a href="#section-5.2-2" class="pilcrow">¶</a></p>
+<p id="section-5.2-3">A formal definition is provided in <a href="#formal-definition" class="xref">Section 5.4</a>.<a href="#section-5.2-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="general-record-format">
-<section id="section-6.3">
+<section id="section-5.3">
         <h3 id="name-general-record-format">
-<a href="#section-6.3" class="section-number selfRef">6.3. </a><a href="#name-general-record-format" class="section-name selfRef">General Record Format</a>
+<a href="#section-5.3" class="section-number selfRef">5.3. </a><a href="#name-general-record-format" class="section-name selfRef">General Record Format</a>
         </h3>
-<p id="section-6.3-1">DMARC records follow the extensible "tag-value" syntax for DNS-based
-key records defined in DKIM <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>.<a href="#section-6.3-1" class="pilcrow">¶</a></p>
-<p id="section-6.3-2"><a href="#iana-considerations" class="xref">Section 9</a> creates a registry for known DMARC tags and
+<p id="section-5.3-1">DMARC records follow the extensible "tag-value" syntax for DNS-based
+key records defined in DKIM <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>.<a href="#section-5.3-1" class="pilcrow">¶</a></p>
+<p id="section-5.3-2"><a href="#iana-considerations" class="xref">Section 8</a> creates a registry for known DMARC tags and
 registers the initial set defined in this document.  Only tags defined
 in this document or in later extensions, and thus added to that registry,
-are to be processed; unknown tags MUST be ignored.<a href="#section-6.3-2" class="pilcrow">¶</a></p>
-<p id="section-6.3-3">The following tags are valid DMARC tags:<a href="#section-6.3-3" class="pilcrow">¶</a></p>
-<dl class="dlParallel" id="section-6.3-4">
-          <dt id="section-6.3-4.1">adkim:</dt>
-<dd id="section-6.3-4.2">
-            <p id="section-6.3-4.2.1">(plain-text; OPTIONAL; default is "r".)  Indicates whether
+are to be processed; unknown tags MUST be ignored.<a href="#section-5.3-2" class="pilcrow">¶</a></p>
+<p id="section-5.3-3">The following tags are valid DMARC tags:<a href="#section-5.3-3" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-5.3-4">
+          <dt id="section-5.3-4.1">adkim:</dt>
+<dd id="section-5.3-4.2">
+            <p id="section-5.3-4.2.1">(plain-text; OPTIONAL; default is "r".)  Indicates whether
 strict or relaxed DKIM Identifier Alignment mode is required by
-the Domain Owner.  See <a href="#dkim-identifiers" class="xref">Section 3.3.1</a> for details.  Valid values
-are as follows:<a href="#section-6.3-4.2.1" class="pilcrow">¶</a></p>
-<dl class="dlParallel" id="section-6.3-4.2.2">
-              <dt id="section-6.3-4.2.2.1">r:</dt>
-<dd id="section-6.3-4.2.2.2">relaxed mode<a href="#section-6.3-4.2.2.2" class="pilcrow">¶</a>
+the Domain Owner.  See <a href="#dkim-identifiers" class="xref">Section 4.4.1</a> for details.  Valid values
+are as follows:<a href="#section-5.3-4.2.1" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-5.3-4.2.2">
+              <dt id="section-5.3-4.2.2.1">r:</dt>
+<dd id="section-5.3-4.2.2.2">relaxed mode<a href="#section-5.3-4.2.2.2" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-4.2.2.3">s:</dt>
-<dd id="section-6.3-4.2.2.4">strict mode<a href="#section-6.3-4.2.2.4" class="pilcrow">¶</a>
+<dt id="section-5.3-4.2.2.3">s:</dt>
+<dd id="section-5.3-4.2.2.4">strict mode<a href="#section-5.3-4.2.2.4" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
 </dl>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-4.3">aspf:</dt>
-<dd id="section-6.3-4.4">
-            <p id="section-6.3-4.4.1">(plain-text; OPTIONAL; default is "r".)  Indicates whether
+<dt id="section-5.3-4.3">aspf:</dt>
+<dd id="section-5.3-4.4">
+            <p id="section-5.3-4.4.1">(plain-text; OPTIONAL; default is "r".)  Indicates whether
 strict or relaxed SPF Identifier Alignment mode is required by the
-Domain Owner.  See <a href="#spf-identifiers" class="xref">Section 3.3.2</a> for details.  Valid values are as
-follows:<a href="#section-6.3-4.4.1" class="pilcrow">¶</a></p>
-<dl class="dlParallel" id="section-6.3-4.4.2">
-              <dt id="section-6.3-4.4.2.1">r:</dt>
-<dd id="section-6.3-4.4.2.2">relaxed mode<a href="#section-6.3-4.4.2.2" class="pilcrow">¶</a>
+Domain Owner.  See <a href="#spf-identifiers" class="xref">Section 4.4.2</a> for details.  Valid values are as
+follows:<a href="#section-5.3-4.4.1" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-5.3-4.4.2">
+              <dt id="section-5.3-4.4.2.1">r:</dt>
+<dd id="section-5.3-4.4.2.2">relaxed mode<a href="#section-5.3-4.4.2.2" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-4.4.2.3">s:</dt>
-<dd id="section-6.3-4.4.2.4">strict mode<a href="#section-6.3-4.4.2.4" class="pilcrow">¶</a>
+<dt id="section-5.3-4.4.2.3">s:</dt>
+<dd id="section-5.3-4.4.2.4">strict mode<a href="#section-5.3-4.4.2.4" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
 </dl>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-4.5">fo:</dt>
-<dd id="section-6.3-4.6">
-            <p id="section-6.3-4.6.1">Failure reporting options (plain-text; OPTIONAL; default is "0")
+<dt id="section-5.3-4.5">fo:</dt>
+<dd id="section-5.3-4.6">
+            <p id="section-5.3-4.6.1">Failure reporting options (plain-text; OPTIONAL; default is "0")
 Provides requested options for generation of failure reports.
 Report generators MAY choose to adhere to the requested options.
 This tag's content MUST be ignored if a "ruf" tag (below) is not
 also specified.  Failure reporting options are shown below. The value
 of this tag is either "0", "1", or a colon-separated list of the
-options represented by alphabetic characters.<a href="#section-6.3-4.6.1" class="pilcrow">¶</a></p>
+options represented by alphabetic characters.<a href="#section-5.3-4.6.1" class="pilcrow">¶</a></p>
 </dd>
 <dd class="break"></dd>
 </dl>
-<p id="section-6.3-5">The valid values and their meanings are:<a href="#section-6.3-5" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-6.3-6">
+<p id="section-5.3-5">The valid values and their meanings are:<a href="#section-5.3-5" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-5.3-6">
 <pre>0:
 :  Generate a DMARC failure report if all underlying
    authentication mechanisms fail to produce an aligned "pass"
@@ -2550,11 +2544,11 @@ s:
 :  Generate an SPF failure report if the message failed SPF
    evaluation, regardless of its alignment.  SPF-specific
    reporting is described in [@!RFC6652].
-</pre><a href="#section-6.3-6" class="pilcrow">¶</a>
+</pre><a href="#section-5.3-6" class="pilcrow">¶</a>
 </div>
-<dl class="dlParallel" id="section-6.3-7">
-          <dt id="section-6.3-7.1">np:</dt>
-<dd id="section-6.3-7.2">Domain Owner Assessment Policy for non-existent subdomains
+<dl class="dlParallel" id="section-5.3-7">
+          <dt id="section-5.3-7.1">np:</dt>
+<dd id="section-5.3-7.2">Domain Owner Assessment Policy for non-existent subdomains
 (plain-text; OPTIONAL).  Indicates the message handling preference
 that the Domain Owner or PSO has for mail using non-existent subdomains
 of the domain queried. It applies only to non-existent subdomains of
@@ -2566,77 +2560,77 @@ policy specified by the "p" tag, if the "sp" tag is not present,
 MUST be applied for non-existent subdomains.  Note that "np" will
 be ignored for DMARC records published on subdomains of Organizational
 Domains and PSDs due to the effect of the DMARC policy discovery
-mechanism described in <a href="#policy-discovery" class="xref">Section 6.7.3</a>.<a href="#section-6.3-7.2" class="pilcrow">¶</a>
+mechanism described in <a href="#policy-discovery" class="xref">Section 5.7.3</a>.<a href="#section-5.3-7.2" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-7.3">p:</dt>
-<dd id="section-6.3-7.4">
-            <p id="section-6.3-7.4.1">Domain Owner Assessment Policy (plain-text; RECOMMENDED for policy
+<dt id="section-5.3-7.3">p:</dt>
+<dd id="section-5.3-7.4">
+            <p id="section-5.3-7.4.1">Domain Owner Assessment Policy (plain-text; RECOMMENDED for policy
 records). Indicates the message handling preference the Domain Owner or
 PSO has for mail using its domain but not passing DMARC verification.
 Policy applies to the domain queried and to subdomains, unless
 subdomain policy is explicitly described using the "sp" or "np" tags.
 This tag is mandatory for policy records only, but not for third-party
 reporting records (see <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> and <span>[<a href="#DMARC-Failure-Reporting" class="xref">DMARC-Failure-Reporting</a>]</span>)
-Possible values are as follows:<a href="#section-6.3-7.4.1" class="pilcrow">¶</a></p>
-<dl class="dlParallel" id="section-6.3-7.4.2">
-              <dt id="section-6.3-7.4.2.1">none:</dt>
-<dd id="section-6.3-7.4.2.2">The Domain Owner offers no expression of concern.<a href="#section-6.3-7.4.2.2" class="pilcrow">¶</a>
+Possible values are as follows:<a href="#section-5.3-7.4.1" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-5.3-7.4.2">
+              <dt id="section-5.3-7.4.2.1">none:</dt>
+<dd id="section-5.3-7.4.2.2">The Domain Owner offers no expression of concern.<a href="#section-5.3-7.4.2.2" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-7.4.2.3">quarantine:</dt>
-<dd id="section-6.3-7.4.2.4">The Domain Owner considers such mail to be suspicious. It
+<dt id="section-5.3-7.4.2.3">quarantine:</dt>
+<dd id="section-5.3-7.4.2.4">The Domain Owner considers such mail to be suspicious. It
 is possible the mail is valid, although the failure creates
-a significant concern.<a href="#section-6.3-7.4.2.4" class="pilcrow">¶</a>
+a significant concern.<a href="#section-5.3-7.4.2.4" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-7.4.2.5">reject:</dt>
-<dd id="section-6.3-7.4.2.6">The Domain Owner considers all such failures to be a clear
+<dt id="section-5.3-7.4.2.5">reject:</dt>
+<dd id="section-5.3-7.4.2.6">The Domain Owner considers all such failures to be a clear
 indication that the use of the domain name is not valid. See
-<a href="#rejecting-messages" class="xref">Section 8.3</a> for some discussion of SMTP rejection
-methods and their implications.<a href="#section-6.3-7.4.2.6" class="pilcrow">¶</a>
+<a href="#rejecting-messages" class="xref">Section 7.3</a> for some discussion of SMTP rejection
+methods and their implications.<a href="#section-5.3-7.4.2.6" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
 </dl>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-7.5">psd:</dt>
-<dd id="section-6.3-7.6">
-            <p id="section-6.3-7.6.1">A flag indicating whether the domain is a PSD. (plain-text; OPTIONAL;
-default is 'n'). Possible values are:<a href="#section-6.3-7.6.1" class="pilcrow">¶</a></p>
-<dl class="dlParallel" id="section-6.3-7.6.2">
-              <dt id="section-6.3-7.6.2.1">y:</dt>
-<dd id="section-6.3-7.6.2.2">Domains on the PSL that publish DMARC policy records SHOULD include
+<dt id="section-5.3-7.5">psd:</dt>
+<dd id="section-5.3-7.6">
+            <p id="section-5.3-7.6.1">A flag indicating whether the domain is a PSD. (plain-text; OPTIONAL;
+default is 'n'). Possible values are:<a href="#section-5.3-7.6.1" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-5.3-7.6.2">
+              <dt id="section-5.3-7.6.2.1">y:</dt>
+<dd id="section-5.3-7.6.2.2">Domains on the PSL that publish DMARC policy records SHOULD include
 this tag with a value of 'y' to indicate that the domain is a PSD. This
 information will be used during policy discovery to determine how to
-apply any DMARC policy records that are discovered during the tree walk.<a href="#section-6.3-7.6.2.2" class="pilcrow">¶</a>
+apply any DMARC policy records that are discovered during the tree walk.<a href="#section-5.3-7.6.2.2" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-7.6.2.3">n:</dt>
-<dd id="section-6.3-7.6.2.4">The default, indicating that the DMARC policy record is published
-for a domain that is not a PSD.<a href="#section-6.3-7.6.2.4" class="pilcrow">¶</a>
+<dt id="section-5.3-7.6.2.3">n:</dt>
+<dd id="section-5.3-7.6.2.4">The default, indicating that the DMARC policy record is published
+for a domain that is not a PSD.<a href="#section-5.3-7.6.2.4" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
 </dl>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-7.7">rua:</dt>
-<dd id="section-6.3-7.8">
-            <p id="section-6.3-7.8.1">Addresses to which aggregate feedback is to be sent (comma-
+<dt id="section-5.3-7.7">rua:</dt>
+<dd id="section-5.3-7.8">
+            <p id="section-5.3-7.8.1">Addresses to which aggregate feedback is to be sent (comma-
 separated plain-text list of DMARC URIs; OPTIONAL).  Section 3 of <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span>
 discusses considerations that apply when the domain name of a URI differs
-from that of the domain advertising the policy.  See <a href="#external-report-addresses" class="xref">Section 10.5</a>
+from that of the domain advertising the policy.  See <a href="#external-report-addresses" class="xref">Section 9.5</a>
 for additional considerations.  Any valid URI can be specified.<br>
 A Mail Receiver MUST implement support for a "mailto:" URI, i.e., the
 ability to send a DMARC report via electronic mail.  If not provided,
 Mail Receivers MUST NOT generate aggregate feedback reports.  URIs
 not supported by Mail Receivers MUST be ignored.  The aggregate
-feedback report format is described in <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-6.3-7.8.1" class="pilcrow">¶</a></p>
+feedback report format is described in <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-5.3-7.8.1" class="pilcrow">¶</a></p>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-7.9">ruf:</dt>
-<dd id="section-6.3-7.10">
-            <p id="section-6.3-7.10.1">Addresses to which message-specific failure information is to
+<dt id="section-5.3-7.9">ruf:</dt>
+<dd id="section-5.3-7.10">
+            <p id="section-5.3-7.10.1">Addresses to which message-specific failure information is to
 be reported (comma-separated plain-text list of DMARC URIs;
 OPTIONAL).  If present, the Domain Owner or PSO is requesting Mail
 Receivers to send detailed failure reports about messages that
@@ -2647,13 +2641,13 @@ considerations that apply when the domain name of a URI differs
 from that of the domain advertising the policy.  A Mail Receiver
 MUST implement support for a "mailto:" URI, i.e., the ability to
 send a DMARC report via electronic mail.  If not provided, Mail
-Receivers MUST NOT generate failure reports.  See <a href="#external-report-addresses" class="xref">Section 10.5</a> for
-additional considerations.<a href="#section-6.3-7.10.1" class="pilcrow">¶</a></p>
+Receivers MUST NOT generate failure reports.  See <a href="#external-report-addresses" class="xref">Section 9.5</a> for
+additional considerations.<a href="#section-5.3-7.10.1" class="pilcrow">¶</a></p>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-7.11">sp:</dt>
-<dd id="section-6.3-7.12">
-            <p id="section-6.3-7.12.1">Domain Owner Assessment Policy for all subdomains (plain-text;
+<dt id="section-5.3-7.11">sp:</dt>
+<dd id="section-5.3-7.12">
+            <p id="section-5.3-7.12.1">Domain Owner Assessment Policy for all subdomains (plain-text;
 OPTIONAL). Indicates the message handling preference the Domain Owner
 or PSO has for mail using an existing subdomain of the domain queried
 but not passing DMARC verification.  It applies only to subdomains of
@@ -2663,64 +2657,64 @@ tag is absent and the "np" tag is either absent or not applicable,
 the policy specified by the "p" tag MUST be applied for subdomains.
 Note that "sp" will be ignored for DMARC records published on
 subdomains of Organizational Domains due to the effect of the
-DMARC policy discovery mechanism described in <a href="#policy-discovery" class="xref">Section 6.7.3</a>.<a href="#section-6.3-7.12.1" class="pilcrow">¶</a></p>
+DMARC policy discovery mechanism described in <a href="#policy-discovery" class="xref">Section 5.7.3</a>.<a href="#section-5.3-7.12.1" class="pilcrow">¶</a></p>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-7.13">t:</dt>
-<dd id="section-6.3-7.14">
-            <p id="section-6.3-7.14.1">DMARC policy test mode (plain-text; OPTIONAL; default is 'n'). For
+<dt id="section-5.3-7.13">t:</dt>
+<dd id="section-5.3-7.14">
+            <p id="section-5.3-7.14.1">DMARC policy test mode (plain-text; OPTIONAL; default is 'n'). For
 the RFC5322.From domain to which the DMARC record applies, the "t"
 tag serves as a signal to the actor performing DMARC verification checks
 as to whether or not the domain owner wishes the assessment policy
 declared in the "p=", "sp=", and/or "np=" tags to actually be applied. This
 parameter does not affect the generation of DMARC reports.  Possible values
-are as follows:<a href="#section-6.3-7.14.1" class="pilcrow">¶</a></p>
-<dl class="dlParallel" id="section-6.3-7.14.2">
-              <dt id="section-6.3-7.14.2.1">y:</dt>
-<dd id="section-6.3-7.14.2.2">A request that the actor performing the DMARC verification check not
+are as follows:<a href="#section-5.3-7.14.1" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-5.3-7.14.2">
+              <dt id="section-5.3-7.14.2.1">y:</dt>
+<dd id="section-5.3-7.14.2.2">A request that the actor performing the DMARC verification check not
 apply the policy, but instead apply any special handling rules it might have
 in place, such as rewriting the RFC5322.From header.  The domain owner is
-currently testing its specified DMARC assessment policy.<a href="#section-6.3-7.14.2.2" class="pilcrow">¶</a>
+currently testing its specified DMARC assessment policy.<a href="#section-5.3-7.14.2.2" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-7.14.2.3">n:</dt>
-<dd id="section-6.3-7.14.2.4">The default, a request to apply the policy as specified to any
-message that produces a DMARC "fail" result.<a href="#section-6.3-7.14.2.4" class="pilcrow">¶</a>
+<dt id="section-5.3-7.14.2.3">n:</dt>
+<dd id="section-5.3-7.14.2.4">The default, a request to apply the policy as specified to any
+message that produces a DMARC "fail" result.<a href="#section-5.3-7.14.2.4" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
 </dl>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-7.15">v:</dt>
-<dd id="section-6.3-7.16">
-            <p id="section-6.3-7.16.1">Version (plain-text; REQUIRED).  Identifies the record retrieved
+<dt id="section-5.3-7.15">v:</dt>
+<dd id="section-5.3-7.16">
+            <p id="section-5.3-7.16.1">Version (plain-text; REQUIRED).  Identifies the record retrieved
 as a DMARC record.  It MUST have the value of "DMARC1".  The value
 of this tag MUST match precisely; if it does not or it is absent,
 the entire retrieved record MUST be ignored.  It MUST be the first
-tag in the list.<a href="#section-6.3-7.16.1" class="pilcrow">¶</a></p>
+tag in the list.<a href="#section-5.3-7.16.1" class="pilcrow">¶</a></p>
 </dd>
 <dd class="break"></dd>
 </dl>
-<p id="section-6.3-8">A DMARC policy record MUST comply with the formal specification found
-in <a href="#formal-definition" class="xref">Section 6.4</a> in that the "v" tag MUST be present and MUST
+<p id="section-5.3-8">A DMARC policy record MUST comply with the formal specification found
+in <a href="#formal-definition" class="xref">Section 5.4</a> in that the "v" tag MUST be present and MUST
 appear first.  Unknown tags MUST be ignored.  Syntax errors
 in the remainder of the record SHOULD be discarded in favor of
-default values (if any) or ignored outright.<a href="#section-6.3-8" class="pilcrow">¶</a></p>
-<p id="section-6.3-9">Note that given the rules of the previous paragraph, addition of a
+default values (if any) or ignored outright.<a href="#section-5.3-8" class="pilcrow">¶</a></p>
+<p id="section-5.3-9">Note that given the rules of the previous paragraph, addition of a
 new tag into the registered list of tags does not itself require a
 new version of DMARC to be generated (with a corresponding change to
 the "v" tag's value), but a change to any existing tags does require
-a new version of DMARC.<a href="#section-6.3-9" class="pilcrow">¶</a></p>
+a new version of DMARC.<a href="#section-5.3-9" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="formal-definition">
-<section id="section-6.4">
+<section id="section-5.4">
         <h3 id="name-formal-definition">
-<a href="#section-6.4" class="section-number selfRef">6.4. </a><a href="#name-formal-definition" class="section-name selfRef">Formal Definition</a>
+<a href="#section-5.4" class="section-number selfRef">5.4. </a><a href="#name-formal-definition" class="section-name selfRef">Formal Definition</a>
         </h3>
-<p id="section-6.4-1">The formal definition of the DMARC format, using <span>[<a href="#RFC5234" class="xref">RFC5234</a>]</span>, is as
-follows:<a href="#section-6.4-1" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-6.4-2">
+<p id="section-5.4-1">The formal definition of the DMARC format, using <span>[<a href="#RFC5234" class="xref">RFC5234</a>]</span>, is as
+follows:<a href="#section-5.4-1" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-5.4-2">
 <pre>  dmarc-uri       = URI
                     ; "URI" is imported from [RFC3986]; commas (ASCII
                     ; 0x2C) and exclamation points (ASCII 0x21)
@@ -2772,86 +2766,86 @@ follows:<a href="#section-6.4-1" class="pilcrow">¶</a></p>
   dmarc-rfmt      = "rf"  *WSP "=" *WSP Keyword *(*WSP ":" Keyword)
                     ; registered reporting formats only
 
-</pre><a href="#section-6.4-2" class="pilcrow">¶</a>
+</pre><a href="#section-5.4-2" class="pilcrow">¶</a>
 </div>
-<p id="section-6.4-3">"Keyword" is imported from Section 4.1.2 of <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span>.<a href="#section-6.4-3" class="pilcrow">¶</a></p>
+<p id="section-5.4-3">"Keyword" is imported from Section 4.1.2 of <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span>.<a href="#section-5.4-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="domain-owner-actions">
-<section id="section-6.5">
+<section id="section-5.5">
         <h3 id="name-domain-owner-actions">
-<a href="#section-6.5" class="section-number selfRef">6.5. </a><a href="#name-domain-owner-actions" class="section-name selfRef">Domain Owner Actions</a>
+<a href="#section-5.5" class="section-number selfRef">5.5. </a><a href="#name-domain-owner-actions" class="section-name selfRef">Domain Owner Actions</a>
         </h3>
-<p id="section-6.5-1">This section describes Domain Owner actions to fully implement the
-DMARC mechanism.<a href="#section-6.5-1" class="pilcrow">¶</a></p>
+<p id="section-5.5-1">This section describes Domain Owner actions to fully implement the
+DMARC mechanism.<a href="#section-5.5-1" class="pilcrow">¶</a></p>
 <div id="publish-an-spf-policy-for-an-aligned-domain">
-<section id="section-6.5.1">
+<section id="section-5.5.1">
           <h4 id="name-publish-an-spf-policy-for-a">
-<a href="#section-6.5.1" class="section-number selfRef">6.5.1. </a><a href="#name-publish-an-spf-policy-for-a" class="section-name selfRef">Publish an SPF Policy for an Aligned Domain</a>
+<a href="#section-5.5.1" class="section-number selfRef">5.5.1. </a><a href="#name-publish-an-spf-policy-for-a" class="section-name selfRef">Publish an SPF Policy for an Aligned Domain</a>
           </h4>
-<p id="section-6.5.1-1">Because DMARC relies on SPF <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span> and DKIM <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>, in
+<p id="section-5.5.1-1">Because DMARC relies on SPF <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span> and DKIM <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>, in
 order to take full advantage of DMARC, a Domain Owner SHOULD first
 ensure that SPF and DKIM authentication are properly configured.
 The easiest first step here is to choose a domain to use as the
 RFC5321.From domain (i.e., the Return-Path domain) for its mail,
 one that aligns with the Author Domain, and then publish an SPF
-policy in DNS for that domain.<a href="#section-6.5.1-1" class="pilcrow">¶</a></p>
+policy in DNS for that domain.<a href="#section-5.5.1-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="configure-sending-system-for-dkim-signing-using-an-aligned-domain">
-<section id="section-6.5.2">
+<section id="section-5.5.2">
           <h4 id="name-configure-sending-system-fo">
-<a href="#section-6.5.2" class="section-number selfRef">6.5.2. </a><a href="#name-configure-sending-system-fo" class="section-name selfRef">Configure Sending System for DKIM Signing Using an Aligned Domain</a>
+<a href="#section-5.5.2" class="section-number selfRef">5.5.2. </a><a href="#name-configure-sending-system-fo" class="section-name selfRef">Configure Sending System for DKIM Signing Using an Aligned Domain</a>
           </h4>
-<p id="section-6.5.2-1">While it is possible to secure a DMARC pass verdict based on only
+<p id="section-5.5.2-1">While it is possible to secure a DMARC pass verdict based on only
 SPF or DKIM, it is commonly accepted best practice to ensure that
 both authentication mechanisms are in place in order to guard
 against failure of just one of them. The Domain Owner SHOULD choose
 a DKIM-Signing domain (i.e., the d= domain in the DKIM-Signature
 header) that aligns with the Author Domain and configure its system
-to sign using that domain.<a href="#section-6.5.2-1" class="pilcrow">¶</a></p>
+to sign using that domain.<a href="#section-5.5.2-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="setup-a-mailbox-to-receive-aggregate-reports">
-<section id="section-6.5.3">
+<section id="section-5.5.3">
           <h4 id="name-setup-a-mailbox-to-receive-">
-<a href="#section-6.5.3" class="section-number selfRef">6.5.3. </a><a href="#name-setup-a-mailbox-to-receive-" class="section-name selfRef">Setup a Mailbox to Receive Aggregate Reports</a>
+<a href="#section-5.5.3" class="section-number selfRef">5.5.3. </a><a href="#name-setup-a-mailbox-to-receive-" class="section-name selfRef">Setup a Mailbox to Receive Aggregate Reports</a>
           </h4>
-<p id="section-6.5.3-1">Proper consumption and analysis of DMARC aggregate reports is the
+<p id="section-5.5.3-1">Proper consumption and analysis of DMARC aggregate reports is the
 key to any successful DMARC deployment for a Domain Owner. DMARC
 aggregate reports, which are XML documents and are defined in
 <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span>, contain valuable data for the Domain
 Owner, showing sources of mail using the Author Domain. Depending
 on how mature the Domain Owner's DMARC rollout is, some of these
 sources could be legitimate ones that were overlooked during the
-intial deployment of SPF and/or DKIM.<a href="#section-6.5.3-1" class="pilcrow">¶</a></p>
-<p id="section-6.5.3-2">Because the aggregate reports are XML documents, it is strongly
+intial deployment of SPF and/or DKIM.<a href="#section-5.5.3-1" class="pilcrow">¶</a></p>
+<p id="section-5.5.3-2">Because the aggregate reports are XML documents, it is strongly
 advised that they be machine-parsed, so setting up a mailbox
 involves more than just the physical creation of the mailbox. Many
 third-party services exist that will process DMARC aggregate reports,
 or the Domain Owner can create its own set of tools. No matter which
 method is chosen, the ability to parse these reports and consume
 the data contained in them will go a long way to ensuring a
-successful deployment.<a href="#section-6.5.3-2" class="pilcrow">¶</a></p>
+successful deployment.<a href="#section-5.5.3-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="publish-a-dmarc-policy-for-the-author-domain">
-<section id="section-6.5.4">
+<section id="section-5.5.4">
           <h4 id="name-publish-a-dmarc-policy-for-">
-<a href="#section-6.5.4" class="section-number selfRef">6.5.4. </a><a href="#name-publish-a-dmarc-policy-for-" class="section-name selfRef">Publish a DMARC Policy for the Author Domain</a>
+<a href="#section-5.5.4" class="section-number selfRef">5.5.4. </a><a href="#name-publish-a-dmarc-policy-for-" class="section-name selfRef">Publish a DMARC Policy for the Author Domain</a>
           </h4>
-<p id="section-6.5.4-1">Once SPF, DKIM, and the aggregate reports mailbox are all in place,
+<p id="section-5.5.4-1">Once SPF, DKIM, and the aggregate reports mailbox are all in place,
 it's time to publish a DMARC record. For best results, Domain Owners
 SHOULD start with "p=none", with the rua tag containg the mailbox
-created in the previous step.<a href="#section-6.5.4-1" class="pilcrow">¶</a></p>
+created in the previous step.<a href="#section-5.5.4-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="collect-and-analyze-reports-and-adjust-authentication">
-<section id="section-6.5.5">
+<section id="section-5.5.5">
           <h4 id="name-collect-and-analyze-reports">
-<a href="#section-6.5.5" class="section-number selfRef">6.5.5. </a><a href="#name-collect-and-analyze-reports" class="section-name selfRef">Collect and Analyze Reports and Adjust Authentication</a>
+<a href="#section-5.5.5" class="section-number selfRef">5.5.5. </a><a href="#name-collect-and-analyze-reports" class="section-name selfRef">Collect and Analyze Reports and Adjust Authentication</a>
           </h4>
-<p id="section-6.5.5-1">The reason for starting at "p=none" is to ensure that nothing's been
+<p id="section-5.5.5-1">The reason for starting at "p=none" is to ensure that nothing's been
 missed in the initial SPF and DKIM deployments. In all but the most
 trivial setups, it is possible for a Domain Owner to overlook a
 server here or be unaware of a third party sending agreeement there.
@@ -2859,265 +2853,265 @@ Starting at "p=none", therefore, takes advantage of DMARC's aggregate
 reporting function, with the Domain Owner using the reports to audit
 its own mail streams. Should any overlooked systems be found in the
 reports, the Domain Owner can adjust the SPF record and/or configure
-DKIM signing for those systems.<a href="#section-6.5.5-1" class="pilcrow">¶</a></p>
+DKIM signing for those systems.<a href="#section-5.5.5-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="decide-if-and-when-to-update-dmarc-policy">
-<section id="section-6.5.6">
+<section id="section-5.5.6">
           <h4 id="name-decide-if-and-when-to-updat">
-<a href="#section-6.5.6" class="section-number selfRef">6.5.6. </a><a href="#name-decide-if-and-when-to-updat" class="section-name selfRef">Decide If and When to Update DMARC Policy</a>
+<a href="#section-5.5.6" class="section-number selfRef">5.5.6. </a><a href="#name-decide-if-and-when-to-updat" class="section-name selfRef">Decide If and When to Update DMARC Policy</a>
           </h4>
-<p id="section-6.5.6-1">Once the Domain Owner is satisfied that it is properly authenticating
+<p id="section-5.5.6-1">Once the Domain Owner is satisfied that it is properly authenticating
 all of its mail, then it is time to decide if it is appropriate to
 change the p= value in its DMARC record to p=quarantine or p=reject.
 Depending on its cadence for sending mail, it may take many months
 of consuming DMARC aggregate reports before a Domain Owner reaches
 the point where it is sure that it is properly authenticating all
 of its mail, and the decision on which p= value to use will depend
-on its needs.<a href="#section-6.5.6-1" class="pilcrow">¶</a></p>
+on its needs.<a href="#section-5.5.6-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="pso-actions">
-<section id="section-6.6">
+<section id="section-5.6">
         <h3 id="name-pso-actions">
-<a href="#section-6.6" class="section-number selfRef">6.6. </a><a href="#name-pso-actions" class="section-name selfRef">PSO Actions</a>
+<a href="#section-5.6" class="section-number selfRef">5.6. </a><a href="#name-pso-actions" class="section-name selfRef">PSO Actions</a>
         </h3>
-<p id="section-6.6-1">In addition to the DMARC Domain Owner actions, PSOs that require use
+<p id="section-5.6-1">In addition to the DMARC Domain Owner actions, PSOs that require use
 of DMARC and participate in PSD DMARC ought to make that information
 availablle to Mail Receivers. <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span> is an experimental
 method for doing so, and the experiment is described in Appendix B
-of that document.<a href="#section-6.6-1" class="pilcrow">¶</a></p>
+of that document.<a href="#section-5.6-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="mail-receiver-actions">
-<section id="section-6.7">
+<section id="section-5.7">
         <h3 id="name-mail-receiver-actions">
-<a href="#section-6.7" class="section-number selfRef">6.7. </a><a href="#name-mail-receiver-actions" class="section-name selfRef">Mail Receiver Actions</a>
+<a href="#section-5.7" class="section-number selfRef">5.7. </a><a href="#name-mail-receiver-actions" class="section-name selfRef">Mail Receiver Actions</a>
         </h3>
-<p id="section-6.7-1">This section describes receiver actions in the DMARC environment.<a href="#section-6.7-1" class="pilcrow">¶</a></p>
+<p id="section-5.7-1">This section describes receiver actions in the DMARC environment.<a href="#section-5.7-1" class="pilcrow">¶</a></p>
 <div id="extract-author-domain">
-<section id="section-6.7.1">
+<section id="section-5.7.1">
           <h4 id="name-extract-author-domain">
-<a href="#section-6.7.1" class="section-number selfRef">6.7.1. </a><a href="#name-extract-author-domain" class="section-name selfRef">Extract Author Domain</a>
+<a href="#section-5.7.1" class="section-number selfRef">5.7.1. </a><a href="#name-extract-author-domain" class="section-name selfRef">Extract Author Domain</a>
           </h4>
-<p id="section-6.7.1-1">The domain in the RFC5322.From header field is extracted as the domain
+<p id="section-5.7.1-1">The domain in the RFC5322.From header field is extracted as the domain
 to be evaluated by DMARC.  If the domain is encoded with UTF-8, the
 domain name must be converted to an A-label, as described in Section
-2.3 of <span>[<a href="#RFC5890" class="xref">RFC5890</a>]</span>, for further processing.<a href="#section-6.7.1-1" class="pilcrow">¶</a></p>
-<p id="section-6.7.1-2">In order to be processed by DMARC, a message typically needs to
+2.3 of <span>[<a href="#RFC5890" class="xref">RFC5890</a>]</span>, for further processing.<a href="#section-5.7.1-1" class="pilcrow">¶</a></p>
+<p id="section-5.7.1-2">In order to be processed by DMARC, a message typically needs to
 contain exactly one RFC5322.From domain (a single From: field with a
 single domain in it). Not all messages meet this requirement, and
 the handling of those that are forbidden under <span>[<a href="#RFC5322" class="xref">RFC5322</a>]</span> or that
-contain no meaningful domains is outside the scope of this document.<a href="#section-6.7.1-2" class="pilcrow">¶</a></p>
-<p id="section-6.7.1-3">The case of a syntactically valid multi-valued RFC5322.From header
+contain no meaningful domains is outside the scope of this document.<a href="#section-5.7.1-2" class="pilcrow">¶</a></p>
+<p id="section-5.7.1-3">The case of a syntactically valid multi-valued RFC5322.From header
 field presents a particular challenge. When a single RFC5322.From
 header field contains multiple addresses, it is possible that there
 may be multiple domains used in those addresses. The process in this
 case is to only proceed with DMARC checking if the domain is
 identical for all of the addresses in a multi-valued RFC5322.From
 header field. Multi-valued RFC5322.From header fields with multiple
-domains MUST be exempt from DMARC checking.<a href="#section-6.7.1-3" class="pilcrow">¶</a></p>
-<p id="section-6.7.1-4">Note that domain names that appear on a public suffix list are not
-exempt from DMARC policy application and reporting.<a href="#section-6.7.1-4" class="pilcrow">¶</a></p>
+domains MUST be exempt from DMARC checking.<a href="#section-5.7.1-3" class="pilcrow">¶</a></p>
+<p id="section-5.7.1-4">Note that domain names that appear on a public suffix list are not
+exempt from DMARC policy application and reporting.<a href="#section-5.7.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="determine-handling-policy">
-<section id="section-6.7.2">
+<section id="section-5.7.2">
           <h4 id="name-determine-handling-policy">
-<a href="#section-6.7.2" class="section-number selfRef">6.7.2. </a><a href="#name-determine-handling-policy" class="section-name selfRef">Determine Handling Policy</a>
+<a href="#section-5.7.2" class="section-number selfRef">5.7.2. </a><a href="#name-determine-handling-policy" class="section-name selfRef">Determine Handling Policy</a>
           </h4>
-<p id="section-6.7.2-1">To arrive at a policy for an individual message, Mail Receivers MUST
+<p id="section-5.7.2-1">To arrive at a policy for an individual message, Mail Receivers MUST
 perform the following actions or their semantic equivalents.
 Steps 2-4 MAY be done in parallel, whereas steps 5 and 6 require
-input from previous steps.<a href="#section-6.7.2-1" class="pilcrow">¶</a></p>
-<p id="section-6.7.2-2">The steps are as follows:<a href="#section-6.7.2-2" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-6.7.2-3">
-            <li id="section-6.7.2-3.1">
-              <p id="section-6.7.2-3.1.1">Extract the RFC5322.From domain from the message (as above).<a href="#section-6.7.2-3.1.1" class="pilcrow">¶</a></p>
+input from previous steps.<a href="#section-5.7.2-1" class="pilcrow">¶</a></p>
+<p id="section-5.7.2-2">The steps are as follows:<a href="#section-5.7.2-2" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-5.7.2-3">
+            <li id="section-5.7.2-3.1">
+              <p id="section-5.7.2-3.1.1">Extract the RFC5322.From domain from the message (as above).<a href="#section-5.7.2-3.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-6.7.2-3.2">
-              <p id="section-6.7.2-3.2.1">Query the DNS for a DMARC policy record.  Continue if one is
+<li id="section-5.7.2-3.2">
+              <p id="section-5.7.2-3.2.1">Query the DNS for a DMARC policy record.  Continue if one is
 found, or terminate DMARC evaluation otherwise.  See
-<a href="#policy-discovery" class="xref">Section 6.7.3</a> for details.<a href="#section-6.7.2-3.2.1" class="pilcrow">¶</a></p>
+<a href="#policy-discovery" class="xref">Section 5.7.3</a> for details.<a href="#section-5.7.2-3.2.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-6.7.2-3.3">
-              <p id="section-6.7.2-3.3.1">Perform DKIM signature verification checks.  A single email could
+<li id="section-5.7.2-3.3">
+              <p id="section-5.7.2-3.3.1">Perform DKIM signature verification checks.  A single email could
 contain multiple DKIM signatures.  The results of this step are
 passed to the remainder of the algorithm, MUST include "pass" or
 "fail", and if "fail", SHOULD include information about the reasons
 for failure. The results MUST further include the value of the "d="
-and "s=" tags from each checked DKIM signature.<a href="#section-6.7.2-3.3.1" class="pilcrow">¶</a></p>
+and "s=" tags from each checked DKIM signature.<a href="#section-5.7.2-3.3.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-6.7.2-3.4">
-              <p id="section-6.7.2-3.4.1">Perform SPF verification checks.  The results of this step are
+<li id="section-5.7.2-3.4">
+              <p id="section-5.7.2-3.4.1">Perform SPF verification checks.  The results of this step are
 passed to the remainder of the algorithm, MUST include "pass" or
 "fail", and if "fail", SHOULD include information about the reasons
 for failure. The results MUST further include the domain name used
-to complete the SPF check.<a href="#section-6.7.2-3.4.1" class="pilcrow">¶</a></p>
+to complete the SPF check.<a href="#section-5.7.2-3.4.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-6.7.2-3.5">
-              <p id="section-6.7.2-3.5.1">Conduct Identifier Alignment checks.  With authentication checks
+<li id="section-5.7.2-3.5">
+              <p id="section-5.7.2-3.5.1">Conduct Identifier Alignment checks.  With authentication checks
 and policy discovery performed, the Mail Receiver checks to see
 if Authenticated Identifiers fall into alignment as described in
 <a href="#terminology" class="xref">Section 3</a>.  If one or more of the Authenticated Identifiers align
 with the RFC5322.From domain, the message is considered to pass
 the DMARC mechanism check.  All other conditions (authentication
 failures, identifier mismatches) are considered to be DMARC
-mechanism check failures.<a href="#section-6.7.2-3.5.1" class="pilcrow">¶</a></p>
+mechanism check failures.<a href="#section-5.7.2-3.5.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-6.7.2-3.6">
-              <p id="section-6.7.2-3.6.1">Apply policy.  Emails that fail the DMARC mechanism check are
+<li id="section-5.7.2-3.6">
+              <p id="section-5.7.2-3.6.1">Apply policy.  Emails that fail the DMARC mechanism check are
 handled in accordance with the discovered DMARC policy of the
 Domain Owner and any local policy rules enforced by the Mail Receiver.
-See <a href="#general-record-format" class="xref">Section 6.3</a> for details.<a href="#section-6.7.2-3.6.1" class="pilcrow">¶</a></p>
+See <a href="#general-record-format" class="xref">Section 5.3</a> for details.<a href="#section-5.7.2-3.6.1" class="pilcrow">¶</a></p>
 </li>
 </ol>
-<p id="section-6.7.2-4">Heuristics applied in the absence of use by a Domain Owner of either
+<p id="section-5.7.2-4">Heuristics applied in the absence of use by a Domain Owner of either
 SPF or DKIM (e.g., <span>[<a href="#Best-Guess-SPF" class="xref">Best-Guess-SPF</a>]</span>) SHOULD NOT be used, as it may be
 the case that the Domain Owner wishes a Message Receiver not to
 consider the results of that underlying authentication protocol at
-all.<a href="#section-6.7.2-4" class="pilcrow">¶</a></p>
-<p id="section-6.7.2-5">DMARC evaluation can only yield a "pass" result after one of the
+all.<a href="#section-5.7.2-4" class="pilcrow">¶</a></p>
+<p id="section-5.7.2-5">DMARC evaluation can only yield a "pass" result after one of the
 underlying authentication mechanisms passes for an aligned
 identifier.  If neither passes and one or both of them fail due to a
 temporary error, the Receiver evaluating the message is unable to
 conclude that the DMARC mechanism had a permanent failure; they
 therefore cannot apply the advertised DMARC policy.  When otherwise
 appropriate, Receivers MAY send feedback reports regarding temporary
-errors.<a href="#section-6.7.2-5" class="pilcrow">¶</a></p>
-<p id="section-6.7.2-6">Handling of messages for which SPF and/or DKIM evaluation encounter a
-permanent DNS error is left to the discretion of the Mail Receiver.<a href="#section-6.7.2-6" class="pilcrow">¶</a></p>
+errors.<a href="#section-5.7.2-5" class="pilcrow">¶</a></p>
+<p id="section-5.7.2-6">Handling of messages for which SPF and/or DKIM evaluation encounter a
+permanent DNS error is left to the discretion of the Mail Receiver.<a href="#section-5.7.2-6" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="policy-discovery">
-<section id="section-6.7.3">
+<section id="section-5.7.3">
           <h4 id="name-policy-discovery">
-<a href="#section-6.7.3" class="section-number selfRef">6.7.3. </a><a href="#name-policy-discovery" class="section-name selfRef">Policy Discovery</a>
+<a href="#section-5.7.3" class="section-number selfRef">5.7.3. </a><a href="#name-policy-discovery" class="section-name selfRef">Policy Discovery</a>
           </h4>
-<p id="section-6.7.3-1">As stated above, the DMARC mechanism uses DNS TXT records to
+<p id="section-5.7.3-1">As stated above, the DMARC mechanism uses DNS TXT records to
 advertise policy.  Policy discovery is accomplished via a method
 similar to the method used for SPF records.  This method, and the
 important differences between DMARC and SPF mechanisms, are discussed
-below.<a href="#section-6.7.3-1" class="pilcrow">¶</a></p>
-<p id="section-6.7.3-2">To balance the conflicting requirements of supporting wildcarding and
+below.<a href="#section-5.7.3-1" class="pilcrow">¶</a></p>
+<p id="section-5.7.3-2">To balance the conflicting requirements of supporting wildcarding and
 allowing subdomain policy overrides, the following DNS lookup scheme
-is employed:<a href="#section-6.7.3-2" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-6.7.3-3">
-            <li id="section-6.7.3-3.1">
-              <p id="section-6.7.3-3.1.1">Mail Receivers MUST query the DNS for a DMARC TXT record at the
+is employed:<a href="#section-5.7.3-2" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-5.7.3-3">
+            <li id="section-5.7.3-3.1">
+              <p id="section-5.7.3-3.1.1">Mail Receivers MUST query the DNS for a DMARC TXT record at the
 DNS domain matching the one found in the RFC5322.From domain in
-the message.  A possibly empty set of records is returned.<a href="#section-6.7.3-3.1.1" class="pilcrow">¶</a></p>
+the message.  A possibly empty set of records is returned.<a href="#section-5.7.3-3.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-6.7.3-3.2">
-              <p id="section-6.7.3-3.2.1">Records that do not start with a "v=" tag that identifies the
-current version of DMARC are discarded.<a href="#section-6.7.3-3.2.1" class="pilcrow">¶</a></p>
+<li id="section-5.7.3-3.2">
+              <p id="section-5.7.3-3.2.1">Records that do not start with a "v=" tag that identifies the
+current version of DMARC are discarded.<a href="#section-5.7.3-3.2.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-6.7.3-3.3">
-              <p id="section-6.7.3-3.3.1">If the set is now empty, the Mail Receiver determines the target
-for additional queries, using steps 4 through 8 below.<a href="#section-6.7.3-3.3.1" class="pilcrow">¶</a></p>
+<li id="section-5.7.3-3.3">
+              <p id="section-5.7.3-3.3.1">If the set is now empty, the Mail Receiver determines the target
+for additional queries, using steps 4 through 8 below.<a href="#section-5.7.3-3.3.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-6.7.3-3.4">
-              <p id="section-6.7.3-3.4.1">Break the subject DNS domain name into a set of "n" ordered labels.
+<li id="section-5.7.3-3.4">
+              <p id="section-5.7.3-3.4.1">Break the subject DNS domain name into a set of "n" ordered labels.
 Number these lables from right to left; e.g., for "example.com",
-"com" would be label 1 and "example" would be label 2.<a href="#section-6.7.3-3.4.1" class="pilcrow">¶</a></p>
+"com" would be label 1 and "example" would be label 2.<a href="#section-5.7.3-3.4.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-6.7.3-3.5">
-              <p id="section-6.7.3-3.5.1">Count the number of labels found in the subject DNS domain. Let that
+<li id="section-5.7.3-3.5">
+              <p id="section-5.7.3-3.5.1">Count the number of labels found in the subject DNS domain. Let that
 number be "x". If x &lt; 5, remove the left-most (highest-numbered)
 label from the subject domain. If x &gt;= 5, remove the left-most
 (highest-numbered) labels from the subject domain until 4 labels remain.
-The resulting DNS domain name is the new target for subsequent lookups.<a href="#section-6.7.3-3.5.1" class="pilcrow">¶</a></p>
+The resulting DNS domain name is the new target for subsequent lookups.<a href="#section-5.7.3-3.5.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-6.7.3-3.6">
-              <p id="section-6.7.3-3.6.1">The Mail Receiver MUST query the DNS for a DMARC TXT record at
+<li id="section-5.7.3-3.6">
+              <p id="section-5.7.3-3.6.1">The Mail Receiver MUST query the DNS for a DMARC TXT record at
 the DNS domain matching this new target in place of the RFC5322.From
 domain in the message. This record can contain policy to be asserted
 for subdomains of the target. A possibly empty set of records is
-returned.<a href="#section-6.7.3-3.6.1" class="pilcrow">¶</a></p>
+returned.<a href="#section-5.7.3-3.6.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-6.7.3-3.7">
-              <p id="section-6.7.3-3.7.1">Records that do not start with a "v=" tag that identifies the
-current version of DMARC are discarded.<a href="#section-6.7.3-3.7.1" class="pilcrow">¶</a></p>
+<li id="section-5.7.3-3.7">
+              <p id="section-5.7.3-3.7.1">Records that do not start with a "v=" tag that identifies the
+current version of DMARC are discarded.<a href="#section-5.7.3-3.7.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-6.7.3-3.8">
-              <p id="section-6.7.3-3.8.1">If the set is now empty, the Mail Receiver determines the target
+<li id="section-5.7.3-3.8">
+              <p id="section-5.7.3-3.8.1">If the set is now empty, the Mail Receiver determines the target
 for additional queries by removing a single label from the target
 domain as described in step 5 and repeating steps 6 and 7 until
-there are no more labels remaining.<a href="#section-6.7.3-3.8.1" class="pilcrow">¶</a></p>
+there are no more labels remaining.<a href="#section-5.7.3-3.8.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-6.7.3-3.9">
-              <p id="section-6.7.3-3.9.1">If the remaining set contains multiple records or no records,
+<li id="section-5.7.3-3.9">
+              <p id="section-5.7.3-3.9.1">If the remaining set contains multiple records or no records,
 policy discovery terminates and DMARC processing is not applied
-to this message.<a href="#section-6.7.3-3.9.1" class="pilcrow">¶</a></p>
+to this message.<a href="#section-5.7.3-3.9.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-6.7.3-3.10">
-              <p id="section-6.7.3-3.10.1">If a retrieved policy record does not contain a valid "p" tag, or
-contains an "sp" tag that is not valid, then:<a href="#section-6.7.3-3.10.1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-6.7.3-3.10.2">
-                <li id="section-6.7.3-3.10.2.1">
-                  <p id="section-6.7.3-3.10.2.1.1">if a "rua" tag is present and contains at least one
+<li id="section-5.7.3-3.10">
+              <p id="section-5.7.3-3.10.1">If a retrieved policy record does not contain a valid "p" tag, or
+contains an "sp" tag that is not valid, then:<a href="#section-5.7.3-3.10.1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-5.7.3-3.10.2">
+                <li id="section-5.7.3-3.10.2.1">
+                  <p id="section-5.7.3-3.10.2.1.1">if a "rua" tag is present and contains at least one
 syntactically valid reporting URI, the Mail Receiver SHOULD
 act as if a record containing a valid "v" tag and "p=none"
-was retrieved, and continue processing;<a href="#section-6.7.3-3.10.2.1.1" class="pilcrow">¶</a></p>
+was retrieved, and continue processing;<a href="#section-5.7.3-3.10.2.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-6.7.3-3.10.2.2">
-                  <p id="section-6.7.3-3.10.2.2.1">otherwise, the Mail Receiver applies no DMARC processing to
-this message.<a href="#section-6.7.3-3.10.2.2.1" class="pilcrow">¶</a></p>
-</li>
-</ol>
+<li id="section-5.7.3-3.10.2.2">
+                  <p id="section-5.7.3-3.10.2.2.1">otherwise, the Mail Receiver applies no DMARC processing to
+this message.<a href="#section-5.7.3-3.10.2.2.1" class="pilcrow">¶</a></p>
 </li>
 </ol>
-<p id="section-6.7.3-4">If the set produced by the mechanism above contains no DMARC policy
+</li>
+</ol>
+<p id="section-5.7.3-4">If the set produced by the mechanism above contains no DMARC policy
 record (i.e., any indication that there is no such record as opposed
 to a transient DNS error), Mail Receivers SHOULD NOT apply the DMARC
-mechanism to the message.<a href="#section-6.7.3-4" class="pilcrow">¶</a></p>
-<p id="section-6.7.3-5">Handling of DNS errors when querying for the DMARC policy record is
+mechanism to the message.<a href="#section-5.7.3-4" class="pilcrow">¶</a></p>
+<p id="section-5.7.3-5">Handling of DNS errors when querying for the DMARC policy record is
 left to the discretion of the Mail Receiver.  For example, to ensure
 minimal disruption of mail flow, transient errors could result in
 delivery of the message ("fail open"), or they could result in the
 message being temporarily rejected (i.e., an SMTP 4yx reply), which
 invites the sending MTA to try again after the condition has possibly
 cleared, allowing a definite DMARC conclusion to be reached ("fail
-closed").<a href="#section-6.7.3-5" class="pilcrow">¶</a></p>
+closed").<a href="#section-5.7.3-5" class="pilcrow">¶</a></p>
 <div id="longest-psd-example">
-<section id="section-6.7.3.1">
+<section id="section-5.7.3.1">
             <h5 id="name-longest-psd-example">
-<a href="#section-6.7.3.1" class="section-number selfRef">6.7.3.1. </a><a href="#name-longest-psd-example" class="section-name selfRef">Longest PSD Example</a>
+<a href="#section-5.7.3.1" class="section-number selfRef">5.7.3.1. </a><a href="#name-longest-psd-example" class="section-name selfRef">Longest PSD Example</a>
             </h5>
-<p id="section-6.7.3.1-1">As an example of step 5 above, for a message with the Organizational
+<p id="section-5.7.3.1-1">As an example of step 5 above, for a message with the Organizational
 Domain of "example.compute.cloudcompany.com.example", the query for
 PSD DMARC would use "compute.cloudcompany.com.example" as the longest
 PSD. The receiver would check to see if that PSD is listed in the DMARC
 PSD Registry, and if so, perform the policy lookup at
-"_dmarc.compute.cloudcompany.com.example".<a href="#section-6.7.3.1-1" class="pilcrow">¶</a></p>
-<p id="section-6.7.3.1-2">Note: Because the PSD policy query comes after the Organizational
+"_dmarc.compute.cloudcompany.com.example".<a href="#section-5.7.3.1-1" class="pilcrow">¶</a></p>
+<p id="section-5.7.3.1-2">Note: Because the PSD policy query comes after the Organizational
 Domain policy query, PSD policy is not used for Organizational
 domains that have published a DMARC policy.  Specifically, this is
 not a mechanism to provide feedback addresses (RUA/RUF) when an
-Organizational Domain has declined to do so.<a href="#section-6.7.3.1-2" class="pilcrow">¶</a></p>
+Organizational Domain has declined to do so.<a href="#section-5.7.3.1-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="store-results-of-dmarc-processing">
-<section id="section-6.7.4">
+<section id="section-5.7.4">
           <h4 id="name-store-results-of-dmarc-proc">
-<a href="#section-6.7.4" class="section-number selfRef">6.7.4. </a><a href="#name-store-results-of-dmarc-proc" class="section-name selfRef">Store Results of DMARC Processing</a>
+<a href="#section-5.7.4" class="section-number selfRef">5.7.4. </a><a href="#name-store-results-of-dmarc-proc" class="section-name selfRef">Store Results of DMARC Processing</a>
           </h4>
-<p id="section-6.7.4-1">The results of Mail Receiver-based DMARC processing should be stored
+<p id="section-5.7.4-1">The results of Mail Receiver-based DMARC processing should be stored
 for eventual presentation back to the Domain Owner in the form of
-aggregate feedback reports.  <a href="#general-record-format" class="xref">Section 6.3</a> and
-<span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> discuss aggregate feedback.<a href="#section-6.7.4-1" class="pilcrow">¶</a></p>
+aggregate feedback reports.  <a href="#general-record-format" class="xref">Section 5.3</a> and
+<span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> discuss aggregate feedback.<a href="#section-5.7.4-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="send-aggregate-reports">
-<section id="section-6.7.5">
+<section id="section-5.7.5">
           <h4 id="name-send-aggregate-reports">
-<a href="#section-6.7.5" class="section-number selfRef">6.7.5. </a><a href="#name-send-aggregate-reports" class="section-name selfRef">Send Aggregate Reports</a>
+<a href="#section-5.7.5" class="section-number selfRef">5.7.5. </a><a href="#name-send-aggregate-reports" class="section-name selfRef">Send Aggregate Reports</a>
           </h4>
-<p id="section-6.7.5-1">For a Domain Owner, DMARC aggregate reports provide data about all
+<p id="section-5.7.5-1">For a Domain Owner, DMARC aggregate reports provide data about all
 mailstreams making use of its domain in email, to include not only
 illegitimate uses but also, and perhaps more importantly, all
 legitimate uses. Domain Owners can use aggregate reports to ensure
@@ -3128,27 +3122,27 @@ none to quarantine to reject, if appropriate. In turn, DMARC policy
 records with p= tag values of 'quarantine' or 'reject' are higher
 value signals to Mail Receivers, ones that can assist Mail Receivers
 with handling decisions for a message in ways that p= tag values of
-'none' cannot.<a href="#section-6.7.5-1" class="pilcrow">¶</a></p>
-<p id="section-6.7.5-2">In order to ensure maximum usefulness for DMARC across the email
+'none' cannot.<a href="#section-5.7.5-1" class="pilcrow">¶</a></p>
+<p id="section-5.7.5-2">In order to ensure maximum usefulness for DMARC across the email
 ecosystem, then, Mail Receivers MUST generate and send aggregate
-reports with a frequency of at least once every 24 hours.<a href="#section-6.7.5-2" class="pilcrow">¶</a></p>
+reports with a frequency of at least once every 24 hours.<a href="#section-5.7.5-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="policy-enforcement-considerations">
-<section id="section-6.8">
+<section id="section-5.8">
         <h3 id="name-policy-enforcement-consider">
-<a href="#section-6.8" class="section-number selfRef">6.8. </a><a href="#name-policy-enforcement-consider" class="section-name selfRef">Policy Enforcement Considerations</a>
+<a href="#section-5.8" class="section-number selfRef">5.8. </a><a href="#name-policy-enforcement-consider" class="section-name selfRef">Policy Enforcement Considerations</a>
         </h3>
-<p id="section-6.8-1">Mail Receivers MAY choose to reject or quarantine email even if email
+<p id="section-5.8-1">Mail Receivers MAY choose to reject or quarantine email even if email
 passes the DMARC mechanism check. The DMARC mechanism does not
 inform Mail Receivers whether an email stream is "good"; a DMARC result
 of "pass" only means that the domain in the RFC5322.From header has been
 verified by the DMARC mechanism. Mail Receivers are encouraged to maintain
 anti-abuse technologies to combat the possibility of DMARC-enabled criminal
-campaigns.<a href="#section-6.8-1" class="pilcrow">¶</a></p>
-<p id="section-6.8-2">Mail Receivers MAY choose to accept email that fails the DMARC
+campaigns.<a href="#section-5.8-1" class="pilcrow">¶</a></p>
+<p id="section-5.8-2">Mail Receivers MAY choose to accept email that fails the DMARC
 mechanism check even if the published Domain Owner Assessment Policy
 is "reject".  Mail Receivers need to make a best effort not to increase
 the likelihood of accepting abusive mail if they choose not to honor
@@ -3156,88 +3150,88 @@ the published Domain Owner Assessment Policy.  At a minimum, addition
 of the Authentication-Results header field (see <span>[<a href="#RFC8601" class="xref">RFC8601</a>]</span>) is
 RECOMMENDED when delivery of failing mail is done.  When this is
 done, the DNS domain name thus recorded MUST be encoded as an
-A-label.<a href="#section-6.8-2" class="pilcrow">¶</a></p>
-<p id="section-6.8-3">Mail Receivers are only obligated to report reject or quarantine
+A-label.<a href="#section-5.8-2" class="pilcrow">¶</a></p>
+<p id="section-5.8-3">Mail Receivers are only obligated to report reject or quarantine
 policy actions in aggregate feedback reports that are due to published
 DMARC Domain Owner Assessment Policy. They are not required to report
 reject or quarantine actions that are the result of local policy. If
 local policy information is exposed, abusers can gain insight into the
-effectiveness and delivery rates of spam campaigns.<a href="#section-6.8-3" class="pilcrow">¶</a></p>
-<p id="section-6.8-4">Final handling of a message is always a matter of local policy.
+effectiveness and delivery rates of spam campaigns.<a href="#section-5.8-3" class="pilcrow">¶</a></p>
+<p id="section-5.8-4">Final handling of a message is always a matter of local policy.
 An operator that wishes to favor DMARC policy over SPF policy, for
 example, will disregard the SPF policy, since enacting an
 SPF-determined rejection prevents evaluation of DKIM; DKIM might
 otherwise pass, satisfying the DMARC evaluation.  There is a
 trade-off to doing so, namely acceptance and processing of the entire
-message body in exchange for the enhanced protection DMARC provides.<a href="#section-6.8-4" class="pilcrow">¶</a></p>
-<p id="section-6.8-5">DMARC-compliant Mail Receivers typically disregard any mail-handling
+message body in exchange for the enhanced protection DMARC provides.<a href="#section-5.8-4" class="pilcrow">¶</a></p>
+<p id="section-5.8-5">DMARC-compliant Mail Receivers typically disregard any mail-handling
 directive discovered as part of an authentication mechanism (e.g.,
 Author Domain Signing Practices (ADSP), SPF) where a DMARC record is
 also discovered that specifies a policy other than "none".  Deviating
 from this practice introduces inconsistency among DMARC operators in
 terms of handling of the message.  However, such deviation is not
-proscribed.<a href="#section-6.8-5" class="pilcrow">¶</a></p>
-<p id="section-6.8-6">To enable Domain Owners to receive DMARC feedback without impacting
+proscribed.<a href="#section-5.8-5" class="pilcrow">¶</a></p>
+<p id="section-5.8-6">To enable Domain Owners to receive DMARC feedback without impacting
 existing mail processing, discovered policies of "p=none" SHOULD NOT
-modify existing mail handling processes.<a href="#section-6.8-6" class="pilcrow">¶</a></p>
-<p id="section-6.8-7">Mail Receivers MUST also implement reporting instructions of DMARC,
+modify existing mail handling processes.<a href="#section-5.8-6" class="pilcrow">¶</a></p>
+<p id="section-5.8-7">Mail Receivers MUST also implement reporting instructions of DMARC,
 even in the absence of a request for DKIM reporting <span>[<a href="#RFC6651" class="xref">RFC6651</a>]</span> or
 SPF reporting <span>[<a href="#RFC6652" class="xref">RFC6652</a>]</span>.  Furthermore, the presence of such requests
-SHOULD NOT affect DMARC reporting.<a href="#section-6.8-7" class="pilcrow">¶</a></p>
+SHOULD NOT affect DMARC reporting.<a href="#section-5.8-7" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="dmarc-feedback">
-<section id="section-7">
+<section id="section-6">
       <h2 id="name-dmarc-feedback">
-<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-dmarc-feedback" class="section-name selfRef">DMARC Feedback</a>
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-dmarc-feedback" class="section-name selfRef">DMARC Feedback</a>
       </h2>
-<p id="section-7-1">Providing Domain Owners with visibility into how Mail Receivers
+<p id="section-6-1">Providing Domain Owners with visibility into how Mail Receivers
 implement and enforce the DMARC mechanism in the form of feedback is
 critical to establishing and maintaining accurate authentication
 deployments.  When Domain Owners can see what effect their policies
 and practices are having, they are better willing and able to use
-quarantine and reject policies.<a href="#section-7-1" class="pilcrow">¶</a></p>
-<p id="section-7-2">The details of this feedback are described in <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-7-2" class="pilcrow">¶</a></p>
-<p id="section-7-3">Operational note for PSD DMARC: For PSOs, feedback for non-existent
+quarantine and reject policies.<a href="#section-6-1" class="pilcrow">¶</a></p>
+<p id="section-6-2">The details of this feedback are described in <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-6-2" class="pilcrow">¶</a></p>
+<p id="section-6-3">Operational note for PSD DMARC: For PSOs, feedback for non-existent
 domains is desirable and useful, just as it is for org-level DMARC
 operators.  See Section 4 of <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span> for discussion of
-Privacy Considerations for PSD DMARC<a href="#section-7-3" class="pilcrow">¶</a></p>
+Privacy Considerations for PSD DMARC<a href="#section-6-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="other-topics">
-<section id="section-8">
+<section id="section-7">
       <h2 id="name-other-topics">
-<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-other-topics" class="section-name selfRef">Other Topics</a>
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-other-topics" class="section-name selfRef">Other Topics</a>
       </h2>
-<p id="section-8-1">This section discusses some topics regarding choices made in the
-development of DMARC, largely to commit the history to record.<a href="#section-8-1" class="pilcrow">¶</a></p>
+<p id="section-7-1">This section discusses some topics regarding choices made in the
+development of DMARC, largely to commit the history to record.<a href="#section-7-1" class="pilcrow">¶</a></p>
 <div id="issues-specific-to-spf">
-<section id="section-8.1">
+<section id="section-7.1">
         <h3 id="name-issues-specific-to-spf">
-<a href="#section-8.1" class="section-number selfRef">8.1. </a><a href="#name-issues-specific-to-spf" class="section-name selfRef">Issues Specific to SPF</a>
+<a href="#section-7.1" class="section-number selfRef">7.1. </a><a href="#name-issues-specific-to-spf" class="section-name selfRef">Issues Specific to SPF</a>
         </h3>
-<p id="section-8.1-1">Though DMARC does not inherently change the semantics of an SPF
+<p id="section-7.1-1">Though DMARC does not inherently change the semantics of an SPF
 policy record, historically lax enforcement of such policies has led
 many to publish extremely broad records containing many large network
 ranges.  Domain Owners are strongly encouraged to carefully review
 their SPF records to understand which networks are authorized to send
-on behalf of the Domain Owner before publishing a DMARC record.<a href="#section-8.1-1" class="pilcrow">¶</a></p>
-<p id="section-8.1-2">Some receiver architectures might implement SPF in advance of any
+on behalf of the Domain Owner before publishing a DMARC record.<a href="#section-7.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.1-2">Some receiver architectures might implement SPF in advance of any
 DMARC operations.  This means that a "-" prefix on a sender's SPF
 mechanism, such as "-all", could cause that rejection to go into
 effect early in handling, causing message rejection before any DMARC
 processing takes place.  Operators choosing to use "-all" should be
-aware of this.<a href="#section-8.1-2" class="pilcrow">¶</a></p>
+aware of this.<a href="#section-7.1-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="dns-load-and-caching">
-<section id="section-8.2">
+<section id="section-7.2">
         <h3 id="name-dns-load-and-caching">
-<a href="#section-8.2" class="section-number selfRef">8.2. </a><a href="#name-dns-load-and-caching" class="section-name selfRef">DNS Load and Caching</a>
+<a href="#section-7.2" class="section-number selfRef">7.2. </a><a href="#name-dns-load-and-caching" class="section-name selfRef">DNS Load and Caching</a>
         </h3>
-<p id="section-8.2-1">DMARC policies are communicated using the DNS and therefore inherit a
+<p id="section-7.2-1">DMARC policies are communicated using the DNS and therefore inherit a
 number of considerations related to DNS caching.  The inherent
 conflict between freshness and the impact of caching on the reduction
 of DNS-lookup overhead should be considered from the Mail Receiver's
@@ -3245,125 +3239,125 @@ point of view.  Should Domain Owners or PSOs publish a DNS record with a very
 short TTL, Mail Receivers can be provoked through the injection of
 large volumes of messages to overwhelm the publisher's DNS.
 Although this is not a concern specific to DMARC, the implications of
-a very short TTL should be considered when publishing DMARC policies.<a href="#section-8.2-1" class="pilcrow">¶</a></p>
-<p id="section-8.2-2">Conversely, long TTLs will cause records to be cached for long
+a very short TTL should be considered when publishing DMARC policies.<a href="#section-7.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.2-2">Conversely, long TTLs will cause records to be cached for long
 periods of time.  This can cause a critical change to DMARC
 parameters advertised by a Domain Owner or PSO to go unnoticed for the
 length of the TTL (while waiting for DNS caches to expire).  Avoiding
 this problem can mean shorter TTLs, with the potential problems
 described above.  A balance should be sought to maintain
 responsiveness of DMARC preference changes while preserving the
-benefits of DNS caching.<a href="#section-8.2-2" class="pilcrow">¶</a></p>
+benefits of DNS caching.<a href="#section-7.2-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="rejecting-messages">
-<section id="section-8.3">
+<section id="section-7.3">
         <h3 id="name-rejecting-messages">
-<a href="#section-8.3" class="section-number selfRef">8.3. </a><a href="#name-rejecting-messages" class="section-name selfRef">Rejecting Messages</a>
+<a href="#section-7.3" class="section-number selfRef">7.3. </a><a href="#name-rejecting-messages" class="section-name selfRef">Rejecting Messages</a>
         </h3>
-<p id="section-8.3-1">This protocol calls for rejection of a message during the SMTP
+<p id="section-7.3-1">This protocol calls for rejection of a message during the SMTP
 session under certain circumstances.  This is preferable to
 generation of a Delivery Status Notification (<span>[<a href="#RFC3464" class="xref">RFC3464</a>]</span>), since
 fraudulent messages caught and rejected using DMARC would then result
 in annoying generation of such failure reports that go back to the
-RFC5321.MailFrom address.<a href="#section-8.3-1" class="pilcrow">¶</a></p>
-<p id="section-8.3-2">This synchronous rejection is typically done in one of two ways:<a href="#section-8.3-2" class="pilcrow">¶</a></p>
+RFC5321.MailFrom address.<a href="#section-7.3-1" class="pilcrow">¶</a></p>
+<p id="section-7.3-2">This synchronous rejection is typically done in one of two ways:<a href="#section-7.3-2" class="pilcrow">¶</a></p>
 <ul>
-<li id="section-8.3-3.1">
-            <p id="section-8.3-3.1.1">Full rejection, wherein the SMTP server issues a 5xy reply code as
+<li id="section-7.3-3.1">
+            <p id="section-7.3-3.1.1">Full rejection, wherein the SMTP server issues a 5xy reply code as
 an indication to the SMTP client that the transaction failed; the
 SMTP client is then responsible for generating notification that
-delivery failed (see Section 4.2.5 of <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span>).<a href="#section-8.3-3.1.1" class="pilcrow">¶</a></p>
+delivery failed (see Section 4.2.5 of <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span>).<a href="#section-7.3-3.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-8.3-3.2">
-            <p id="section-8.3-3.2.1">A "silent discard", wherein the SMTP server returns a 2xy reply
+<li id="section-7.3-3.2">
+            <p id="section-7.3-3.2.1">A "silent discard", wherein the SMTP server returns a 2xy reply
 code implying to the client that delivery (or, at least, relay)
 was successfully completed, but then simply discarding the message
-with no further action.<a href="#section-8.3-3.2.1" class="pilcrow">¶</a></p>
+with no further action.<a href="#section-7.3-3.2.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
-<p id="section-8.3-4">Each of these has a cost.  For instance, a silent discard can help to
+<p id="section-7.3-4">Each of these has a cost.  For instance, a silent discard can help to
 prevent backscatter, but it also effectively means that the SMTP
 server has to be programmed to give a false result, which can
-confound external debugging efforts.<a href="#section-8.3-4" class="pilcrow">¶</a></p>
-<p id="section-8.3-5">Similarly, the text portion of the SMTP reply may be important to
+confound external debugging efforts.<a href="#section-7.3-4" class="pilcrow">¶</a></p>
+<p id="section-7.3-5">Similarly, the text portion of the SMTP reply may be important to
 consider.  For example, when rejecting a message, revealing the
 reason for the rejection might give an attacker enough information to
 bypass those efforts on a later attempt, though it might also assist
 a legitimate client to determine the source of some local issue that
-caused the rejection.<a href="#section-8.3-5" class="pilcrow">¶</a></p>
-<p id="section-8.3-6">In the latter case, when doing an SMTP rejection, providing a clear
+caused the rejection.<a href="#section-7.3-5" class="pilcrow">¶</a></p>
+<p id="section-7.3-6">In the latter case, when doing an SMTP rejection, providing a clear
 hint can be useful in resolving issues.  A receiver might indicate in
 plain text the reason for the rejection by using the word "DMARC"
 somewhere in the reply text.  Many systems are able to scan the SMTP
 reply text to determine the nature of the rejection.  Thus, providing
 a machine-detectable reason for rejection allows the problems causing
 rejections to be properly addressed by automated systems.  For
-example:<a href="#section-8.3-6" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-8.3-7">
+example:<a href="#section-7.3-6" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-7.3-7">
 <pre>550 5.7.1 Email rejected per DMARC policy for example.com
-</pre><a href="#section-8.3-7" class="pilcrow">¶</a>
+</pre><a href="#section-7.3-7" class="pilcrow">¶</a>
 </div>
-<p id="section-8.3-8">If a Mail Receiver elects to defer delivery due to inability to
+<p id="section-7.3-8">If a Mail Receiver elects to defer delivery due to inability to
 retrieve or apply DMARC policy, this is best done with a 4xy SMTP
-reply code.<a href="#section-8.3-8" class="pilcrow">¶</a></p>
+reply code.<a href="#section-7.3-8" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="identifier-alignment-considerations">
-<section id="section-8.4">
+<section id="section-7.4">
         <h3 id="name-identifier-alignment-consid">
-<a href="#section-8.4" class="section-number selfRef">8.4. </a><a href="#name-identifier-alignment-consid" class="section-name selfRef">Identifier Alignment Considerations</a>
+<a href="#section-7.4" class="section-number selfRef">7.4. </a><a href="#name-identifier-alignment-consid" class="section-name selfRef">Identifier Alignment Considerations</a>
         </h3>
-<p id="section-8.4-1">The DMARC mechanism allows both DKIM and SPF-authenticated
+<p id="section-7.4-1">The DMARC mechanism allows both DKIM and SPF-authenticated
 identifiers to authenticate email on behalf of a Domain Owner and,
 possibly, on behalf of different subdomains.  If malicious or unaware
 users can gain control of the SPF record or DKIM selector records for
 a subdomain, the subdomain can be used to generate DMARC-passing
-email on behalf of the Organizational Domain.<a href="#section-8.4-1" class="pilcrow">¶</a></p>
-<p id="section-8.4-2">For example, an attacker who controls the SPF record for
+email on behalf of the Organizational Domain.<a href="#section-7.4-1" class="pilcrow">¶</a></p>
+<p id="section-7.4-2">For example, an attacker who controls the SPF record for
 "evil.example.com" can send mail with an RFC5322.From header field
 containing "foo@example.com" that can pass both authentication and
-the DMARC check against "example.com".<a href="#section-8.4-2" class="pilcrow">¶</a></p>
-<p id="section-8.4-3">The Organizational Domain administrator should be careful not to
+the DMARC check against "example.com".<a href="#section-7.4-2" class="pilcrow">¶</a></p>
+<p id="section-7.4-3">The Organizational Domain administrator should be careful not to
 delegate control of subdomains if this is an issue, and to consider
-using the "strict" Identifier Alignment option if appropriate.<a href="#section-8.4-3" class="pilcrow">¶</a></p>
+using the "strict" Identifier Alignment option if appropriate.<a href="#section-7.4-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="interoperability-issues">
-<section id="section-8.5">
+<section id="section-7.5">
         <h3 id="name-interoperability-issues">
-<a href="#section-8.5" class="section-number selfRef">8.5. </a><a href="#name-interoperability-issues" class="section-name selfRef">Interoperability Issues</a>
+<a href="#section-7.5" class="section-number selfRef">7.5. </a><a href="#name-interoperability-issues" class="section-name selfRef">Interoperability Issues</a>
         </h3>
-<p id="section-8.5-1">DMARC limits which end-to-end scenarios can achieve a "pass" result.<a href="#section-8.5-1" class="pilcrow">¶</a></p>
-<p id="section-8.5-2">Because DMARC relies on SPF <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span> and/or DKIM <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span> to achieve
-a "pass", their limitations also apply.<a href="#section-8.5-2" class="pilcrow">¶</a></p>
-<p id="section-8.5-3">Additional DMARC constraints occur when a message is processed by
+<p id="section-7.5-1">DMARC limits which end-to-end scenarios can achieve a "pass" result.<a href="#section-7.5-1" class="pilcrow">¶</a></p>
+<p id="section-7.5-2">Because DMARC relies on SPF <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span> and/or DKIM <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span> to achieve
+a "pass", their limitations also apply.<a href="#section-7.5-2" class="pilcrow">¶</a></p>
+<p id="section-7.5-3">Additional DMARC constraints occur when a message is processed by
 some Mediators, such as mailing lists.  Transiting a Mediator often
 causes either the authentication to fail or Identifier Alignment to
 be lost.  These transformations may conform to standards but will
-still prevent a DMARC "pass".<a href="#section-8.5-3" class="pilcrow">¶</a></p>
-<p id="section-8.5-4">In addition to Mediators, mail that is sent by authorized,
+still prevent a DMARC "pass".<a href="#section-7.5-3" class="pilcrow">¶</a></p>
+<p id="section-7.5-4">In addition to Mediators, mail that is sent by authorized,
 independent third parties might not be sent with Identifier
-Alignment, also preventing a "pass" result.<a href="#section-8.5-4" class="pilcrow">¶</a></p>
-<p id="section-8.5-5">Issues specific to the use of policy mechanisms alongside DKIM are
-further discussed in <span>[<a href="#RFC6377" class="xref">RFC6377</a>]</span>, particularly Section 5.2.<a href="#section-8.5-5" class="pilcrow">¶</a></p>
+Alignment, also preventing a "pass" result.<a href="#section-7.5-4" class="pilcrow">¶</a></p>
+<p id="section-7.5-5">Issues specific to the use of policy mechanisms alongside DKIM are
+further discussed in <span>[<a href="#RFC6377" class="xref">RFC6377</a>]</span>, particularly Section 5.2.<a href="#section-7.5-5" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="iana-considerations">
-<section id="section-9">
+<section id="section-8">
       <h2 id="name-iana-considerations">
-<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
       </h2>
-<p id="section-9-1">This section describes actions completed by IANA.<a href="#section-9-1" class="pilcrow">¶</a></p>
+<p id="section-8-1">This section describes actions completed by IANA.<a href="#section-8-1" class="pilcrow">¶</a></p>
 <div id="authentication-results-method-registry-update">
-<section id="section-9.1">
+<section id="section-8.1">
         <h3 id="name-authentication-results-meth">
-<a href="#section-9.1" class="section-number selfRef">9.1. </a><a href="#name-authentication-results-meth" class="section-name selfRef">Authentication-Results Method Registry Update</a>
+<a href="#section-8.1" class="section-number selfRef">8.1. </a><a href="#name-authentication-results-meth" class="section-name selfRef">Authentication-Results Method Registry Update</a>
         </h3>
-<p id="section-9.1-1">IANA has added the following to the "Email Authentication Methods"
-registry:<a href="#section-9.1-1" class="pilcrow">¶</a></p>
+<p id="section-8.1-1">IANA has added the following to the "Email Authentication Methods"
+registry:<a href="#section-8.1-1" class="pilcrow">¶</a></p>
 <span id="name-authentication-results-metho"></span><table class="left" id="table-1">
           <caption>
 <a href="#table-1" class="selfRef">Table 1</a>:
@@ -3419,12 +3413,12 @@ registry:<a href="#section-9.1-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="authentication-results-result-registry-update">
-<section id="section-9.2">
+<section id="section-8.2">
         <h3 id="name-authentication-results-resu">
-<a href="#section-9.2" class="section-number selfRef">9.2. </a><a href="#name-authentication-results-resu" class="section-name selfRef">Authentication-Results Result Registry Update</a>
+<a href="#section-8.2" class="section-number selfRef">8.2. </a><a href="#name-authentication-results-resu" class="section-name selfRef">Authentication-Results Result Registry Update</a>
         </h3>
-<p id="section-9.2-1">IANA has added the following in the "Email Authentication Result
-Names" registry:<a href="#section-9.2-1" class="pilcrow">¶</a></p>
+<p id="section-8.2-1">IANA has added the following in the "Email Authentication Result
+Names" registry:<a href="#section-8.2-1" class="pilcrow">¶</a></p>
 <span id="name-authentication-results-resul"></span><table class="left" id="table-2">
           <caption>
 <a href="#table-2" class="selfRef">Table 2</a>:
@@ -3496,37 +3490,37 @@ Names" registry:<a href="#section-9.2-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="feedback-report-header-fields-registry-update">
-<section id="section-9.3">
+<section id="section-8.3">
         <h3 id="name-feedback-report-header-fiel">
-<a href="#section-9.3" class="section-number selfRef">9.3. </a><a href="#name-feedback-report-header-fiel" class="section-name selfRef">Feedback Report Header Fields Registry Update</a>
+<a href="#section-8.3" class="section-number selfRef">8.3. </a><a href="#name-feedback-report-header-fiel" class="section-name selfRef">Feedback Report Header Fields Registry Update</a>
         </h3>
-<p id="section-9.3-1">The following has been added to the "Feedback Report Header Fields"
-registry:<a href="#section-9.3-1" class="pilcrow">¶</a></p>
-<p id="section-9.3-2">Field Name:  Identity-Alignment<a href="#section-9.3-2" class="pilcrow">¶</a></p>
-<dl class="dlParallel" id="section-9.3-3">
-          <dt id="section-9.3-3.1">Description:</dt>
-<dd id="section-9.3-3.2">indicates whether the message about which a report is
+<p id="section-8.3-1">The following has been added to the "Feedback Report Header Fields"
+registry:<a href="#section-8.3-1" class="pilcrow">¶</a></p>
+<p id="section-8.3-2">Field Name:  Identity-Alignment<a href="#section-8.3-2" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-8.3-3">
+          <dt id="section-8.3-3.1">Description:</dt>
+<dd id="section-8.3-3.2">indicates whether the message about which a report is
 being generated had any identifiers in alignment as defined in
-RFC 7489<a href="#section-9.3-3.2" class="pilcrow">¶</a>
+RFC 7489<a href="#section-8.3-3.2" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
 </dl>
-<p id="section-9.3-4">Multiple Appearances:  No<a href="#section-9.3-4" class="pilcrow">¶</a></p>
-<p id="section-9.3-5">Related "Feedback-Type":  auth-failure<a href="#section-9.3-5" class="pilcrow">¶</a></p>
-<p id="section-9.3-6">Reference:  RFC 7489<a href="#section-9.3-6" class="pilcrow">¶</a></p>
-<p id="section-9.3-7">Status:  current<a href="#section-9.3-7" class="pilcrow">¶</a></p>
+<p id="section-8.3-4">Multiple Appearances:  No<a href="#section-8.3-4" class="pilcrow">¶</a></p>
+<p id="section-8.3-5">Related "Feedback-Type":  auth-failure<a href="#section-8.3-5" class="pilcrow">¶</a></p>
+<p id="section-8.3-6">Reference:  RFC 7489<a href="#section-8.3-6" class="pilcrow">¶</a></p>
+<p id="section-8.3-7">Status:  current<a href="#section-8.3-7" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="dmarc-tag-registry">
-<section id="section-9.4">
+<section id="section-8.4">
         <h3 id="name-dmarc-tag-registry">
-<a href="#section-9.4" class="section-number selfRef">9.4. </a><a href="#name-dmarc-tag-registry" class="section-name selfRef">DMARC Tag Registry</a>
+<a href="#section-8.4" class="section-number selfRef">8.4. </a><a href="#name-dmarc-tag-registry" class="section-name selfRef">DMARC Tag Registry</a>
         </h3>
-<p id="section-9.4-1">A new registry tree called "Domain-based Message Authentication,
+<p id="section-8.4-1">A new registry tree called "Domain-based Message Authentication,
 Reporting, and Conformance (DMARC) Parameters" has been created.
 Within it, a new sub-registry called the "DMARC Tag Registry" has
-been created.<a href="#section-9.4-1" class="pilcrow">¶</a></p>
-<p id="section-9.4-2">Names of DMARC tags must be registered with IANA in this new
+been created.<a href="#section-8.4-1" class="pilcrow">¶</a></p>
+<p id="section-8.4-2">Names of DMARC tags must be registered with IANA in this new
 sub-registry.  New entries are assigned only for values that have
 been documented in a manner that satisfies the terms of Specification
 Required, per <span>[<a href="#RFC8126" class="xref">RFC8126</a>]</span>.  Each registration must include
@@ -3535,11 +3529,11 @@ and its status, which must be one of "current", "experimental", or
 "historic".  The Designated Expert needs to confirm that the provided
 specification adequately describes the new tag and clearly presents
 how it would be used within the DMARC context by Domain Owners and
-Mail Receivers.<a href="#section-9.4-2" class="pilcrow">¶</a></p>
-<p id="section-9.4-3">To avoid version compatibility issues, tags added to the DMARC
+Mail Receivers.<a href="#section-8.4-2" class="pilcrow">¶</a></p>
+<p id="section-8.4-3">To avoid version compatibility issues, tags added to the DMARC
 specification are to avoid changing the semantics of existing records
-when processed by implementations conforming to prior specifications.<a href="#section-9.4-3" class="pilcrow">¶</a></p>
-<p id="section-9.4-4">The initial set of entries in this registry is as follows:<a href="#section-9.4-4" class="pilcrow">¶</a></p>
+when processed by implementations conforming to prior specifications.<a href="#section-8.4-3" class="pilcrow">¶</a></p>
+<p id="section-8.4-4">The initial set of entries in this registry is as follows:<a href="#section-8.4-4" class="pilcrow">¶</a></p>
 <span id="name-dmarc-tag-registry-2"></span><table class="left" id="table-3">
           <caption>
 <a href="#table-3" class="selfRef">Table 3</a>:
@@ -3631,14 +3625,14 @@ when processed by implementations conforming to prior specifications.<a href="#s
 </section>
 </div>
 <div id="dmarc-report-format-registry">
-<section id="section-9.5">
+<section id="section-8.5">
         <h3 id="name-dmarc-report-format-registr">
-<a href="#section-9.5" class="section-number selfRef">9.5. </a><a href="#name-dmarc-report-format-registr" class="section-name selfRef">DMARC Report Format Registry</a>
+<a href="#section-8.5" class="section-number selfRef">8.5. </a><a href="#name-dmarc-report-format-registr" class="section-name selfRef">DMARC Report Format Registry</a>
         </h3>
-<p id="section-9.5-1">Also within "Domain-based Message Authentication, Reporting, and
+<p id="section-8.5-1">Also within "Domain-based Message Authentication, Reporting, and
 Conformance (DMARC) Parameters", a new sub-registry called "DMARC
-Report Format Registry" has been created.<a href="#section-9.5-1" class="pilcrow">¶</a></p>
-<p id="section-9.5-2">Names of DMARC failure reporting formats must be registered with IANA
+Report Format Registry" has been created.<a href="#section-8.5-1" class="pilcrow">¶</a></p>
+<p id="section-8.5-2">Names of DMARC failure reporting formats must be registered with IANA
 in this registry.  New entries are assigned only for values that
 satisfy the definition of Specification Required, per
 <span>[<a href="#RFC8126" class="xref">RFC8126</a>]</span>.  In addition to a reference to a permanent
@@ -3647,8 +3641,8 @@ brief description; and its status, which must be one of "current",
 "experimental", or "historic".  The Designated Expert needs to
 confirm that the provided specification adequately describes the
 report format and clearly presents how it would be used within the
-DMARC context by Domain Owners and Mail Receivers.<a href="#section-9.5-2" class="pilcrow">¶</a></p>
-<p id="section-9.5-3">The initial entry in this registry is as follows:<a href="#section-9.5-3" class="pilcrow">¶</a></p>
+DMARC context by Domain Owners and Mail Receivers.<a href="#section-8.5-2" class="pilcrow">¶</a></p>
+<p id="section-8.5-3">The initial entry in this registry is as follows:<a href="#section-8.5-3" class="pilcrow">¶</a></p>
 <span id="name-dmarc-report-format-registry"></span><table class="left" id="table-4">
           <caption>
 <a href="#table-4" class="selfRef">Table 4</a>:
@@ -3674,12 +3668,12 @@ DMARC context by Domain Owners and Mail Receivers.<a href="#section-9.5-2" class
 </section>
 </div>
 <div id="underscored-and-globally-scoped-dns-node-names-registry">
-<section id="section-9.6">
+<section id="section-8.6">
         <h3 id="name-underscored-and-globally-sc">
-<a href="#section-9.6" class="section-number selfRef">9.6. </a><a href="#name-underscored-and-globally-sc" class="section-name selfRef">Underscored and Globally Scoped DNS Node Names Registry</a>
+<a href="#section-8.6" class="section-number selfRef">8.6. </a><a href="#name-underscored-and-globally-sc" class="section-name selfRef">Underscored and Globally Scoped DNS Node Names Registry</a>
         </h3>
-<p id="section-9.6-1">Per <span>[<a href="#RFC8552" class="xref">RFC8552</a>]</span>, please add the following entry to the "Underscored
-and Globally Scoped DNS Node Names" registry:<a href="#section-9.6-1" class="pilcrow">¶</a></p>
+<p id="section-8.6-1">Per <span>[<a href="#RFC8552" class="xref">RFC8552</a>]</span>, please add the following entry to the "Underscored
+and Globally Scoped DNS Node Names" registry:<a href="#section-8.6-1" class="pilcrow">¶</a></p>
 <span id="name-underscored-and-globally-sco"></span><table class="left" id="table-5">
           <caption>
 <a href="#table-5" class="selfRef">Table 5</a>:
@@ -3705,93 +3699,93 @@ and Globally Scoped DNS Node Names" registry:<a href="#section-9.6-1" class="pil
 </section>
 </div>
 <div id="security-considerations">
-<section id="section-10">
+<section id="section-9">
       <h2 id="name-security-considerations">
-<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
       </h2>
-<p id="section-10-1">This section discusses security issues and possible remediations
-(where available) for DMARC.<a href="#section-10-1" class="pilcrow">¶</a></p>
+<p id="section-9-1">This section discusses security issues and possible remediations
+(where available) for DMARC.<a href="#section-9-1" class="pilcrow">¶</a></p>
 <div id="authentication-methods">
-<section id="section-10.1">
+<section id="section-9.1">
         <h3 id="name-authentication-methods">
-<a href="#section-10.1" class="section-number selfRef">10.1. </a><a href="#name-authentication-methods" class="section-name selfRef">Authentication Methods</a>
+<a href="#section-9.1" class="section-number selfRef">9.1. </a><a href="#name-authentication-methods" class="section-name selfRef">Authentication Methods</a>
         </h3>
-<p id="section-10.1-1">Security considerations from the authentication methods used by DMARC
-are incorporated here by reference.<a href="#section-10.1-1" class="pilcrow">¶</a></p>
+<p id="section-9.1-1">Security considerations from the authentication methods used by DMARC
+are incorporated here by reference.<a href="#section-9.1-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="attacks-on-reporting-uris">
-<section id="section-10.2">
+<section id="section-9.2">
         <h3 id="name-attacks-on-reporting-uris">
-<a href="#section-10.2" class="section-number selfRef">10.2. </a><a href="#name-attacks-on-reporting-uris" class="section-name selfRef">Attacks on Reporting URIs</a>
+<a href="#section-9.2" class="section-number selfRef">9.2. </a><a href="#name-attacks-on-reporting-uris" class="section-name selfRef">Attacks on Reporting URIs</a>
         </h3>
-<p id="section-10.2-1">URIs published in DNS TXT records are well-understood possible
+<p id="section-9.2-1">URIs published in DNS TXT records are well-understood possible
 targets for attack.  Specifications such as <span>[<a href="#RFC1035" class="xref">RFC1035</a>]</span> and <span>[<a href="#RFC2142" class="xref">RFC2142</a>]</span> either
 expose or cause the exposure of email addresses that could be flooded
 by an attacker, for example; MX, NS, and other records found in the
 DNS advertise potential attack destinations; common DNS names such as
 "www" plainly identify the locations at which particular services can
 be found, providing destinations for targeted denial-of-service or
-penetration attacks.<a href="#section-10.2-1" class="pilcrow">¶</a></p>
-<p id="section-10.2-2">Thus, Domain Owners will need to harden these addresses against
-various attacks, including but not limited to:<a href="#section-10.2-2" class="pilcrow">¶</a></p>
+penetration attacks.<a href="#section-9.2-1" class="pilcrow">¶</a></p>
+<p id="section-9.2-2">Thus, Domain Owners will need to harden these addresses against
+various attacks, including but not limited to:<a href="#section-9.2-2" class="pilcrow">¶</a></p>
 <ul>
-<li id="section-10.2-3.1">
-            <p id="section-10.2-3.1.1">high-volume denial-of-service attacks;<a href="#section-10.2-3.1.1" class="pilcrow">¶</a></p>
+<li id="section-9.2-3.1">
+            <p id="section-9.2-3.1.1">high-volume denial-of-service attacks;<a href="#section-9.2-3.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-10.2-3.2">
-            <p id="section-10.2-3.2.1">deliberate construction of malformed reports intended to identify
-or exploit parsing or processing vulnerabilities;<a href="#section-10.2-3.2.1" class="pilcrow">¶</a></p>
+<li id="section-9.2-3.2">
+            <p id="section-9.2-3.2.1">deliberate construction of malformed reports intended to identify
+or exploit parsing or processing vulnerabilities;<a href="#section-9.2-3.2.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-10.2-3.3">
-            <p id="section-10.2-3.3.1">deliberate construction of reports containing false claims for the
+<li id="section-9.2-3.3">
+            <p id="section-9.2-3.3.1">deliberate construction of reports containing false claims for the
 Submitter or Reported-Domain fields, including the possibility of
-false data from compromised but known Mail Receivers.<a href="#section-10.2-3.3.1" class="pilcrow">¶</a></p>
+false data from compromised but known Mail Receivers.<a href="#section-9.2-3.3.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </section>
 </div>
 <div id="dns-security">
-<section id="section-10.3">
+<section id="section-9.3">
         <h3 id="name-dns-security">
-<a href="#section-10.3" class="section-number selfRef">10.3. </a><a href="#name-dns-security" class="section-name selfRef">DNS Security</a>
+<a href="#section-9.3" class="section-number selfRef">9.3. </a><a href="#name-dns-security" class="section-name selfRef">DNS Security</a>
         </h3>
-<p id="section-10.3-1">The DMARC mechanism and its underlying technologies (SPF, DKIM)
+<p id="section-9.3-1">The DMARC mechanism and its underlying technologies (SPF, DKIM)
 depend on the security of the DNS. Examples of how hostile parties can
 have an adverse impact on DNS traffic include:
 *  If they can snoop on DNS traffic, they can get an idea of who is
-   sending mail.<a href="#section-10.3-1" class="pilcrow">¶</a></p>
+   sending mail.<a href="#section-9.3-1" class="pilcrow">¶</a></p>
 <ul>
-<li id="section-10.3-2.1">
-            <p id="section-10.3-2.1.1">If they can block outgoing or reply DNS messages, they can prevent
+<li id="section-9.3-2.1">
+            <p id="section-9.3-2.1.1">If they can block outgoing or reply DNS messages, they can prevent
 systems from discovering senders' DMARC policies, causing recipients
-to assume p=none by default.<a href="#section-10.3-2.1.1" class="pilcrow">¶</a></p>
+to assume p=none by default.<a href="#section-9.3-2.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-10.3-2.2">
-            <p id="section-10.3-2.2.1">If they can send forged response packets, they can make aligned mail
-appear unaligned or vice-versa.<a href="#section-10.3-2.2.1" class="pilcrow">¶</a></p>
+<li id="section-9.3-2.2">
+            <p id="section-9.3-2.2.1">If they can send forged response packets, they can make aligned mail
+appear unaligned or vice-versa.<a href="#section-9.3-2.2.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
-<p id="section-10.3-3">None of these threats are unique to DMARC, and they can be addressed using
-a variety of techniques, including, but not limited to:<a href="#section-10.3-3" class="pilcrow">¶</a></p>
+<p id="section-9.3-3">None of these threats are unique to DMARC, and they can be addressed using
+a variety of techniques, including, but not limited to:<a href="#section-9.3-3" class="pilcrow">¶</a></p>
 <ul>
-<li id="section-10.3-4.1">
-            <p id="section-10.3-4.1.1">Signing DNS records with DNSSEC <span>[<a href="#RFC4033" class="xref">RFC4033</a>]</span>, which enables recipients to
-detect and discard forged responses.<a href="#section-10.3-4.1.1" class="pilcrow">¶</a></p>
+<li id="section-9.3-4.1">
+            <p id="section-9.3-4.1.1">Signing DNS records with DNSSEC <span>[<a href="#RFC4033" class="xref">RFC4033</a>]</span>, which enables recipients to
+detect and discard forged responses.<a href="#section-9.3-4.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-10.3-4.2">
-            <p id="section-10.3-4.2.1">DNS over TLS <span>[<a href="#RFC7858" class="xref">RFC7858</a>]</span> or DNS over HTTPS <span>[<a href="#RFC8484" class="xref">RFC8484</a>]</span> can mitigate snooping
-and forged responses.<a href="#section-10.3-4.2.1" class="pilcrow">¶</a></p>
+<li id="section-9.3-4.2">
+            <p id="section-9.3-4.2.1">DNS over TLS <span>[<a href="#RFC7858" class="xref">RFC7858</a>]</span> or DNS over HTTPS <span>[<a href="#RFC8484" class="xref">RFC8484</a>]</span> can mitigate snooping
+and forged responses.<a href="#section-9.3-4.2.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </section>
 </div>
 <div id="display-name-attacks">
-<section id="section-10.4">
+<section id="section-9.4">
         <h3 id="name-display-name-attacks">
-<a href="#section-10.4" class="section-number selfRef">10.4. </a><a href="#name-display-name-attacks" class="section-name selfRef">Display Name Attacks</a>
+<a href="#section-9.4" class="section-number selfRef">9.4. </a><a href="#name-display-name-attacks" class="section-name selfRef">Display Name Attacks</a>
         </h3>
-<p id="section-10.4-1">A common attack in messaging abuse is the presentation of false
+<p id="section-9.4-1">A common attack in messaging abuse is the presentation of false
 information in the display-name portion of the RFC5322.From header field.
 For example, it is possible for the email address in that field to be
 an arbitrary address or domain name, while containing a well-known
@@ -3799,84 +3793,84 @@ name (a person, brand, role, etc.) in the display name, intending to
 fool the end user into believing that the name is used legitimately.
 The attack is predicated on the notion that most common MUAs will
 show the display name and not the email address when both are
-available.<a href="#section-10.4-1" class="pilcrow">¶</a></p>
-<p id="section-10.4-2">Generally, display name attacks are out of scope for DMARC, as
+available.<a href="#section-9.4-1" class="pilcrow">¶</a></p>
+<p id="section-9.4-2">Generally, display name attacks are out of scope for DMARC, as
 further exploration of possible defenses against these attacks needs
-to be undertaken.<a href="#section-10.4-2" class="pilcrow">¶</a></p>
-<p id="section-10.4-3">There are a few possible mechanisms that attempt mitigation of these
-attacks, such as the following:<a href="#section-10.4-3" class="pilcrow">¶</a></p>
+to be undertaken.<a href="#section-9.4-2" class="pilcrow">¶</a></p>
+<p id="section-9.4-3">There are a few possible mechanisms that attempt mitigation of these
+attacks, such as the following:<a href="#section-9.4-3" class="pilcrow">¶</a></p>
 <ul>
-<li id="section-10.4-4.1">
-            <p id="section-10.4-4.1.1">If the display name is found to include an email address (as
+<li id="section-9.4-4.1">
+            <p id="section-9.4-4.1.1">If the display name is found to include an email address (as
 specified in <span>[<a href="#RFC5322" class="xref">RFC5322</a>]</span>), execute the DMARC mechanism on the domain
 name found there rather than the domain name discovered
 originally.  However, this addresses only a very specific attack
 space, and spoofers can easily circumvent it by simply not using
 an email address in the display name.  There are also known cases
 of legitimate uses of an email address in the display name with a
-domain different from the one in the address portion, e.g.,<a href="#section-10.4-4.1.1" class="pilcrow">¶</a></p>
-<p id="section-10.4-4.1.2">From: "user@example.org via Bug Tracker" <a href="mailto:support@example.com">support@example.com</a><a href="#section-10.4-4.1.2" class="pilcrow">¶</a></p>
+domain different from the one in the address portion, e.g.,<a href="#section-9.4-4.1.1" class="pilcrow">¶</a></p>
+<p id="section-9.4-4.1.2">From: "user@example.org via Bug Tracker" <a href="mailto:support@example.com">support@example.com</a><a href="#section-9.4-4.1.2" class="pilcrow">¶</a></p>
 </li>
-<li id="section-10.4-4.2">
-            <p id="section-10.4-4.2.1">In the MUA, only show the display name if the DMARC mechanism
+<li id="section-9.4-4.2">
+            <p id="section-9.4-4.2.1">In the MUA, only show the display name if the DMARC mechanism
 succeeds.  This too is easily defeated, as an attacker could
 arrange to pass the DMARC tests while fraudulently using another
-domain name in the display name.<a href="#section-10.4-4.2.1" class="pilcrow">¶</a></p>
+domain name in the display name.<a href="#section-9.4-4.2.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-10.4-4.3">
-            <p id="section-10.4-4.3.1">In the MUA, only show the display name if the DMARC mechanism
+<li id="section-9.4-4.3">
+            <p id="section-9.4-4.3.1">In the MUA, only show the display name if the DMARC mechanism
 passes and the email address thus verified matches one found in
-the receiving user's list of known addresses.<a href="#section-10.4-4.3.1" class="pilcrow">¶</a></p>
+the receiving user's list of known addresses.<a href="#section-9.4-4.3.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </section>
 </div>
 <div id="external-report-addresses">
-<section id="section-10.5">
+<section id="section-9.5">
         <h3 id="name-external-reporting-addresse">
-<a href="#section-10.5" class="section-number selfRef">10.5. </a><a href="#name-external-reporting-addresse" class="section-name selfRef">External Reporting Addresses</a>
+<a href="#section-9.5" class="section-number selfRef">9.5. </a><a href="#name-external-reporting-addresse" class="section-name selfRef">External Reporting Addresses</a>
         </h3>
-<p id="section-10.5-1">To avoid abuse by bad actors, reporting addresses generally have to
+<p id="section-9.5-1">To avoid abuse by bad actors, reporting addresses generally have to
 be inside the domains about which reports are requested.  In order to
 accommodate special cases such as a need to get reports about domains
 that cannot actually receive mail, Section 3 of <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> describes
-a DNS-based mechanism for verifying approved external reporting.<a href="#section-10.5-1" class="pilcrow">¶</a></p>
-<p id="section-10.5-2">The obvious consideration here is an increased DNS load against
+a DNS-based mechanism for verifying approved external reporting.<a href="#section-9.5-1" class="pilcrow">¶</a></p>
+<p id="section-9.5-2">The obvious consideration here is an increased DNS load against
 domains that are claimed as external recipients.  Negative caching
 will mitigate this problem, but only to a limited extent, mostly
-dependent on the default TTL in the domain's SOA record.<a href="#section-10.5-2" class="pilcrow">¶</a></p>
-<p id="section-10.5-3">Where possible, external reporting is best achieved by having the
+dependent on the default TTL in the domain's SOA record.<a href="#section-9.5-2" class="pilcrow">¶</a></p>
+<p id="section-9.5-3">Where possible, external reporting is best achieved by having the
 report be directed to domains that can receive mail and simply having
-it automatically forwarded to the desired external destination.<a href="#section-10.5-3" class="pilcrow">¶</a></p>
-<p id="section-10.5-4">Note that the addresses shown in the "ruf" tag receive more
+it automatically forwarded to the desired external destination.<a href="#section-9.5-3" class="pilcrow">¶</a></p>
+<p id="section-9.5-4">Note that the addresses shown in the "ruf" tag receive more
 information that might be considered private data, since it is
 possible for actual email content to appear in the failure reports.
 The URIs identified there are thus more attractive targets for
 intrusion attempts than those found in the "rua" tag.  Moreover,
 attacking the DNS of the subject domain to cause failure data to be
 routed fraudulently to an attacker's systems may be an attractive
-prospect.  Deployment of <span>[<a href="#RFC4033" class="xref">RFC4033</a>]</span> is advisable if this is a concern.<a href="#section-10.5-4" class="pilcrow">¶</a></p>
+prospect.  Deployment of <span>[<a href="#RFC4033" class="xref">RFC4033</a>]</span> is advisable if this is a concern.<a href="#section-9.5-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="secure-protocols">
-<section id="section-10.6">
+<section id="section-9.6">
         <h3 id="name-secure-protocols">
-<a href="#section-10.6" class="section-number selfRef">10.6. </a><a href="#name-secure-protocols" class="section-name selfRef">Secure Protocols</a>
+<a href="#section-9.6" class="section-number selfRef">9.6. </a><a href="#name-secure-protocols" class="section-name selfRef">Secure Protocols</a>
         </h3>
-<p id="section-10.6-1">This document encourages use of secure transport mechanisms to
+<p id="section-9.6-1">This document encourages use of secure transport mechanisms to
 prevent loss of private data to third parties that may be able to
 monitor such transmissions.  Unencrypted mechanisms should be
-avoided.<a href="#section-10.6-1" class="pilcrow">¶</a></p>
-<p id="section-10.6-2">In particular, a message that was originally encrypted or otherwise
+avoided.<a href="#section-9.6-1" class="pilcrow">¶</a></p>
+<p id="section-9.6-2">In particular, a message that was originally encrypted or otherwise
 secured might appear in a report that is not sent securely, which
-could reveal private information.<a href="#section-10.6-2" class="pilcrow">¶</a></p>
+could reveal private information.<a href="#section-9.6-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
-<section id="section-11">
+<section id="section-10">
       <h2 id="name-normative-references">
-<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
       </h2>
 <dl class="references">
 <dt id="DMARC-Aggregate-Reporting">[DMARC-Aggregate-Reporting]</dt>
@@ -3953,9 +3947,9 @@ could reveal private information.<a href="#section-10.6-2" class="pilcrow">¶</a
 <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-12">
+<section id="section-11">
       <h2 id="name-informative-references">
-<a href="#section-12" class="section-number selfRef">12. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
+<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
       </h2>
 <dl class="references">
 <dt id="Best-Guess-SPF">[Best-Guess-SPF]</dt>
@@ -4224,7 +4218,7 @@ labels; this would cause a Mail Receiver to attempt a large number of
 queries in search of a policy record.  Sending many such messages
 constitutes an amplified denial-of-service attack.<a href="#section-a.6-3" class="pilcrow">¶</a></p>
 <p id="section-a.6-4">The Organizational Domain mechanism is a necessary component to the
-goals of DMARC.  The method described in <a href="#determining-the-organizational-domain" class="xref">Section 3.4</a> is far from
+goals of DMARC.  The method described in <a href="#determining-the-organizational-domain" class="xref">Section 4.5</a> is far from
 perfect but serves this purpose reasonably well without adding undue
 burden or semantics to the DNS.  If a method is created to do so that
 is more reliable and secure than the use of a public suffix list,

--- a/draft-ietf-dmarc-dmarcbis-04.html
+++ b/draft-ietf-dmarc-dmarcbis-04.html
@@ -1,0 +1,5317 @@
+<!DOCTYPE html>
+<html lang="en" class="Internet-Draft">
+<head>
+<meta charset="utf-8">
+<meta content="Common,Latin" name="scripts">
+<meta content="initial-scale=1.0" name="viewport">
+<title>Domain-based Message Authentication, Reporting, and Conformance (DMARC)</title>
+<meta content="Todd M. Herr" name="author">
+<meta content="John Levine" name="author">
+<meta content="
+       This document describes the Domain-based Message Authentication,
+Reporting, and Conformance (DMARC) protocol. 
+       DMARC permits the owner of an email author's domain name to enable
+verification of the domain's use, to indicate the Domain Owner's or
+Public Suffix Operator's severity of concern regarding failed
+verification, and to request reports about use of the domain name.
+Mail receiving organizations can use this information when evaluating
+handling choices for incoming mail. 
+       This document obsoletes RFC 7489. 
+    " name="description">
+<meta content="xml2rfc 2.44.0" name="generator">
+<meta content="draft-ietf-dmarc-dmarcbis-04" name="ietf.draft">
+<link href="draft-ietf-dmarc-dmarcbis-04.xml" rel="alternate" type="application/rfc+xml">
+<link href="#copyright" rel="license">
+<style type="text/css">/*
+
+  NOTE: Changes at the bottom of this file overrides some earlier settings.
+
+  Once the style has stabilized and has been adopted as an official RFC style,
+  this can be consolidated so that style settings occur only in one place, but
+  for now the contents of this file consists first of the initial CSS work as
+  provided to the RFC Formatter (xml2rfc) work, followed by itemized and
+  commented changes found necssary during the development of the v3
+  formatters.
+
+*/
+
+/* fonts */
+@import url('https://fonts.googleapis.com/css?family=Noto+Sans'); /* Sans-serif */
+@import url('https://fonts.googleapis.com/css?family=Noto+Serif'); /* Serif (print) */
+@import url('https://fonts.googleapis.com/css?family=Roboto+Mono'); /* Monospace */
+
+@viewport {
+  zoom: 1.0;
+  width: extend-to-zoom;
+}
+@-ms-viewport {
+  width: extend-to-zoom;
+  zoom: 1.0;
+}
+/* general and mobile first */
+html {
+}
+body {
+  max-width: 90%;
+  margin: 1.5em auto;
+  color: #222;
+  background-color: #fff;
+  font-size: 14px;
+  font-family: 'Noto Sans', Arial, Helvetica, sans-serif;
+  line-height: 1.6;
+  scroll-behavior: smooth;
+}
+.ears {
+  display: none;
+}
+
+/* headings */
+#title, h1, h2, h3, h4, h5, h6 {
+  margin: 1em 0 0.5em;
+  font-weight: bold;
+  line-height: 1.3;
+}
+#title {
+  clear: both;
+  border-bottom: 1px solid #ddd;
+  margin: 0 0 0.5em 0;
+  padding: 1em 0 0.5em;
+}
+.author {
+  padding-bottom: 4px;
+}
+h1 {
+  font-size: 26px;
+  margin: 1em 0;
+}
+h2 {
+  font-size: 22px;
+  margin-top: -20px;  /* provide offset for in-page anchors */
+  padding-top: 33px;
+}
+h3 {
+  font-size: 18px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h4 {
+  font-size: 16px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h5, h6 {
+  font-size: 14px;
+}
+#n-copyright-notice {
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 1em;
+  margin-bottom: 1em;
+}
+/* general structure */
+p {
+  padding: 0;
+  margin: 0 0 1em 0;
+  text-align: left;
+}
+div, span {
+  position: relative;
+}
+div {
+  margin: 0;
+}
+.alignRight.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignRight.art-text pre {
+  padding: 0;
+}
+.alignRight {
+  margin: 1em 0;
+}
+.alignRight > *:first-child {
+  border: none;
+  margin: 0;
+  float: right;
+  clear: both;
+}
+.alignRight > *:nth-child(2) {
+  clear: both;
+  display: block;
+  border: none;
+}
+svg {
+  display: block;
+}
+.alignCenter.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignCenter.art-text pre {
+  padding: 0;
+}
+.alignCenter {
+  margin: 1em 0;
+}
+.alignCenter > *:first-child {
+  border: none;
+  /* this isn't optimal, but it's an existence proof.  PrinceXML doesn't
+     support flexbox yet.
+  */
+  display: table;
+  margin: 0 auto;
+}
+
+/* lists */
+ol, ul {
+  padding: 0;
+  margin: 0 0 1em 2em;
+}
+ol ol, ul ul, ol ul, ul ol {
+  margin-left: 1em;
+}
+li {
+  margin: 0 0 0.25em 0;
+}
+.ulCompact li {
+  margin: 0;
+}
+ul.empty, .ulEmpty {
+  list-style-type: none;
+}
+ul.empty li, .ulEmpty li {
+  margin-top: 0.5em;
+}
+ul.compact, .ulCompact,
+ol.compact, .olCompact {
+  line-height: 100%;
+  margin: 0 0 0 2em;
+}
+
+/* definition lists */
+dl {
+}
+dl > dt {
+  float: left;
+  margin-right: 1em;
+}
+/* 
+dl.nohang > dt {
+  float: none;
+}
+*/
+dl > dd {
+  margin-bottom: .8em;
+  min-height: 1.3em;
+}
+dl.compact > dd, .dlCompact > dd {
+  margin-bottom: 0em;
+}
+dl > dd > dl {
+  margin-top: 0.5em;
+  margin-bottom: 0em;
+}
+
+/* links */
+a {
+  text-decoration: none;
+}
+a[href] {
+  color: #22e; /* Arlen: WCAG 2019 */
+}
+a[href]:hover {
+  background-color: #f2f2f2;
+}
+figcaption a[href],
+a[href].selfRef {
+  color: #222;
+}
+/* XXX probably not this:
+a.selfRef:hover {
+  background-color: transparent;
+  cursor: default;
+} */
+
+/* Figures */
+tt, code, pre, code {
+  background-color: #f9f9f9;
+  font-family: 'Roboto Mono', monospace;
+}
+pre {
+  border: 1px solid #eee;
+  margin: 0;
+  padding: 1em;
+}
+img {
+  max-width: 100%;
+}
+figure {
+  margin: 0;
+}
+figure blockquote {
+  margin: 0.8em 0.4em 0.4em;
+}
+figcaption {
+  font-style: italic;
+  margin: 0 0 1em 0;
+}
+@media screen {
+  pre {
+    overflow-x: auto;
+    max-width: 100%;
+    max-width: calc(100% - 22px);
+  }
+}
+
+/* aside, blockquote */
+aside, blockquote {
+  margin-left: 0;
+  padding: 1.2em 2em;
+}
+blockquote {
+  background-color: #f9f9f9;
+  color: #111; /* Arlen: WCAG 2019 */
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  margin: 1em 0;
+}
+cite {
+  display: block;
+  text-align: right;
+  font-style: italic;
+}
+
+/* tables */
+table {
+  width: 100%;
+  margin: 0 0 1em;
+  border-collapse: collapse;
+  border: 1px solid #eee;
+}
+th, td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.5em 0.75em;
+}
+th {
+  text-align: left;
+  background-color: #e9e9e9;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f5f5f5;
+}
+table caption {
+  font-style: italic;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+}
+table p {
+  /* XXX to avoid bottom margin on table row signifiers. If paragraphs should
+     be allowed within tables more generally, it would be far better to select on a class. */
+  margin: 0;
+}
+
+/* pilcrow */
+a.pilcrow {
+  color: #666; /* Arlen: AHDJ 2019 */
+  text-decoration: none;
+  visibility: hidden;
+  user-select: none;
+  -ms-user-select: none;
+  -o-user-select:none;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}
+@media screen {
+  aside:hover > a.pilcrow,
+  p:hover > a.pilcrow,
+  blockquote:hover > a.pilcrow,
+  div:hover > a.pilcrow,
+  li:hover > a.pilcrow,
+  pre:hover > a.pilcrow {
+    visibility: visible;
+  }
+  a.pilcrow:hover {
+    background-color: transparent;
+  }
+}
+
+/* misc */
+hr {
+  border: 0;
+  border-top: 1px solid #eee;
+}
+.bcp14 {
+  font-variant: small-caps;
+}
+
+.role {
+  font-variant: all-small-caps;
+}
+
+/* info block */
+#identifiers {
+  margin: 0;
+  font-size: 0.9em;
+}
+#identifiers dt {
+  width: 3em;
+  clear: left;
+}
+#identifiers dd {
+  float: left;
+  margin-bottom: 0;
+}
+#identifiers .authors .author {
+  display: inline-block;
+  margin-right: 1.5em;
+}
+#identifiers .authors .org {
+  font-style: italic;
+}
+
+/* The prepared/rendered info at the very bottom of the page */
+.docInfo {
+  color: #666; /* Arlen: WCAG 2019 */
+  font-size: 0.9em;
+  font-style: italic;
+  margin-top: 2em;
+}
+.docInfo .prepared {
+  float: left;
+}
+.docInfo .prepared {
+  float: right;
+}
+
+/* table of contents */
+#toc  {
+  padding: 0.75em 0 2em 0;
+  margin-bottom: 1em;
+}
+nav.toc ul {
+  margin: 0 0.5em 0 0;
+  padding: 0;
+  list-style: none;
+}
+nav.toc li {
+  line-height: 1.3em;
+  margin: 0.75em 0;
+  padding-left: 1.2em;
+  text-indent: -1.2em;
+}
+/* references */
+.references dt {
+  text-align: right;
+  font-weight: bold;
+  min-width: 7em;
+}
+.references dd {
+  margin-left: 8em;
+  overflow: auto;
+}
+
+.refInstance {
+  margin-bottom: 1.25em;
+}
+
+.references .ascii {
+  margin-bottom: 0.25em;
+}
+
+/* index */
+.index ul {
+  margin: 0 0 0 1em;
+  padding: 0;
+  list-style: none;
+}
+.index ul ul {
+  margin: 0;
+}
+.index li {
+  margin: 0;
+  text-indent: -2em;
+  padding-left: 2em;
+  padding-bottom: 5px;
+}
+.indexIndex {
+  margin: 0.5em 0 1em;
+}
+.index a {
+  font-weight: 700;
+}
+/* make the index two-column on all but the smallest screens */
+@media (min-width: 600px) {
+  .index ul {
+    -moz-column-count: 2;
+    -moz-column-gap: 20px;
+  }
+  .index ul ul {
+    -moz-column-count: 1;
+    -moz-column-gap: 0;
+  }
+}
+
+/* authors */
+address.vcard {
+  font-style: normal;
+  margin: 1em 0;
+}
+
+address.vcard .nameRole {
+  font-weight: 700;
+  margin-left: 0;
+}
+address.vcard .label {
+  font-family: "Noto Sans",Arial,Helvetica,sans-serif;
+  margin: 0.5em 0;
+}
+address.vcard .type {
+  display: none;
+}
+.alternative-contact {
+  margin: 1.5em 0 1em;
+}
+hr.addr {
+  border-top: 1px dashed;
+  margin: 0;
+  color: #ddd;
+  max-width: calc(100% - 16px);
+}
+
+/* temporary notes */
+.rfcEditorRemove::before {
+  position: absolute;
+  top: 0.2em;
+  right: 0.2em;
+  padding: 0.2em;
+  content: "The RFC Editor will remove this note";
+  color: #9e2a00; /* Arlen: WCAG 2019 */
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+}
+.rfcEditorRemove {
+  position: relative;
+  padding-top: 1.8em;
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  border-radius: 3px;
+}
+.cref {
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  padding: 2px 4px;
+}
+.crefSource {
+  font-style: italic;
+}
+/* alternative layout for smaller screens */
+@media screen and (max-width: 1023px) {
+  body {
+    padding-top: 2em;
+  }
+  #title {
+    padding: 1em 0;
+  }
+  h1 {
+    font-size: 24px;
+  }
+  h2 {
+    font-size: 20px;
+    margin-top: -18px;  /* provide offset for in-page anchors */
+    padding-top: 38px;
+  }
+  #identifiers dd {
+    max-width: 60%;
+  }
+  #toc {
+    position: fixed;
+    z-index: 2;
+    top: 0;
+    right: 0;
+    padding: 0;
+    margin: 0;
+    background-color: inherit;
+    border-bottom: 1px solid #ccc;
+  }
+  #toc h2 {
+    margin: -1px 0 0 0;
+    padding: 4px 0 4px 6px;
+    padding-right: 1em;
+    min-width: 190px;
+    font-size: 1.1em;
+    text-align: right;
+    background-color: #444;
+    color: white;
+    cursor: pointer;
+  }
+  #toc h2::before { /* css hamburger */
+    float: right;
+    position: relative;
+    width: 1em;
+    height: 1px;
+    left: -164px;
+    margin: 6px 0 0 0;
+    background: white none repeat scroll 0 0;
+    box-shadow: 0 4px 0 0 white, 0 8px 0 0 white;
+    content: "";
+  }
+  #toc nav {
+    display: none;
+    padding: 0.5em 1em 1em;
+    overflow: auto;
+    height: calc(100vh - 48px);
+    border-left: 1px solid #ddd;
+  }
+}
+
+/* alternative layout for wide screens */
+@media screen and (min-width: 1024px) {
+  body {
+    max-width: 724px;
+    margin: 42px auto;
+    padding-left: 1.5em;
+    padding-right: 29em;
+  }
+  #toc {
+    position: fixed;
+    top: 42px;
+    right: 42px;
+    width: 25%;
+    margin: 0;
+    padding: 0 1em;
+    z-index: 1;
+  }
+  #toc h2 {
+    border-top: none;
+    border-bottom: 1px solid #ddd;
+    font-size: 1em;
+    font-weight: normal;
+    margin: 0;
+    padding: 0.25em 1em 1em 0;
+  }
+  #toc nav {
+    display: block;
+    height: calc(90vh - 84px);
+    bottom: 0;
+    padding: 0.5em 0 0;
+    overflow: auto;
+  }
+  img { /* future proofing */
+    max-width: 100%;
+    height: auto;
+  }
+}
+
+/* pagination */
+@media print {
+  body {
+
+    width: 100%;
+  }
+  p {
+    orphans: 3;
+    widows: 3;
+  }
+  #n-copyright-notice {
+    border-bottom: none;
+  }
+  #toc, #n-introduction {
+    page-break-before: always;
+  }
+  #toc {
+    border-top: none;
+    padding-top: 0;
+  }
+  figure, pre {
+    page-break-inside: avoid;
+  }
+  figure {
+    overflow: scroll;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    page-break-after: avoid;
+  }
+  h2+*, h3+*, h4+*, h5+*, h6+* {
+    page-break-before: avoid;
+  }
+  pre {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-size: 10pt;
+  }
+  table {
+    border: 1px solid #ddd;
+  }
+  td {
+    border-top: 1px solid #ddd;
+  }
+}
+
+/* This is commented out here, as the string-set: doesn't
+   pass W3C validation currently */
+/*
+.ears thead .left {
+  string-set: ears-top-left content();
+}
+
+.ears thead .center {
+  string-set: ears-top-center content();
+}
+
+.ears thead .right {
+  string-set: ears-top-right content();
+}
+
+.ears tfoot .left {
+  string-set: ears-bottom-left content();
+}
+
+.ears tfoot .center {
+  string-set: ears-bottom-center content();
+}
+
+.ears tfoot .right {
+  string-set: ears-bottom-right content();
+}
+*/
+
+@page :first {
+  padding-top: 0;
+  @top-left {
+    content: normal;
+    border: none;
+  }
+  @top-center {
+    content: normal;
+    border: none;
+  }
+  @top-right {
+    content: normal;
+    border: none;
+  }
+}
+
+@page {
+  size: A4;
+  margin-bottom: 45mm;
+  padding-top: 20px;
+  /* The follwing is commented out here, but set appropriately by in code, as
+     the content depends on the document */
+  /*
+  @top-left {
+    content: 'Internet-Draft';
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-left {
+    content: string(ears-top-left);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-center {
+    content: string(ears-top-center);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-right {
+    content: string(ears-top-right);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @bottom-left {
+    content: string(ears-bottom-left);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-center {
+    content: string(ears-bottom-center);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-right {
+      content: '[Page ' counter(page) ']';
+      vertical-align: top;
+      border-top: solid 1px #ccc;
+  }
+  */
+
+}
+
+/* Changes introduced to fix issues found during implementation */
+/* Make sure links are clickable even if overlapped by following H* */
+a {
+  z-index: 2;
+}
+/* Separate body from document info even without intervening H1 */
+section {
+  clear: both;
+}
+
+
+/* Top align author divs, to avoid names without organization dropping level with org names */
+.author {
+  vertical-align: top;
+}
+
+/* Leave room in document info to show Internet-Draft on one line */
+#identifiers dt {
+  width: 8em;
+}
+
+/* Don't waste quite as much whitespace between label and value in doc info */
+#identifiers dd {
+  margin-left: 1em;
+}
+
+/* Give floating toc a background color (needed when it's a div inside section */
+#toc {
+  background-color: white;
+}
+
+/* Make the collapsed ToC header render white on gray also when it's a link */
+@media screen and (max-width: 1023px) {
+  #toc h2 a,
+  #toc h2 a:link,
+  #toc h2 a:focus,
+  #toc h2 a:hover,
+  #toc a.toplink,
+  #toc a.toplink:hover {
+    color: white;
+    background-color: #444;
+    text-decoration: none;
+  }
+}
+
+/* Give the bottom of the ToC some whitespace */
+@media screen and (min-width: 1024px) {
+  #toc {
+    padding: 0 0 1em 1em;
+  }
+}
+
+/* Style section numbers with more space between number and title */
+.section-number {
+  padding-right: 0.5em;
+}
+
+/* prevent monospace from becoming overly large */
+tt, code, pre, code {
+  font-size: 95%;
+}
+
+/* Fix the height/width aspect for ascii art*/
+pre.sourcecode,
+.art-text pre {
+  line-height: 1.12;
+}
+
+
+/* Add styling for a link in the ToC that points to the top of the document */
+a.toplink {
+  float: right;
+  margin-right: 0.5em;
+}
+
+/* Fix the dl styling to match the RFC 7992 attributes */
+dl > dt,
+dl.dlParallel > dt {
+  float: left;
+  margin-right: 1em;
+}
+dl.dlNewline > dt {
+  float: none;
+}
+
+/* Provide styling for table cell text alignment */
+table td.text-left,
+table th.text-left {
+  text-align: left;
+}
+table td.text-center,
+table th.text-center {
+  text-align: center;
+}
+table td.text-right,
+table th.text-right {
+  text-align: right;
+}
+
+/* Make the alternative author contact informatio look less like just another
+   author, and group it closer with the primary author contact information */
+.alternative-contact {
+  margin: 0.5em 0 0.25em 0;
+}
+address .non-ascii {
+  margin: 0 0 0 2em;
+}
+
+/* With it being possible to set tables with alignment
+  left, center, and right, { width: 100%; } does not make sense */
+table {
+  width: auto;
+}
+
+/* Avoid reference text that sits in a block with very wide left margin,
+   because of a long floating dt label.*/
+.references dd {
+  overflow: visible;
+}
+
+/* Control caption placement */
+caption {
+  caption-side: bottom;
+}
+
+/* Limit the width of the author address vcard, so names in right-to-left
+   script don't end up on the other side of the page. */
+
+address.vcard {
+  max-width: 30em;
+  margin-right: auto;
+}
+
+/* For address alignment dependent on LTR or RTL scripts */
+address div.left {
+  text-align: left;
+}
+address div.right {
+  text-align: right;
+}
+
+/* Provide table alignment support.  We can't use the alignX classes above
+   since they do unwanted things with caption and other styling. */
+table.right {
+ margin-left: auto;
+ margin-right: 0;
+}
+table.center {
+ margin-left: auto;
+ margin-right: auto;
+}
+table.left {
+ margin-left: 0;
+ margin-right: auto;
+}
+
+/* Give the table caption label the same styling as the figcaption */
+caption a[href] {
+  color: #222;
+}
+
+@media print {
+  .toplink {
+    display: none;
+  }
+
+  /* avoid overwriting the top border line with the ToC header */
+  #toc {
+    padding-top: 1px;
+  }
+
+  /* Avoid page breaks inside dl and author address entries */
+  .vcard {
+    page-break-inside: avoid;
+  }
+
+}
+/* Avoid wrapping of URLs in references */
+@media screen {
+  .references a {
+    white-space: nowrap;
+  }
+}
+/* Tweak the bcp14 keyword presentation */
+.bcp14 {
+  font-variant: small-caps;
+  font-weight: bold;
+  font-size: 0.9em;
+}
+/* Tweak the invisible space above H* in order not to overlay links in text above */
+ h2 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 31px;
+ }
+ h3 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+ h4 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+/* Float artwork pilcrow to the right */
+@media screen {
+  .artwork a.pilcrow {
+    display: block;
+    line-height: 0.7;
+    margin-top: 0.15em;
+  }
+}
+/* Make pilcrows on dd visible */
+@media screen {
+  dd:hover > a.pilcrow {
+    visibility: visible;
+  }
+}
+/* Make the placement of figcaption match that of a table's caption
+   by removing the figure's added bottom margin */
+.alignLeft.art-text,
+.alignCenter.art-text,
+.alignRight.art-text {
+   margin-bottom: 0;
+}
+.alignLeft,
+.alignCenter,
+.alignRight {
+  margin: 1em 0 0 0;
+}
+/* In print, the pilcrow won't show on hover, so prevent it from taking up space,
+   possibly even requiring a new line */
+@media print {
+  a.pilcrow {
+    display: none;
+  }
+}
+/* Styling for the external metadata */
+div#external-metadata {
+  background-color: #eee;
+  padding: 0.5em;
+  margin-bottom: 0.5em;
+  display: none;
+}
+div#internal-metadata {
+  padding: 0.5em;                       /* to match the external-metadata padding */
+}
+/* Styling for title RFC Number */
+h1#rfcnum {
+  clear: both;
+  margin: 0 0 -1em;
+  padding: 1em 0 0 0;
+}
+/* Make .olPercent look the same as <ol><li> */
+dl.olPercent > dd {
+  margin-bottom: 0.25em;
+  min-height: initial;
+}
+/* Give aside some styling to set it apart */
+aside {
+  border-left: 1px solid #ddd;
+  margin: 1em 0 1em 2em;
+  padding: 0.2em 2em;
+}
+aside > dl,
+aside > ol,
+aside > ul,
+aside > table,
+aside > p {
+  margin-bottom: 0.5em;
+}
+/* Additional page break settings */
+@media print {
+  figcaption, table caption {
+    page-break-before: avoid;
+  }
+}
+/* Font size adjustments for print */
+@media print {
+  body  { font-size: 10pt;      line-height: normal; max-width: 96%; }
+  h1    { font-size: 1.72em;    padding-top: 1.5em; } /* 1*1.2*1.2*1.2 */
+  h2    { font-size: 1.44em;    padding-top: 1.5em; } /* 1*1.2*1.2 */
+  h3    { font-size: 1.2em;     padding-top: 1.5em; } /* 1*1.2 */
+  h4    { font-size: 1em;       padding-top: 1.5em; }
+  h5, h6 { font-size: 1em;      margin: initial; padding: 0.5em 0 0.3em; }
+}
+/* Sourcecode margin in print, when there's no pilcrow */
+@media print {
+  .artwork,
+  .sourcecode {
+    margin-bottom: 1em;
+  }
+}
+/* Avoid narrow tables forcing too narrow table captions, which may render badly */
+table {
+  min-width: 20em;
+}
+/* ol type a */
+ol.type-a { list-style-type: lower-alpha; }
+ol.type-A { list-style-type: upper-alpha; }
+ol.type-i { list-style-type: lower-roman; }
+ol.type-I { list-style-type: lower-roman; }
+/* Apply the print table and row borders in general, on request from the RPC,
+and increase the contrast between border and odd row background sligthtly */
+table {
+  border: 1px solid #ddd;
+}
+td {
+  border-top: 1px solid #ddd;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f8f8f8;
+}
+/* Use style rules to govern display of the TOC. */
+@media screen and (max-width: 1023px) {
+  #toc nav { display: none; }
+  #toc.active nav { display: block; }
+}
+/* Add support for keepWithNext */
+.keepWithNext {
+  break-after: avoid-page;
+  break-after: avoid-page;
+}
+/* Add support for keepWithPrevious */
+.keepWithPrevious {
+  break-before: avoid-page;
+}
+/* Change the approach to avoiding breaks inside artwork etc. */
+figure, pre, table, .artwork, .sourcecode  {
+  break-before: avoid-page;
+  break-after: auto;
+}
+/* Avoid breaks between <dt> and <dd> */
+dl {
+  break-inside: auto;
+}
+dt {
+  break-before: auto;
+  break-after: avoid-page;
+}
+dd {
+  break-before: avoid-page;
+  break-after: auto;
+  orphans: 3;
+  widows: 3
+}
+dd.break {
+  margin-bottom: 0;
+  min-height: 0;
+  break-before: auto;
+  break-inside: auto;
+  break-after: auto;
+}
+/* Undo break-before ToC */
+@media print {
+  #toc {
+    break-before: auto;
+  }
+}</style>
+<link href="rfc-local.css" rel="stylesheet" type="text/css">
+</head>
+<body>
+<script src="metadata.min.js"></script>
+<table class="ears">
+<thead><tr>
+<td class="left">Internet-Draft</td>
+<td class="center">DMARCbis</td>
+<td class="right">September 2021</td>
+</tr></thead>
+<tfoot><tr>
+<td class="left">Herr (ed) &amp; Levine (ed)</td>
+<td class="center">Expires 24 March 2022</td>
+<td class="right">[Page]</td>
+</tr></tfoot>
+</table>
+<div id="external-metadata" class="document-information"></div>
+<div id="internal-metadata" class="document-information">
+<dl id="identifiers">
+<dt class="label-workgroup">Workgroup:</dt>
+<dd class="workgroup">DMARC</dd>
+<dt class="label-internet-draft">Internet-Draft:</dt>
+<dd class="internet-draft">draft-ietf-dmarc-dmarcbis-04</dd>
+<dt class="label-obsoletes">Obsoletes:</dt>
+<dd class="obsoletes">
+<a href="https://www.rfc-editor.org/rfc/rfc7489" class="eref">7489</a> (if approved)</dd>
+<dt class="label-published">Published:</dt>
+<dd class="published">
+<time datetime="2021-09-20" class="published">20 September 2021</time>
+    </dd>
+<dt class="label-intended-status">Intended Status:</dt>
+<dd class="intended-status">Standards Track</dd>
+<dt class="label-expires">Expires:</dt>
+<dd class="expires"><time datetime="2022-03-24">24 March 2022</time></dd>
+<dt class="label-authors">Authors:</dt>
+<dd class="authors">
+<div class="author">
+      <div class="author-name">T. Herr (ed)</div>
+<div class="org">Valimail</div>
+</div>
+<div class="author">
+      <div class="author-name">J. Levine (ed)</div>
+<div class="org">Standcore LLC</div>
+</div>
+</dd>
+</dl>
+</div>
+<h1 id="title">Domain-based Message Authentication, Reporting, and Conformance (DMARC)</h1>
+<section id="section-abstract">
+      <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
+<p id="section-abstract-1">This document describes the Domain-based Message Authentication,
+Reporting, and Conformance (DMARC) protocol.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
+<p id="section-abstract-2">DMARC permits the owner of an email author's domain name to enable
+verification of the domain's use, to indicate the Domain Owner's or
+Public Suffix Operator's severity of concern regarding failed
+verification, and to request reports about use of the domain name.
+Mail receiving organizations can use this information when evaluating
+handling choices for incoming mail.<a href="#section-abstract-2" class="pilcrow">¶</a></p>
+<p id="section-abstract-3">This document obsoletes RFC 7489.<a href="#section-abstract-3" class="pilcrow">¶</a></p>
+</section>
+<div id="status-of-memo">
+<section id="section-boilerplate.1">
+        <h2 id="name-status-of-this-memo">
+<a href="#name-status-of-this-memo" class="section-name selfRef">Status of This Memo</a>
+        </h2>
+<p id="section-boilerplate.1-1">
+        This Internet-Draft is submitted in full conformance with the
+        provisions of BCP 78 and BCP 79.<a href="#section-boilerplate.1-1" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-2">
+        Internet-Drafts are working documents of the Internet Engineering Task
+        Force (IETF). Note that other groups may also distribute working
+        documents as Internet-Drafts. The list of current Internet-Drafts is
+        at <span><a href="https://datatracker.ietf.org/drafts/current/">https://datatracker.ietf.org/drafts/current/</a></span>.<a href="#section-boilerplate.1-2" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-3">
+        Internet-Drafts are draft documents valid for a maximum of six months
+        and may be updated, replaced, or obsoleted by other documents at any
+        time. It is inappropriate to use Internet-Drafts as reference
+        material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-4">
+        This Internet-Draft will expire on 24 March 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="copyright">
+<section id="section-boilerplate.2">
+        <h2 id="name-copyright-notice">
+<a href="#name-copyright-notice" class="section-name selfRef">Copyright Notice</a>
+        </h2>
+<p id="section-boilerplate.2-1">
+            Copyright (c) 2021 IETF Trust and the persons identified as the
+            document authors. All rights reserved.<a href="#section-boilerplate.2-1" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.2-2">
+            This document is subject to BCP 78 and the IETF Trust's Legal
+            Provisions Relating to IETF Documents
+            (<span><a href="https://trustee.ietf.org/license-info">https://trustee.ietf.org/license-info</a></span>) in effect on the date of
+            publication of this document. Please review these documents
+            carefully, as they describe your rights and restrictions with
+            respect to this document. Code Components extracted from this
+            document must include Simplified BSD License text as described in
+            Section 4.e of the Trust Legal Provisions and are provided without
+            warranty as described in the Simplified BSD License.<a href="#section-boilerplate.2-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="toc">
+<section id="section-toc.1">
+        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
+<a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
+        </h2>
+<nav class="toc"><ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.1">
+            <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="xref">1</a>.  <a href="#name-introduction" class="xref">Introduction</a><a href="#section-toc.1-1.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.2">
+            <p id="section-toc.1-1.2.1"><a href="#section-2" class="xref">2</a>.  <a href="#name-requirements" class="xref">Requirements</a><a href="#section-toc.1-1.2.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.1">
+                <p id="section-toc.1-1.2.2.1.1" class="keepWithNext"><a href="#section-2.1" class="xref">2.1</a>.  <a href="#name-high-level-goals" class="xref">High-Level Goals</a><a href="#section-toc.1-1.2.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.2">
+                <p id="section-toc.1-1.2.2.2.1" class="keepWithNext"><a href="#section-2.2" class="xref">2.2</a>.  <a href="#name-out-of-scope" class="xref">Out of Scope</a><a href="#section-toc.1-1.2.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.3">
+                <p id="section-toc.1-1.2.2.3.1"><a href="#section-2.3" class="xref">2.3</a>.  <a href="#name-scalability" class="xref">Scalability</a><a href="#section-toc.1-1.2.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.4">
+                <p id="section-toc.1-1.2.2.4.1"><a href="#section-2.4" class="xref">2.4</a>.  <a href="#name-anti-phishing" class="xref">Anti-Phishing</a><a href="#section-toc.1-1.2.2.4.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3">
+            <p id="section-toc.1-1.3.1"><a href="#section-3" class="xref">3</a>.  <a href="#name-terminology-and-definitions" class="xref">Terminology and Definitions</a><a href="#section-toc.1-1.3.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.1">
+                <p id="section-toc.1-1.3.2.1.1"><a href="#section-3.1" class="xref">3.1</a>.  <a href="#name-conventions-used-in-this-do" class="xref">Conventions Used in This Document</a><a href="#section-toc.1-1.3.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.2">
+                <p id="section-toc.1-1.3.2.2.1"><a href="#section-3.2" class="xref">3.2</a>.  <a href="#name-authenticated-identifiers" class="xref">Authenticated Identifiers</a><a href="#section-toc.1-1.3.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.3">
+                <p id="section-toc.1-1.3.2.3.1"><a href="#section-3.3" class="xref">3.3</a>.  <a href="#name-author-domain" class="xref">Author Domain</a><a href="#section-toc.1-1.3.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.4">
+                <p id="section-toc.1-1.3.2.4.1"><a href="#section-3.4" class="xref">3.4</a>.  <a href="#name-domain-owner" class="xref">Domain Owner</a><a href="#section-toc.1-1.3.2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.5">
+                <p id="section-toc.1-1.3.2.5.1"><a href="#section-3.5" class="xref">3.5</a>.  <a href="#name-identifier-alignment" class="xref">Identifier Alignment</a><a href="#section-toc.1-1.3.2.5.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.6">
+                <p id="section-toc.1-1.3.2.6.1"><a href="#section-3.6" class="xref">3.6</a>.  <a href="#name-longest-psd" class="xref">Longest PSD</a><a href="#section-toc.1-1.3.2.6.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.7">
+                <p id="section-toc.1-1.3.2.7.1"><a href="#section-3.7" class="xref">3.7</a>.  <a href="#name-mail-receiver" class="xref">Mail Receiver</a><a href="#section-toc.1-1.3.2.7.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.8">
+                <p id="section-toc.1-1.3.2.8.1"><a href="#section-3.8" class="xref">3.8</a>.  <a href="#name-non-existent-domains" class="xref">Non-existent Domains</a><a href="#section-toc.1-1.3.2.8.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.9">
+                <p id="section-toc.1-1.3.2.9.1"><a href="#section-3.9" class="xref">3.9</a>.  <a href="#name-organizational-domain" class="xref">Organizational Domain</a><a href="#section-toc.1-1.3.2.9.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.10">
+                <p id="section-toc.1-1.3.2.10.1"><a href="#section-3.10" class="xref">3.10</a>. <a href="#name-public-suffix-domain-psd" class="xref">Public Suffix Domain (PSD)</a><a href="#section-toc.1-1.3.2.10.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.11">
+                <p id="section-toc.1-1.3.2.11.1"><a href="#section-3.11" class="xref">3.11</a>. <a href="#name-public-suffix-operator-pso" class="xref">Public Suffix Operator (PSO)</a><a href="#section-toc.1-1.3.2.11.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.12">
+                <p id="section-toc.1-1.3.2.12.1"><a href="#section-3.12" class="xref">3.12</a>. <a href="#name-pso-controlled-domain-names" class="xref">PSO Controlled Domain Names</a><a href="#section-toc.1-1.3.2.12.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.13">
+                <p id="section-toc.1-1.3.2.13.1"><a href="#section-3.13" class="xref">3.13</a>. <a href="#name-report-receiver" class="xref">Report Receiver</a><a href="#section-toc.1-1.3.2.13.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.14">
+                <p id="section-toc.1-1.3.2.14.1"><a href="#section-3.14" class="xref">3.14</a>. <a href="#name-more-on-identifier-alignmen" class="xref">More on Identifier Alignment</a><a href="#section-toc.1-1.3.2.14.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.14.2.1">
+                    <p id="section-toc.1-1.3.2.14.2.1.1"><a href="#section-3.14.1" class="xref">3.14.1</a>.  <a href="#name-dkim-authenticated-identifi" class="xref">DKIM-Authenticated Identifiers</a><a href="#section-toc.1-1.3.2.14.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.14.2.2">
+                    <p id="section-toc.1-1.3.2.14.2.2.1"><a href="#section-3.14.2" class="xref">3.14.2</a>.  <a href="#name-spf-authenticated-identifie" class="xref">SPF-Authenticated Identifiers</a><a href="#section-toc.1-1.3.2.14.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.14.2.3">
+                    <p id="section-toc.1-1.3.2.14.2.3.1"><a href="#section-3.14.3" class="xref">3.14.3</a>.  <a href="#name-alignment-and-extension-tec" class="xref">Alignment and Extension Technologies</a><a href="#section-toc.1-1.3.2.14.2.3.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.15">
+                <p id="section-toc.1-1.3.2.15.1"><a href="#section-3.15" class="xref">3.15</a>. <a href="#name-determining-the-organizatio" class="xref">Determining The Organizational Domain</a><a href="#section-toc.1-1.3.2.15.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.4">
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-overview" class="xref">Overview</a><a href="#section-toc.1-1.4.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.4.2.1">
+                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="xref">4.1</a>.  <a href="#name-authentication-mechanisms" class="xref">Authentication Mechanisms</a><a href="#section-toc.1-1.4.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.4.2.2">
+                <p id="section-toc.1-1.4.2.2.1"><a href="#section-4.2" class="xref">4.2</a>.  <a href="#name-key-concepts" class="xref">Key Concepts</a><a href="#section-toc.1-1.4.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.4.2.3">
+                <p id="section-toc.1-1.4.2.3.1"><a href="#section-4.3" class="xref">4.3</a>.  <a href="#name-flow-diagram" class="xref">Flow Diagram</a><a href="#section-toc.1-1.4.2.3.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.5">
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-use-of-rfc5322from" class="xref">Use of RFC5322.From</a><a href="#section-toc.1-1.5.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6">
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-policy" class="xref">Policy</a><a href="#section-toc.1-1.6.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.1">
+                <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="xref">6.1</a>.  <a href="#name-dmarc-policy-record" class="xref">DMARC Policy Record</a><a href="#section-toc.1-1.6.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.2">
+                <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="xref">6.2</a>.  <a href="#name-dmarc-uris" class="xref">DMARC URIs</a><a href="#section-toc.1-1.6.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.3">
+                <p id="section-toc.1-1.6.2.3.1"><a href="#section-6.3" class="xref">6.3</a>.  <a href="#name-general-record-format" class="xref">General Record Format</a><a href="#section-toc.1-1.6.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.4">
+                <p id="section-toc.1-1.6.2.4.1"><a href="#section-6.4" class="xref">6.4</a>.  <a href="#name-formal-definition" class="xref">Formal Definition</a><a href="#section-toc.1-1.6.2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.5">
+                <p id="section-toc.1-1.6.2.5.1"><a href="#section-6.5" class="xref">6.5</a>.  <a href="#name-domain-owner-actions" class="xref">Domain Owner Actions</a><a href="#section-toc.1-1.6.2.5.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.5.2.1">
+                    <p id="section-toc.1-1.6.2.5.2.1.1"><a href="#section-6.5.1" class="xref">6.5.1</a>.  <a href="#name-publish-an-spf-policy-for-a" class="xref">Publish an SPF Policy for an Aligned Domain</a><a href="#section-toc.1-1.6.2.5.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.5.2.2">
+                    <p id="section-toc.1-1.6.2.5.2.2.1"><a href="#section-6.5.2" class="xref">6.5.2</a>.  <a href="#name-configure-sending-system-fo" class="xref">Configure Sending System for DKIM Signing Using an Aligned Domain</a><a href="#section-toc.1-1.6.2.5.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.5.2.3">
+                    <p id="section-toc.1-1.6.2.5.2.3.1"><a href="#section-6.5.3" class="xref">6.5.3</a>.  <a href="#name-setup-a-mailbox-to-receive-" class="xref">Setup a Mailbox to Receive Aggregate Reports</a><a href="#section-toc.1-1.6.2.5.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.5.2.4">
+                    <p id="section-toc.1-1.6.2.5.2.4.1"><a href="#section-6.5.4" class="xref">6.5.4</a>.  <a href="#name-publish-a-dmarc-policy-for-" class="xref">Publish a DMARC Policy for the Author Domain</a><a href="#section-toc.1-1.6.2.5.2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.5.2.5">
+                    <p id="section-toc.1-1.6.2.5.2.5.1"><a href="#section-6.5.5" class="xref">6.5.5</a>.  <a href="#name-collect-and-analyze-reports" class="xref">Collect and Analyze Reports and Adjust Authentication</a><a href="#section-toc.1-1.6.2.5.2.5.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.5.2.6">
+                    <p id="section-toc.1-1.6.2.5.2.6.1"><a href="#section-6.5.6" class="xref">6.5.6</a>.  <a href="#name-decide-if-and-when-to-updat" class="xref">Decide If and When to Update DMARC Policy</a><a href="#section-toc.1-1.6.2.5.2.6.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.6">
+                <p id="section-toc.1-1.6.2.6.1"><a href="#section-6.6" class="xref">6.6</a>.  <a href="#name-pso-actions" class="xref">PSO Actions</a><a href="#section-toc.1-1.6.2.6.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.7">
+                <p id="section-toc.1-1.6.2.7.1"><a href="#section-6.7" class="xref">6.7</a>.  <a href="#name-mail-receiver-actions" class="xref">Mail Receiver Actions</a><a href="#section-toc.1-1.6.2.7.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.7.2.1">
+                    <p id="section-toc.1-1.6.2.7.2.1.1"><a href="#section-6.7.1" class="xref">6.7.1</a>.  <a href="#name-extract-author-domain" class="xref">Extract Author Domain</a><a href="#section-toc.1-1.6.2.7.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.7.2.2">
+                    <p id="section-toc.1-1.6.2.7.2.2.1"><a href="#section-6.7.2" class="xref">6.7.2</a>.  <a href="#name-determine-handling-policy" class="xref">Determine Handling Policy</a><a href="#section-toc.1-1.6.2.7.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.7.2.3">
+                    <p id="section-toc.1-1.6.2.7.2.3.1"><a href="#section-6.7.3" class="xref">6.7.3</a>.  <a href="#name-policy-discovery" class="xref">Policy Discovery</a><a href="#section-toc.1-1.6.2.7.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.7.2.4">
+                    <p id="section-toc.1-1.6.2.7.2.4.1"><a href="#section-6.7.4" class="xref">6.7.4</a>.  <a href="#name-store-results-of-dmarc-proc" class="xref">Store Results of DMARC Processing</a><a href="#section-toc.1-1.6.2.7.2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.7.2.5">
+                    <p id="section-toc.1-1.6.2.7.2.5.1"><a href="#section-6.7.5" class="xref">6.7.5</a>.  <a href="#name-send-aggregate-reports" class="xref">Send Aggregate Reports</a><a href="#section-toc.1-1.6.2.7.2.5.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.8">
+                <p id="section-toc.1-1.6.2.8.1"><a href="#section-6.8" class="xref">6.8</a>.  <a href="#name-policy-enforcement-consider" class="xref">Policy Enforcement Considerations</a><a href="#section-toc.1-1.6.2.8.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.7">
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-dmarc-feedback" class="xref">DMARC Feedback</a><a href="#section-toc.1-1.7.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.8">
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-other-topics" class="xref">Other Topics</a><a href="#section-toc.1-1.8.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.8.2.1">
+                <p id="section-toc.1-1.8.2.1.1"><a href="#section-8.1" class="xref">8.1</a>.  <a href="#name-issues-specific-to-spf" class="xref">Issues Specific to SPF</a><a href="#section-toc.1-1.8.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.8.2.2">
+                <p id="section-toc.1-1.8.2.2.1"><a href="#section-8.2" class="xref">8.2</a>.  <a href="#name-dns-load-and-caching" class="xref">DNS Load and Caching</a><a href="#section-toc.1-1.8.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.8.2.3">
+                <p id="section-toc.1-1.8.2.3.1"><a href="#section-8.3" class="xref">8.3</a>.  <a href="#name-rejecting-messages" class="xref">Rejecting Messages</a><a href="#section-toc.1-1.8.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.8.2.4">
+                <p id="section-toc.1-1.8.2.4.1"><a href="#section-8.4" class="xref">8.4</a>.  <a href="#name-identifier-alignment-consid" class="xref">Identifier Alignment Considerations</a><a href="#section-toc.1-1.8.2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.8.2.5">
+                <p id="section-toc.1-1.8.2.5.1"><a href="#section-8.5" class="xref">8.5</a>.  <a href="#name-interoperability-issues" class="xref">Interoperability Issues</a><a href="#section-toc.1-1.8.2.5.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.9">
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-iana-considerations" class="xref">IANA Considerations</a><a href="#section-toc.1-1.9.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.9.2.1">
+                <p id="section-toc.1-1.9.2.1.1"><a href="#section-9.1" class="xref">9.1</a>.  <a href="#name-authentication-results-meth" class="xref">Authentication-Results Method Registry Update</a><a href="#section-toc.1-1.9.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.9.2.2">
+                <p id="section-toc.1-1.9.2.2.1"><a href="#section-9.2" class="xref">9.2</a>.  <a href="#name-authentication-results-resu" class="xref">Authentication-Results Result Registry Update</a><a href="#section-toc.1-1.9.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.9.2.3">
+                <p id="section-toc.1-1.9.2.3.1"><a href="#section-9.3" class="xref">9.3</a>.  <a href="#name-feedback-report-header-fiel" class="xref">Feedback Report Header Fields Registry Update</a><a href="#section-toc.1-1.9.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.9.2.4">
+                <p id="section-toc.1-1.9.2.4.1"><a href="#section-9.4" class="xref">9.4</a>.  <a href="#name-dmarc-tag-registry" class="xref">DMARC Tag Registry</a><a href="#section-toc.1-1.9.2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.9.2.5">
+                <p id="section-toc.1-1.9.2.5.1"><a href="#section-9.5" class="xref">9.5</a>.  <a href="#name-dmarc-report-format-registr" class="xref">DMARC Report Format Registry</a><a href="#section-toc.1-1.9.2.5.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.9.2.6">
+                <p id="section-toc.1-1.9.2.6.1"><a href="#section-9.6" class="xref">9.6</a>.  <a href="#name-underscored-and-globally-sc" class="xref">Underscored and Globally Scoped DNS Node Names Registry</a><a href="#section-toc.1-1.9.2.6.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.10">
+            <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-security-considerations" class="xref">Security Considerations</a><a href="#section-toc.1-1.10.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.10.2.1">
+                <p id="section-toc.1-1.10.2.1.1"><a href="#section-10.1" class="xref">10.1</a>.  <a href="#name-authentication-methods" class="xref">Authentication Methods</a><a href="#section-toc.1-1.10.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.10.2.2">
+                <p id="section-toc.1-1.10.2.2.1"><a href="#section-10.2" class="xref">10.2</a>.  <a href="#name-attacks-on-reporting-uris" class="xref">Attacks on Reporting URIs</a><a href="#section-toc.1-1.10.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.10.2.3">
+                <p id="section-toc.1-1.10.2.3.1"><a href="#section-10.3" class="xref">10.3</a>.  <a href="#name-dns-security" class="xref">DNS Security</a><a href="#section-toc.1-1.10.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.10.2.4">
+                <p id="section-toc.1-1.10.2.4.1"><a href="#section-10.4" class="xref">10.4</a>.  <a href="#name-display-name-attacks" class="xref">Display Name Attacks</a><a href="#section-toc.1-1.10.2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.10.2.5">
+                <p id="section-toc.1-1.10.2.5.1"><a href="#section-10.5" class="xref">10.5</a>.  <a href="#name-external-reporting-addresse" class="xref">External Reporting Addresses</a><a href="#section-toc.1-1.10.2.5.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.10.2.6">
+                <p id="section-toc.1-1.10.2.6.1"><a href="#section-10.6" class="xref">10.6</a>.  <a href="#name-secure-protocols" class="xref">Secure Protocols</a><a href="#section-toc.1-1.10.2.6.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.11">
+            <p id="section-toc.1-1.11.1"><a href="#section-11" class="xref">11</a>. <a href="#name-normative-references" class="xref">Normative References</a><a href="#section-toc.1-1.11.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.12">
+            <p id="section-toc.1-1.12.1"><a href="#section-12" class="xref">12</a>. <a href="#name-informative-references" class="xref">Informative References</a><a href="#section-toc.1-1.12.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.13">
+            <p id="section-toc.1-1.13.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-technology-considerations" class="xref">Technology Considerations</a><a href="#section-toc.1-1.13.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.1">
+                <p id="section-toc.1-1.13.2.1.1"><a href="#section-a.1" class="xref">A.1</a>.  <a href="#name-s-mime" class="xref">S/MIME</a><a href="#section-toc.1-1.13.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.2">
+                <p id="section-toc.1-1.13.2.2.1"><a href="#section-a.2" class="xref">A.2</a>.  <a href="#name-method-exclusion" class="xref">Method Exclusion</a><a href="#section-toc.1-1.13.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.3">
+                <p id="section-toc.1-1.13.2.3.1"><a href="#section-a.3" class="xref">A.3</a>.  <a href="#name-sender-header-field" class="xref">Sender Header Field</a><a href="#section-toc.1-1.13.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.4">
+                <p id="section-toc.1-1.13.2.4.1"><a href="#section-a.4" class="xref">A.4</a>.  <a href="#name-domain-existence-test" class="xref">Domain Existence Test</a><a href="#section-toc.1-1.13.2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.5">
+                <p id="section-toc.1-1.13.2.5.1"><a href="#section-a.5" class="xref">A.5</a>.  <a href="#name-issues-with-adsp-in-operati" class="xref">Issues with ADSP in Operation</a><a href="#section-toc.1-1.13.2.5.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.6">
+                <p id="section-toc.1-1.13.2.6.1"><a href="#section-a.6" class="xref">A.6</a>.  <a href="#name-organizational-domain-disco" class="xref">Organizational Domain Discovery Issues</a><a href="#section-toc.1-1.13.2.6.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.6.2.1">
+                    <p id="section-toc.1-1.13.2.6.2.1.1"><a href="#section-a.6.1" class="xref">A.6.1</a>.  <a href="#name-public-suffix-lists" class="xref">Public Suffix Lists</a><a href="#section-toc.1-1.13.2.6.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.7">
+                <p id="section-toc.1-1.13.2.7.1"><a href="#section-a.7" class="xref">A.7</a>.  <a href="#name-removal-of-the-pct-tag" class="xref">Removal of the "pct" Tag</a><a href="#section-toc.1-1.13.2.7.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14">
+            <p id="section-toc.1-1.14.1"><a href="#section-appendix.b" class="xref">Appendix B</a>.  <a href="#name-examples" class="xref">Examples</a><a href="#section-toc.1-1.14.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.1">
+                <p id="section-toc.1-1.14.2.1.1"><a href="#section-b.1" class="xref">B.1</a>.  <a href="#name-identifier-alignment-exampl" class="xref">Identifier Alignment Examples</a><a href="#section-toc.1-1.14.2.1.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.1.2.1">
+                    <p id="section-toc.1-1.14.2.1.2.1.1"><a href="#section-b.1.1" class="xref">B.1.1</a>.  <a href="#name-spf" class="xref">SPF</a><a href="#section-toc.1-1.14.2.1.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.1.2.2">
+                    <p id="section-toc.1-1.14.2.1.2.2.1"><a href="#section-b.1.2" class="xref">B.1.2</a>.  <a href="#name-dkim" class="xref">DKIM</a><a href="#section-toc.1-1.14.2.1.2.2.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.2">
+                <p id="section-toc.1-1.14.2.2.1"><a href="#section-b.2" class="xref">B.2</a>.  <a href="#name-domain-owner-example" class="xref">Domain Owner Example</a><a href="#section-toc.1-1.14.2.2.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.2.2.1">
+                    <p id="section-toc.1-1.14.2.2.2.1.1"><a href="#section-b.2.1" class="xref">B.2.1</a>.  <a href="#name-entire-domain-monitoring-on" class="xref">Entire Domain, Monitoring Only</a><a href="#section-toc.1-1.14.2.2.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.2.2.2">
+                    <p id="section-toc.1-1.14.2.2.2.2.1"><a href="#section-b.2.2" class="xref">B.2.2</a>.  <a href="#name-entire-domain-monitoring-onl" class="xref">Entire Domain, Monitoring Only, Per-Message Reports</a><a href="#section-toc.1-1.14.2.2.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.2.2.3">
+                    <p id="section-toc.1-1.14.2.2.2.3.1"><a href="#section-b.2.3" class="xref">B.2.3</a>.  <a href="#name-per-message-failure-reports" class="xref">Per-Message Failure Reports Directed to Third Party</a><a href="#section-toc.1-1.14.2.2.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.2.2.4">
+                    <p id="section-toc.1-1.14.2.2.2.4.1"><a href="#section-b.2.4" class="xref">B.2.4</a>.  <a href="#name-subdomain-testing-and-multi" class="xref">Subdomain, Testing, and Multiple Aggregate Report URIs</a><a href="#section-toc.1-1.14.2.2.2.4.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.3">
+                <p id="section-toc.1-1.14.2.3.1"><a href="#section-b.3" class="xref">B.3</a>.  <a href="#name-mail-receiver-example" class="xref">Mail Receiver Example</a><a href="#section-toc.1-1.14.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.4">
+                <p id="section-toc.1-1.14.2.4.1"><a href="#section-b.4" class="xref">B.4</a>.  <a href="#name-processing-of-smtp-time" class="xref">Processing of SMTP Time</a><a href="#section-toc.1-1.14.2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.14.2.5">
+                <p id="section-toc.1-1.14.2.5.1"><a href="#section-b.5" class="xref">B.5</a>.  <a href="#name-utilization-of-aggregate-fe" class="xref">Utilization of Aggregate Feedback: Example</a><a href="#section-toc.1-1.14.2.5.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15">
+            <p id="section-toc.1-1.15.1"><a href="#section-appendix.c" class="xref">Appendix C</a>.  <a href="#name-change-log" class="xref">Change Log</a><a href="#section-toc.1-1.15.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.1">
+                <p id="section-toc.1-1.15.2.1.1"><a href="#section-c.1" class="xref">C.1</a>.  <a href="#name-january-5-2021" class="xref">January 5, 2021</a><a href="#section-toc.1-1.15.2.1.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.1.2.1">
+                    <p id="section-toc.1-1.15.2.1.2.1.1"><a href="#section-c.1.1" class="xref">C.1.1</a>.  <a href="#name-ticket-80-dmarcbis-should-h" class="xref">Ticket 80 - DMARCbis SHould Have Clear and Concise Defintion of DMARC</a><a href="#section-toc.1-1.15.2.1.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.2">
+                <p id="section-toc.1-1.15.2.2.1"><a href="#section-c.2" class="xref">C.2</a>.  <a href="#name-february-4-2021" class="xref">February 4, 2021</a><a href="#section-toc.1-1.15.2.2.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.2.2.1">
+                    <p id="section-toc.1-1.15.2.2.2.1.1"><a href="#section-c.2.1" class="xref">C.2.1</a>.  <a href="#name-ticket-1-spf-rfc-4408-vs-72" class="xref">Ticket 1 - SPF RFC 4408 vs 7208</a><a href="#section-toc.1-1.15.2.2.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.3">
+                <p id="section-toc.1-1.15.2.3.1"><a href="#section-c.3" class="xref">C.3</a>.  <a href="#name-february-10-2021" class="xref">February 10, 2021</a><a href="#section-toc.1-1.15.2.3.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.3.2.1">
+                    <p id="section-toc.1-1.15.2.3.2.1.1"><a href="#section-c.3.1" class="xref">C.3.1</a>.  <a href="#name-ticket-84-remove-erroneous-" class="xref">Ticket 84 - Remove Erroneous References to RFC3986</a><a href="#section-toc.1-1.15.2.3.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.4">
+                <p id="section-toc.1-1.15.2.4.1"><a href="#section-c.4" class="xref">C.4</a>.  <a href="#name-march-1-2021" class="xref">March 1, 2021</a><a href="#section-toc.1-1.15.2.4.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.4.2.1">
+                    <p id="section-toc.1-1.15.2.4.2.1.1"><a href="#section-c.4.1" class="xref">C.4.1</a>.  <a href="#name-design-team-work-begins" class="xref">Design Team Work Begins</a><a href="#section-toc.1-1.15.2.4.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.5">
+                <p id="section-toc.1-1.15.2.5.1"><a href="#section-c.5" class="xref">C.5</a>.  <a href="#name-march-8-2021" class="xref">March 8, 2021</a><a href="#section-toc.1-1.15.2.5.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.5.2.1">
+                    <p id="section-toc.1-1.15.2.5.2.1.1"><a href="#section-c.5.1" class="xref">C.5.1</a>.  <a href="#name-removed-e-gustafsson-as-edi" class="xref">Removed E. Gustafsson as editor</a><a href="#section-toc.1-1.15.2.5.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.5.2.2">
+                    <p id="section-toc.1-1.15.2.5.2.2.1"><a href="#section-c.5.2" class="xref">C.5.2</a>.  <a href="#name-ticket-3-two-tiny-nits" class="xref">Ticket 3 - Two tiny nits</a><a href="#section-toc.1-1.15.2.5.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.5.2.3">
+                    <p id="section-toc.1-1.15.2.5.2.3.1"><a href="#section-c.5.3" class="xref">C.5.3</a>.  <a href="#name-ticket-4-definition-of-fo-p" class="xref">Ticket 4 - Definition of "fo" parameter</a><a href="#section-toc.1-1.15.2.5.2.3.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.6">
+                <p id="section-toc.1-1.15.2.6.1"><a href="#section-c.6" class="xref">C.6</a>.  <a href="#name-march-16-2021" class="xref">March 16, 2021</a><a href="#section-toc.1-1.15.2.6.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.6.2.1">
+                    <p id="section-toc.1-1.15.2.6.2.1.1"><a href="#section-c.6.1" class="xref">C.6.1</a>.  <a href="#name-ticket-7-abnf-for-dmarc-rec" class="xref">Ticket 7 - ABNF for dmarc-record is slightly wrong</a><a href="#section-toc.1-1.15.2.6.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.6.2.2">
+                    <p id="section-toc.1-1.15.2.6.2.2.1"><a href="#section-c.6.2" class="xref">C.6.2</a>.  <a href="#name-ticket-26-abnf-for-pct-allo" class="xref">Ticket 26 - ABNF for pct allows "999"</a><a href="#section-toc.1-1.15.2.6.2.2.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.7">
+                <p id="section-toc.1-1.15.2.7.1"><a href="#section-c.7" class="xref">C.7</a>.  <a href="#name-march-23-2021" class="xref">March 23, 2021</a><a href="#section-toc.1-1.15.2.7.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.7.2.1">
+                    <p id="section-toc.1-1.15.2.7.2.1.1"><a href="#section-c.7.1" class="xref">C.7.1</a>.  <a href="#name-ticket-75-using-wording-alt" class="xref">Ticket 75 - Using wording alternatives to 'disposition', 'dispose', and the like</a><a href="#section-toc.1-1.15.2.7.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.7.2.2">
+                    <p id="section-toc.1-1.15.2.7.2.2.1"><a href="#section-c.7.2" class="xref">C.7.2</a>.  <a href="#name-ticket-72-remove-absolute-r" class="xref">Ticket 72 - Remove absolute requirement for p= tag in DMARC record</a><a href="#section-toc.1-1.15.2.7.2.2.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.8">
+                <p id="section-toc.1-1.15.2.8.1"><a href="#section-c.8" class="xref">C.8</a>.  <a href="#name-march-29-2021" class="xref">March 29, 2021</a><a href="#section-toc.1-1.15.2.8.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.8.2.1">
+                    <p id="section-toc.1-1.15.2.8.2.1.1"><a href="#section-c.8.1" class="xref">C.8.1</a>.  <a href="#name-ticket-54-remove-or-expand-" class="xref">Ticket 54 - Remove or expand limits on number of recipients per report</a><a href="#section-toc.1-1.15.2.8.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.9">
+                <p id="section-toc.1-1.15.2.9.1"><a href="#section-c.9" class="xref">C.9</a>.  <a href="#name-april-12-2021" class="xref">April 12, 2021</a><a href="#section-toc.1-1.15.2.9.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.9.2.1">
+                    <p id="section-toc.1-1.15.2.9.2.1.1"><a href="#section-c.9.1" class="xref">C.9.1</a>.  <a href="#name-ticket-50-remove-ri-tag" class="xref">Ticket 50 - Remove ri= tag</a><a href="#section-toc.1-1.15.2.9.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.9.2.2">
+                    <p id="section-toc.1-1.15.2.9.2.2.1"><a href="#section-c.9.2" class="xref">C.9.2</a>.  <a href="#name-ticket-66-define-what-it-me" class="xref">Ticket 66 - Define what it means to have implemented DMARC</a><a href="#section-toc.1-1.15.2.9.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.9.2.3">
+                    <p id="section-toc.1-1.15.2.9.2.3.1"><a href="#section-c.9.3" class="xref">C.9.3</a>.  <a href="#name-ticket-96-tweaks-to-abstrac" class="xref">Ticket 96 - Tweaks to Abstract and Introduction</a><a href="#section-toc.1-1.15.2.9.2.3.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.10">
+                <p id="section-toc.1-1.15.2.10.1"><a href="#section-c.10" class="xref">C.10</a>. <a href="#name-april-13-2021" class="xref">April 13, 2021</a><a href="#section-toc.1-1.15.2.10.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.10.2.1">
+                    <p id="section-toc.1-1.15.2.10.2.1.1"><a href="#section-c.10.1" class="xref">C.10.1</a>.  <a href="#name-ticket-53-remove-reporting-" class="xref">Ticket 53 - Remove reporting message size chunking</a><a href="#section-toc.1-1.15.2.10.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.10.2.2">
+                    <p id="section-toc.1-1.15.2.10.2.2.1"><a href="#section-c.10.2" class="xref">C.10.2</a>.  <a href="#name-ticket-52-remove-strict-ali" class="xref">Ticket 52 - Remove strict alignment (and adkim and aspf tags)</a><a href="#section-toc.1-1.15.2.10.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.10.2.3">
+                    <p id="section-toc.1-1.15.2.10.2.3.1"><a href="#section-c.10.3" class="xref">C.10.3</a>.  <a href="#name-ticket-47-remove-pct-tag" class="xref">Ticket 47 - Remove pct= tag</a><a href="#section-toc.1-1.15.2.10.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.10.2.4">
+                    <p id="section-toc.1-1.15.2.10.2.4.1"><a href="#section-c.10.4" class="xref">C.10.4</a>.  <a href="#name-ticket-2-flow-of-operations" class="xref">Ticket 2 - Flow of operations text in dmarc-base</a><a href="#section-toc.1-1.15.2.10.2.4.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.11">
+                <p id="section-toc.1-1.15.2.11.1"><a href="#section-c.11" class="xref">C.11</a>. <a href="#name-april-14-2021" class="xref">April 14, 2021</a><a href="#section-toc.1-1.15.2.11.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.11.2.1">
+                    <p id="section-toc.1-1.15.2.11.2.1.1"><a href="#section-c.11.1" class="xref">C.11.1</a>.  <a href="#name-ticket-107-dmarcbis-should-" class="xref">Ticket 107 - DMARCbis should take a stand on multi-valued From fields</a><a href="#section-toc.1-1.15.2.11.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.11.2.2">
+                    <p id="section-toc.1-1.15.2.11.2.2.1"><a href="#section-c.11.2" class="xref">C.11.2</a>.  <a href="#name-ticket-82-deprecate-rf-and-" class="xref">Ticket 82 - Deprecate rf= and maybe fo= tag</a><a href="#section-toc.1-1.15.2.11.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.11.2.3">
+                    <p id="section-toc.1-1.15.2.11.2.3.1"><a href="#section-c.11.3" class="xref">C.11.3</a>.  <a href="#name-ticket-85-proposed-change-t" class="xref">Ticket 85 - Proposed change to wording describing 'p' tag and values</a><a href="#section-toc.1-1.15.2.11.2.3.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.12">
+                <p id="section-toc.1-1.15.2.12.1"><a href="#section-c.12" class="xref">C.12</a>. <a href="#name-april-15-2021" class="xref">April 15, 2021</a><a href="#section-toc.1-1.15.2.12.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.12.2.1">
+                    <p id="section-toc.1-1.15.2.12.2.1.1"><a href="#section-c.12.1" class="xref">C.12.1</a>.  <a href="#name-ticket-86-a-r-results-for-d" class="xref">Ticket 86 - A-R results for DMARC</a><a href="#section-toc.1-1.15.2.12.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.12.2.2">
+                    <p id="section-toc.1-1.15.2.12.2.2.1"><a href="#section-c.12.2" class="xref">C.12.2</a>.  <a href="#name-ticket-62-make-aggregate-re" class="xref">Ticket 62 - Make aggregate reporting a normative MUST</a><a href="#section-toc.1-1.15.2.12.2.2.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.13">
+                <p id="section-toc.1-1.15.2.13.1"><a href="#section-c.13" class="xref">C.13</a>. <a href="#name-april-19-2021" class="xref">April 19, 2021</a><a href="#section-toc.1-1.15.2.13.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.13.2.1">
+                    <p id="section-toc.1-1.15.2.13.2.1.1"><a href="#section-c.13.1" class="xref">C.13.1</a>.  <a href="#name-ticket-109-sanity-check-dma" class="xref">Ticket 109 - Sanity Check DMARCbis Document</a><a href="#section-toc.1-1.15.2.13.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.14">
+                <p id="section-toc.1-1.15.2.14.1"><a href="#section-c.14" class="xref">C.14</a>. <a href="#name-april-20-2021" class="xref">April 20, 2021</a><a href="#section-toc.1-1.15.2.14.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.14.2.1">
+                    <p id="section-toc.1-1.15.2.14.2.1.1"><a href="#section-c.14.1" class="xref">C.14.1</a>.  <a href="#name-ticket-108-changes-to-dmarc" class="xref">Ticket 108 - Changes to DMARCbis for PSD</a><a href="#section-toc.1-1.15.2.14.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.15">
+                <p id="section-toc.1-1.15.2.15.1"><a href="#section-c.15" class="xref">C.15</a>. <a href="#name-april-22-2021" class="xref">April 22, 2021</a><a href="#section-toc.1-1.15.2.15.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.15.2.1">
+                    <p id="section-toc.1-1.15.2.15.2.1.1"><a href="#section-c.15.1" class="xref">C.15.1</a>.  <a href="#name-ticket-104-update-the-secur" class="xref">Ticket 104 - Update the Security Considerations section 11.3 on DNS</a><a href="#section-toc.1-1.15.2.15.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.16">
+                <p id="section-toc.1-1.15.2.16.1"><a href="#section-c.16" class="xref">C.16</a>. <a href="#name-june-16-2021" class="xref">June 16, 2021</a><a href="#section-toc.1-1.15.2.16.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.16.2.1">
+                    <p id="section-toc.1-1.15.2.16.2.1.1"><a href="#section-c.16.1" class="xref">C.16.1</a>.  <a href="#name-publication-of-draft-ietf-d" class="xref">Publication of draft-ietf-dmarc-dmarcbis-02</a><a href="#section-toc.1-1.15.2.16.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.17">
+                <p id="section-toc.1-1.15.2.17.1"><a href="#section-c.17" class="xref">C.17</a>. <a href="#name-august-12-2021" class="xref">August 12, 2021</a><a href="#section-toc.1-1.15.2.17.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.15.2.17.2.1">
+                    <p id="section-toc.1-1.15.2.17.2.1.1"><a href="#section-c.17.1" class="xref">C.17.1</a>.  <a href="#name-publication-of-draft-ietf-dm" class="xref">Publication of draft-ietf-dmarc-dmarcbis-03</a><a href="#section-toc.1-1.15.2.17.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.16">
+            <p id="section-toc.1-1.16.1"><a href="#section-appendix.d" class="xref"></a><a href="#name-acknowledgements" class="xref">Acknowledgements</a><a href="#section-toc.1-1.16.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.17">
+            <p id="section-toc.1-1.17.1"><a href="#section-appendix.e" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a><a href="#section-toc.1-1.17.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</nav>
+</section>
+</div>
+<div id="introduction">
+<section id="section-1">
+      <h2 id="name-introduction">
+<a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction" class="section-name selfRef">Introduction</a>
+      </h2>
+<p id="section-1-1">RFC EDITOR: PLEASE REMOVE THE FOLLOWING PARAGRAPH BEFORE PUBLISHING:
+The source for this draft is maintained in GitHub at:
+<a href="https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis">https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis</a><a href="#section-1-1" class="pilcrow">¶</a></p>
+<p id="section-1-2">Abusive email often includes unauthorized and deceptive use of a
+domain name in the RFC5322.From header field. The domain typically
+belongs to an organization expected to be known to - and presumably
+trusted by - the recipient. The Sender Policy Framework (SPF) (<span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span>)
+and DomainKeys Identified Mail (DKIM) (<span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>) protocols provide
+domain-level authentication but are not directly associated with the
+RFC5322.From domain. DMARC leverages them, so that Domain Owners
+publish a DNS record indicating their RFC5322.From field:<a href="#section-1-2" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-1-3.1">Email authentication policies<a href="#section-1-3.1" class="pilcrow">¶</a>
+</li>
+<li id="section-1-3.2">Level of concern for mail that fails authentication checks<a href="#section-1-3.2" class="pilcrow">¶</a>
+</li>
+<li id="section-1-3.3">Desire for reports about email use of the domain name<a href="#section-1-3.3" class="pilcrow">¶</a>
+</li>
+</ul>
+<p id="section-1-4">DMARC can cover non-existent sub-domains, below the "Organizational
+Domain", as well as domains at the top of the name hierarchy,
+controlled by Public Suffix Operators (PSOs).<a href="#section-1-4" class="pilcrow">¶</a></p>
+<p id="section-1-5">As with SPF and DKIM, DMARC classes results as "pass" or "fail". A
+pass from either SPF or DKIM is required. Depending on the stated
+DMARC policy, the passed domain must be "aligned" with the RFC5322.From
+domain in one of two modes - "relaxed" or "strict".  Domains are said
+to be "in relaxed alignment" if they have the same Organizational Domain,
+which is at the top of the domain hierarchy, while having the same
+administrative authority as the RFC5322.From domain, while domains are
+"in strict alignment" if and only if they are identical.<a href="#section-1-5" class="pilcrow">¶</a></p>
+<p id="section-1-6">A DMARC pass indicates only that the RFC5322.From domain has been
+authenticated for that message; authentication does not carry an
+explicit or implicit value assertion about that message or about
+the Domain Owner. Indeed, a mail-receiving organization that performs
+DMARC verification can choose to follow the Domain Owner's requested
+disposition for authentication failures, and to inform the Domain
+Owner of the mail handling decision for that message. It also might
+choose different actions.<a href="#section-1-6" class="pilcrow">¶</a></p>
+<p id="section-1-7">For a mail-receiving organization supporting DMARC, a message that
+passes verification is part of a message stream that is reliably
+associated with the RFC5322.From field Domain Owner. Therefore,
+reputation assessment of that stream by the mail-receiving organization
+is not encumbered by accounting for unauthorized use of that domain
+in the RFC5322.From field.  A message that fails this verification
+is not necessarily associated with the Domain Owner's domain and its
+reputation.<a href="#section-1-7" class="pilcrow">¶</a></p>
+<p id="section-1-8">DMARC, in the associated <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> and <span>[<a href="#DMARC-Failure-Reporting" class="xref">DMARC-Failure-Reporting</a>]</span>
+documents, also specifies a reporting framework. Using it, a mail-receiving
+domain can generate regular reports about messages that claim to be from
+a domain publishing DMARC policies, sending those reports to the address(es)
+specified by the Domain Owner.<a href="#section-1-8" class="pilcrow">¶</a></p>
+<p id="section-1-9">Use of DMARC creates some interoperability challenges that require due
+consideration before deployment, particularly with configurations that
+can cause mail to be rejected.  These are discussed in <a href="#other-topics" class="xref">Section 8</a>.<a href="#section-1-9" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="requirements">
+<section id="section-2">
+      <h2 id="name-requirements">
+<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-requirements" class="section-name selfRef">Requirements</a>
+      </h2>
+<p id="section-2-1">Specification of DMARC is guided by the following high-level goals,
+security dependencies, detailed requirements, and items that are
+documented as out of scope.<a href="#section-2-1" class="pilcrow">¶</a></p>
+<div id="high-level-goals">
+<section id="section-2.1">
+        <h3 id="name-high-level-goals">
+<a href="#section-2.1" class="section-number selfRef">2.1. </a><a href="#name-high-level-goals" class="section-name selfRef">High-Level Goals</a>
+        </h3>
+<p id="section-2.1-1">DMARC has the following high-level goals:<a href="#section-2.1-1" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-2.1-2.1">
+            <p id="section-2.1-2.1.1">Allow Domain Owners and PSOs to assert their severity of concern for
+authentication failures for messages purporting to have
+authorship within the domain.<a href="#section-2.1-2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.1-2.2">
+            <p id="section-2.1-2.2.1">Allow Domain Owners and PSOs to verify their authentication deployment.<a href="#section-2.1-2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.1-2.3">
+            <p id="section-2.1-2.3.1">Minimize implementation complexity for both senders and receivers,
+as well as the impact on handling and delivery of legitimate
+messages.<a href="#section-2.1-2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.1-2.4">
+            <p id="section-2.1-2.4.1">Reduce the amount of successfully delivered spoofed email.<a href="#section-2.1-2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.1-2.5">
+            <p id="section-2.1-2.5.1">Work at Internet scale.<a href="#section-2.1-2.5.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</section>
+</div>
+<div id="out-of-scope">
+<section id="section-2.2">
+        <h3 id="name-out-of-scope">
+<a href="#section-2.2" class="section-number selfRef">2.2. </a><a href="#name-out-of-scope" class="section-name selfRef">Out of Scope</a>
+        </h3>
+<p id="section-2.2-1">Several topics and issues are specifically out of scope for this
+work.  These include the following:<a href="#section-2.2-1" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-2.2-2.1">
+            <p id="section-2.2-2.1.1">different treatment of messages that are not authenticated versus
+those that fail authentication;<a href="#section-2.2-2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.2-2.2">
+            <p id="section-2.2-2.2.1">evaluation of anything other than RFC5322.From header field;<a href="#section-2.2-2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.2-2.3">
+            <p id="section-2.2-2.3.1">multiple reporting formats;<a href="#section-2.2-2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.2-2.4">
+            <p id="section-2.2-2.4.1">publishing policy other than via the DNS;<a href="#section-2.2-2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.2-2.5">
+            <p id="section-2.2-2.5.1">reporting or otherwise evaluating other than the last-hop IP
+address;<a href="#section-2.2-2.5.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.2-2.6">
+            <p id="section-2.2-2.6.1">attacks in the From: header field, also known as "display name"
+attacks;<a href="#section-2.2-2.6.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.2-2.7">
+            <p id="section-2.2-2.7.1">authentication of entities other than domains, since DMARC is
+built upon SPF and DKIM, which authenticate domains; and<a href="#section-2.2-2.7.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.2-2.8">
+            <p id="section-2.2-2.8.1">content analysis.<a href="#section-2.2-2.8.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</section>
+</div>
+<div id="scalability">
+<section id="section-2.3">
+        <h3 id="name-scalability">
+<a href="#section-2.3" class="section-number selfRef">2.3. </a><a href="#name-scalability" class="section-name selfRef">Scalability</a>
+        </h3>
+<p id="section-2.3-1">Scalability is a major issue for systems that need to operate in a
+system as widely deployed as current SMTP email.  For this reason,
+DMARC seeks to avoid the need for third parties or pre-sending
+agreements between senders and receivers.  This preserves the
+positive aspects of the current email infrastructure.<a href="#section-2.3-1" class="pilcrow">¶</a></p>
+<p id="section-2.3-2">Although DMARC does not introduce third-party senders (namely
+external agents authorized to send on behalf of an operator) to the
+email-handling flow, it also does not preclude them.  Such third
+parties are free to provide services in conjunction with DMARC.<a href="#section-2.3-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="anti-phishing">
+<section id="section-2.4">
+        <h3 id="name-anti-phishing">
+<a href="#section-2.4" class="section-number selfRef">2.4. </a><a href="#name-anti-phishing" class="section-name selfRef">Anti-Phishing</a>
+        </h3>
+<p id="section-2.4-1">DMARC is designed to prevent bad actors from sending mail that claims
+to come from legitimate senders, particularly senders of
+transactional email (official mail that is about business
+transactions).  One of the primary uses of this kind of spoofed mail
+is phishing (enticing users to provide information by pretending to
+be the legitimate service requesting the information).  Thus, DMARC
+is significantly informed by ongoing efforts to enact large-scale,
+Internet-wide anti-phishing measures.<a href="#section-2.4-1" class="pilcrow">¶</a></p>
+<p id="section-2.4-2">Although DMARC can only be used to combat specific forms of exact-
+domain spoofing directly, the DMARC mechanism has been found to be
+useful in the creation of reliable and defensible message streams.<a href="#section-2.4-2" class="pilcrow">¶</a></p>
+<p id="section-2.4-3">DMARC does not attempt to solve all problems with spoofed or
+otherwise fraudulent email.  In particular, it does not address the
+use of visually similar domain names ("cousin domains") or abuse of
+the RFC5322.From human-readable &lt;display-name&gt;.<a href="#section-2.4-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="terminology">
+<section id="section-3">
+      <h2 id="name-terminology-and-definitions">
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-terminology-and-definitions" class="section-name selfRef">Terminology and Definitions</a>
+      </h2>
+<p id="section-3-1">This section defines terms used in the rest of the document.<a href="#section-3-1" class="pilcrow">¶</a></p>
+<div id="conventions-used-in-this-document">
+<section id="section-3.1">
+        <h3 id="name-conventions-used-in-this-do">
+<a href="#section-3.1" class="section-number selfRef">3.1. </a><a href="#name-conventions-used-in-this-do" class="section-name selfRef">Conventions Used in This Document</a>
+        </h3>
+<p id="section-3.1-1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in BCP 14 <span>[<a href="#RFC2119" class="xref">RFC2119</a>]</span> <span>[<a href="#RFC8174" class="xref">RFC8174</a>]</span>
+when, and only when, they appear in all capitals, as shown here.<a href="#section-3.1-1" class="pilcrow">¶</a></p>
+<p id="section-3.1-2">Readers are encouraged to be familiar with the contents of
+<span>[<a href="#RFC5598" class="xref">RFC5598</a>]</span>.  In particular, that document defines various roles in
+the messaging infrastructure that can appear the same or separate in
+various contexts.  For example, a Domain Owner could, via the
+messaging security mechanisms on which DMARC is based, delegate the
+ability to send mail as the Domain Owner to a third party with
+another role.  This document does not address the distinctions among
+such roles; the reader is encouraged to become familiar with that
+material before continuing.<a href="#section-3.1-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="authenticated-identifiers">
+<section id="section-3.2">
+        <h3 id="name-authenticated-identifiers">
+<a href="#section-3.2" class="section-number selfRef">3.2. </a><a href="#name-authenticated-identifiers" class="section-name selfRef">Authenticated Identifiers</a>
+        </h3>
+<p id="section-3.2-1">Domain-level identifiers that are verified using authentication technologies
+are referred to as "Authenticated Identifiers".  See <a href="#authenication-mechanisms" class="xref">Section 4.1</a>
+for details about the supported mechanisms.<a href="#section-3.2-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="author-domain">
+<section id="section-3.3">
+        <h3 id="name-author-domain">
+<a href="#section-3.3" class="section-number selfRef">3.3. </a><a href="#name-author-domain" class="section-name selfRef">Author Domain</a>
+        </h3>
+<p id="section-3.3-1">The domain name of the apparent author, as extracted from the From: header field.<a href="#section-3.3-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="domain-owner">
+<section id="section-3.4">
+        <h3 id="name-domain-owner">
+<a href="#section-3.4" class="section-number selfRef">3.4. </a><a href="#name-domain-owner" class="section-name selfRef">Domain Owner</a>
+        </h3>
+<p id="section-3.4-1">An entity or organization that owns a DNS domain.  The
+term "owns" here indicates that the entity or organization being
+referenced holds the registration of that DNS domain.  Domain
+Owners range from complex, globally distributed organizations, to
+service providers working on behalf of non-technical clients, to
+individuals responsible for maintaining personal domains.  This
+specification uses this term as analogous to an Administrative
+Management Domain as defined in <span>[<a href="#RFC5598" class="xref">RFC5598</a>]</span>.  It can also refer
+to delegates, such as Report Receivers, when those are outside of
+their immediate management domain.<a href="#section-3.4-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="identifier-alignment">
+<section id="section-3.5">
+        <h3 id="name-identifier-alignment">
+<a href="#section-3.5" class="section-number selfRef">3.5. </a><a href="#name-identifier-alignment" class="section-name selfRef">Identifier Alignment</a>
+        </h3>
+<p id="section-3.5-1">When the domain in the address in the From: header field has the
+same Organizational Domain as a domain verified by SPF or DKIM
+(or both), it has Identifier Alignment. (see below)<a href="#section-3.5-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="longest-psd">
+<section id="section-3.6">
+        <h3 id="name-longest-psd">
+<a href="#section-3.6" class="section-number selfRef">3.6. </a><a href="#name-longest-psd" class="section-name selfRef">Longest PSD</a>
+        </h3>
+<p id="section-3.6-1">The term Longest PSD is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.6-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="mail-receiver">
+<section id="section-3.7">
+        <h3 id="name-mail-receiver">
+<a href="#section-3.7" class="section-number selfRef">3.7. </a><a href="#name-mail-receiver" class="section-name selfRef">Mail Receiver</a>
+        </h3>
+<p id="section-3.7-1">The entity or organization that receives and processes email.<br>
+Mail Receivers operate one or more Internet-facing Mail Transport
+Agents (MTAs).<a href="#section-3.7-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="non-existent-domains">
+<section id="section-3.8">
+        <h3 id="name-non-existent-domains">
+<a href="#section-3.8" class="section-number selfRef">3.8. </a><a href="#name-non-existent-domains" class="section-name selfRef">Non-existent Domains</a>
+        </h3>
+<p id="section-3.8-1">For DMARC purposes, a non-existent domain is a domain for which there
+is an NXDOMAIN or NODATA response for A, AAAA, and MX records.  This
+is a broader definition than that in <span>[<a href="#RFC8020" class="xref">RFC8020</a>]</span>.<a href="#section-3.8-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="organizational-domain">
+<section id="section-3.9">
+        <h3 id="name-organizational-domain">
+<a href="#section-3.9" class="section-number selfRef">3.9. </a><a href="#name-organizational-domain" class="section-name selfRef">Organizational Domain</a>
+        </h3>
+<p id="section-3.9-1">The domain that was registered with a domain name registrar.  In
+the absence of more accurate methods, heuristics are used to determine
+this, since it is not always the case that the registered domain name
+is simply a top-level DNS domain plus one component (e.g., "example.com",
+where "com" is a top-level domain).  The Organizational Domain is
+determined by applying the algorithm found in
+<a href="#determining-the-organizational-domain" class="xref">Section 3.15</a>.<a href="#section-3.9-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="public-suffix-domain">
+<section id="section-3.10">
+        <h3 id="name-public-suffix-domain-psd">
+<a href="#section-3.10" class="section-number selfRef">3.10. </a><a href="#name-public-suffix-domain-psd" class="section-name selfRef">Public Suffix Domain (PSD)</a>
+        </h3>
+<p id="section-3.10-1">The term Public Suffix Domain is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.10-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="public-suffix-operator">
+<section id="section-3.11">
+        <h3 id="name-public-suffix-operator-pso">
+<a href="#section-3.11" class="section-number selfRef">3.11. </a><a href="#name-public-suffix-operator-pso" class="section-name selfRef">Public Suffix Operator (PSO)</a>
+        </h3>
+<p id="section-3.11-1">The term Public Suffix Operator is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.11-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="pso-controlled-domain-names">
+<section id="section-3.12">
+        <h3 id="name-pso-controlled-domain-names">
+<a href="#section-3.12" class="section-number selfRef">3.12. </a><a href="#name-pso-controlled-domain-names" class="section-name selfRef">PSO Controlled Domain Names</a>
+        </h3>
+<p id="section-3.12-1">The term PSO Controlled Domain Names is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.12-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="report-receiver">
+<section id="section-3.13">
+        <h3 id="name-report-receiver">
+<a href="#section-3.13" class="section-number selfRef">3.13. </a><a href="#name-report-receiver" class="section-name selfRef">Report Receiver</a>
+        </h3>
+<p id="section-3.13-1">An operator that receives reports from another operator
+implementing the reporting mechanisms described in this document
+and/or the documents <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> and <span>[<a href="#DMARC-Failure-Reporting" class="xref">DMARC-Failure-Reporting</a>]</span>.
+Such an operator might be receiving reports about messages related
+to a domain for which it is the Domain Owner or PSO, or reports about
+messages related to another operator's domain.  This term applies
+collectively to the system components that receive and process these
+reports and the organizations that operate them.<a href="#section-3.13-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="more-on-identifier-alignment">
+<section id="section-3.14">
+        <h3 id="name-more-on-identifier-alignmen">
+<a href="#section-3.14" class="section-number selfRef">3.14. </a><a href="#name-more-on-identifier-alignmen" class="section-name selfRef">More on Identifier Alignment</a>
+        </h3>
+<p id="section-3.14-1">Email authentication technologies authenticate various (and
+disparate) aspects of an individual message.  For example, DKIM <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>
+authenticates the domain that affixed a signature to the message,
+while SPF <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span> can authenticate either the domain that appears in the
+RFC5321.MailFrom (MAIL FROM) portion of an SMTP <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span> conversation or the
+RFC5321.EHLO/HELO domain, or both.  These may be different domains, and they
+are typically not visible to the end user.<a href="#section-3.14-1" class="pilcrow">¶</a></p>
+<p id="section-3.14-2">DMARC authenticates use of the RFC5322.From domain by requiring that
+it have the same Organizational Domain as (i.e., be aligned with) an
+Authenticated Identifier. Domain names in this context are to be compared
+in a case-insensitive manner, per <span>[<a href="#RFC4343" class="xref">RFC4343</a>]</span>. The RFC5322.From domain
+was selected as the central identity of the DMARC mechanism because it
+is a required message header field and therefore guaranteed to be present
+in compliant messages, and most Mail User Agents (MUAs) represent the
+RFC5322.From header field as the originator of the message and render
+some or all of this header field's content to end users.<a href="#section-3.14-2" class="pilcrow">¶</a></p>
+<p id="section-3.14-3">It is important to note that Identifier Alignment cannot occur with a
+message that is not valid per <span>[<a href="#RFC5322" class="xref">RFC5322</a>]</span>, particularly one with a
+malformed, absent, or repeated RFC5322.From header field, since in that case
+there is no reliable way to determine a DMARC policy that applies to
+the message.  Accordingly, DMARC operation is predicated on the input
+being a valid RFC5322 message object, and handling of such
+non-compliant cases is outside of the scope of this specification.
+Further discussion of this can be found in <a href="#extract-author-domain" class="xref">Section 6.7.1</a>.<a href="#section-3.14-3" class="pilcrow">¶</a></p>
+<p id="section-3.14-4">Each of the underlying authentication technologies that DMARC takes
+as input yields authenticated domains as their outputs when they
+succeed.<a href="#section-3.14-4" class="pilcrow">¶</a></p>
+<div id="dkim-identifiers">
+<section id="section-3.14.1">
+          <h4 id="name-dkim-authenticated-identifi">
+<a href="#section-3.14.1" class="section-number selfRef">3.14.1. </a><a href="#name-dkim-authenticated-identifi" class="section-name selfRef">DKIM-Authenticated Identifiers</a>
+          </h4>
+<p id="section-3.14.1-1">DMARC requires Identifier Alignment based on the result of a DKIM
+authentication because a message can bear a valid signature from any
+domain, including domains used by a mailing list or even a bad actor.
+Therefore, merely bearing a valid signature is not enough to infer
+authenticity of the Author Domain.<a href="#section-3.14.1-1" class="pilcrow">¶</a></p>
+<p id="section-3.14.1-2">DMARC permits Identifier Alignment based on the result of a DKIM
+authentication to be strict or relaxed. (Note that these terms are
+not related to DKIM's "simple" and "relaxed" canonicalization modes.)<a href="#section-3.14.1-2" class="pilcrow">¶</a></p>
+<p id="section-3.14.1-3">In relaxed mode, the Organizational Domains of both the DKIM-authenticated
+signing domain (taken from the value of the d= tag in the signature)
+and that of the RFC5322.From domain must be equal if the identifiers
+are to be considered to be aligned. In strict mode, only an exact match
+between both Fully Qualified Domain Names (FQDNs) is considered to produce
+Identifier Alignment.<a href="#section-3.14.1-3" class="pilcrow">¶</a></p>
+<p id="section-3.14.1-4">To illustrate, in relaxed mode, if a verified DKIM signature
+successfully verifies with a "d=" domain of "example.com", and the
+RFC5322.From address is "alerts@news.example.com", the DKIM "d="
+domain and the RFC5322.From domain are considered to be "in alignment",
+because both domains have the same Organizational Domain of "example.com".
+In strict mode, this test would fail because the d= domain does not
+exactly match the RFC5322.From domain.<a href="#section-3.14.1-4" class="pilcrow">¶</a></p>
+<p id="section-3.14.1-5">However, a DKIM signature bearing a value of "d=com" would never allow
+an "in alignment" result, as "com" should appear on all public suffix
+lists (see <a href="#public-suffix-lists" class="xref">Appendix A.6.1</a>) and therefore cannot be an Organizational
+Domain.<a href="#section-3.14.1-5" class="pilcrow">¶</a></p>
+<p id="section-3.14.1-6">Note that a single email can contain multiple DKIM signatures, and it
+is considered to produce a DMARC "pass" result if any DKIM signature
+is aligned and verifies.<a href="#section-3.14.1-6" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="spf-identifiers">
+<section id="section-3.14.2">
+          <h4 id="name-spf-authenticated-identifie">
+<a href="#section-3.14.2" class="section-number selfRef">3.14.2. </a><a href="#name-spf-authenticated-identifie" class="section-name selfRef">SPF-Authenticated Identifiers</a>
+          </h4>
+<p id="section-3.14.2-1">DMARC permits Identifier Alignment based on the result of an SPF
+authentication. As with DKIM, Identifier Alignement can be either
+strict or relaxed.<a href="#section-3.14.2-1" class="pilcrow">¶</a></p>
+<p id="section-3.14.2-2">In relaxed mode, the Organizational Domains of the SPF-authenticated
+domain and RFC5322.From domain must be equal if the identifiers are
+to be considered to be aligned. In strict mode, the two FQDNs must
+match exactly in order from them to be considered to be aligned.<a href="#section-3.14.2-2" class="pilcrow">¶</a></p>
+<p id="section-3.14.2-3">For example, in relaxed mode, if a message passes an SPF check with an
+RFC5321.MailFrom domain of "cbg.bounces.example.com", and the address
+portion of the RFC5322.From header field contains
+"payments@example.com", the Authenticated RFC5321.MailFrom domain
+identifier and the RFC5322.From domain are considered to be "in
+alignment" because they have the same Organizational Domain
+("example.com"). In strict mode, this test would fail because the
+two domains are not identical.<a href="#section-3.14.2-3" class="pilcrow">¶</a></p>
+<p id="section-3.14.2-4">The reader should note that SPF alignment checks in DMARC rely solely
+on the RFC5321.MailFrom domain. This differs from section 2.3 of
+<span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span>, which recommends that SPF checks be done on not only the
+"MAIL FROM" but also on a separate check of the "HELO" identity.<a href="#section-3.14.2-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="alignment-and-extension-technologies">
+<section id="section-3.14.3">
+          <h4 id="name-alignment-and-extension-tec">
+<a href="#section-3.14.3" class="section-number selfRef">3.14.3. </a><a href="#name-alignment-and-extension-tec" class="section-name selfRef">Alignment and Extension Technologies</a>
+          </h4>
+<p id="section-3.14.3-1">If in the future DMARC is extended to include the use of other
+authentication mechanisms, the extensions will need to allow for
+domain identifier extraction so that alignment with the RFC5322.From
+domain can be verified.<a href="#section-3.14.3-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="determining-the-organizational-domain">
+<section id="section-3.15">
+        <h3 id="name-determining-the-organizatio">
+<a href="#section-3.15" class="section-number selfRef">3.15. </a><a href="#name-determining-the-organizatio" class="section-name selfRef">Determining The Organizational Domain</a>
+        </h3>
+<p id="section-3.15-1">The Organizational Domain is determined using the following
+algorithm:<a href="#section-3.15-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-3.15-2">
+          <li id="section-3.15-2.1">
+            <p id="section-3.15-2.1.1">Acquire a "public suffix" list, i.e., a list of DNS domain names
+reserved for registrations.  Some country Top-Level Domains
+(TLDs) make specific registration requirements, e.g., the United
+Kingdom places company registrations under ".co.uk"; other TLDs
+such as ".com" appear in the IANA registry of top-level DNS
+domains.  A public suffix list is the union of all of these.
+<a href="#public-suffix-lists" class="xref">Appendix A.6.1</a> contains some discussion about obtaining a public
+suffix list.<a href="#section-3.15-2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-3.15-2.2">
+            <p id="section-3.15-2.2.1">Break the subject DNS domain name into a set of "n" ordered
+labels.  Number these labels from right to left; e.g., for
+"example.com", "com" would be label 1 and "example" would be
+label 2.<a href="#section-3.15-2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-3.15-2.3">
+            <p id="section-3.15-2.3.1">Search the public suffix list for the name that matches the
+largest number of labels found in the subject DNS domain.  Let
+that number be "x".<a href="#section-3.15-2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-3.15-2.4">
+            <p id="section-3.15-2.4.1">Construct a new DNS domain name using the name that matched from
+the public suffix list and prefixing to it the "x+1"th label from
+the subject domain.  This new name is the Organizational Domain.<a href="#section-3.15-2.4.1" class="pilcrow">¶</a></p>
+</li>
+</ol>
+<p id="section-3.15-3">Thus, since "com" is an IANA-registered TLD, a subject domain of
+"a.b.c.d.example.com" would have an Organizational Domain of
+"example.com".<a href="#section-3.15-3" class="pilcrow">¶</a></p>
+<p id="section-3.15-4">The process of determining a suffix is currently a heuristic one.  No
+list is guaranteed to be accurate or current.<a href="#section-3.15-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="overview">
+<section id="section-4">
+      <h2 id="name-overview">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-overview" class="section-name selfRef">Overview</a>
+      </h2>
+<p id="section-4-1">This section provides a general overview of the design and operation
+of the DMARC environment.<a href="#section-4-1" class="pilcrow">¶</a></p>
+<div id="authenication-mechanisms">
+<section id="section-4.1">
+        <h3 id="name-authentication-mechanisms">
+<a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-authentication-mechanisms" class="section-name selfRef">Authentication Mechanisms</a>
+        </h3>
+<p id="section-4.1-1">The following mechanisms for determining Authenticated Identifiers
+are supported in this version of DMARC:<a href="#section-4.1-1" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-4.1-2.1">
+            <p id="section-4.1-2.1.1">DKIM, <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>, which provides a domain-level identifier in the content of
+the "d=" tag of a verified DKIM-Signature header field.<a href="#section-4.1-2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4.1-2.2">
+            <p id="section-4.1-2.2.1">SPF, <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span>, which can authenticate both the domain found in
+an <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span> HELO/EHLO command (the HELO identity) and the domain
+found in an SMTP MAIL command (the MAIL FROM identity). As noted earlier,
+however, DMARC relies solely on SPF authentication of the domain found in
+SMTP MAIL FROM command. Section 2.4 of <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span> describes MAIL FROM
+processing for cases in which the MAIL command has a null path.<a href="#section-4.1-2.2.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</section>
+</div>
+<div id="key-concepts">
+<section id="section-4.2">
+        <h3 id="name-key-concepts">
+<a href="#section-4.2" class="section-number selfRef">4.2. </a><a href="#name-key-concepts" class="section-name selfRef">Key Concepts</a>
+        </h3>
+<p id="section-4.2-1">DMARC policies are published by the Domain Owner or PSO, and retrieved by
+the Mail Receiver during the SMTP session, via the DNS.<a href="#section-4.2-1" class="pilcrow">¶</a></p>
+<p id="section-4.2-2">DMARC's verification function is based on whether the RFC5322.From
+domain is aligned with an authenticated domain name from SPF or DKIM.<br>
+When a DMARC policy is published for the domain name found in the
+RFC5322.From header field, and that domain name is not verified
+through SPF or DKIM, the handling of that message can be affected
+by that DMARC policy when delivered to a participating receiver.<a href="#section-4.2-2" class="pilcrow">¶</a></p>
+<p id="section-4.2-3">It is important to note that the authentication mechanisms employed
+by DMARC authenticate only a DNS domain and do not authenticate the
+local-part of any email address identifier found in a message, nor do
+they validate the legitimacy of message content.<a href="#section-4.2-3" class="pilcrow">¶</a></p>
+<p id="section-4.2-4">DMARC's feedback component involves the collection of information
+about received messages claiming to be from the Author Domain
+for periodic aggregate reports to the Domain Owner or PSO.  The
+parameters and format for such reports are discussed in <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-4.2-4" class="pilcrow">¶</a></p>
+<p id="section-4.2-5">A DMARC-enabled Mail Receiver might also generate per-message reports
+that contain information related to individual messages that fail SPF
+and/or DKIM.  Per-message failure reports are a useful source of
+information when debugging deployments (if messages can be determined
+to be legitimate even though failing authentication) or in analyzing
+attacks.  The capability for such services is enabled by DMARC but
+defined in other referenced material such as <span>[<a href="#RFC6591" class="xref">RFC6591</a>]</span> and <span>[<a href="#DMARC-Failure-Reporting" class="xref">DMARC-Failure-Reporting</a>]</span><a href="#section-4.2-5" class="pilcrow">¶</a></p>
+<p id="section-4.2-6">A message satisfies the DMARC checks if at least one of the supported
+authentication mechanisms:<a href="#section-4.2-6" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-4.2-7">
+          <li id="section-4.2-7.1">
+            <p id="section-4.2-7.1.1">produces a "pass" result, and<a href="#section-4.2-7.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4.2-7.2">
+            <p id="section-4.2-7.2.1">produces that result based on an identifier that is in alignment,
+as defined in <a href="#terminology" class="xref">Section 3</a>.<a href="#section-4.2-7.2.1" class="pilcrow">¶</a></p>
+</li>
+</ol>
+</section>
+</div>
+<div id="flow-diagram">
+<section id="section-4.3">
+        <h3 id="name-flow-diagram">
+<a href="#section-4.3" class="section-number selfRef">4.3. </a><a href="#name-flow-diagram" class="section-name selfRef">Flow Diagram</a>
+        </h3>
+<div id="section-4.3-1">
+<pre class="sourcecode lang-ascii-art"> +---------------+                             +--------------------+
+ | Author Domain |&lt; . . . . . . . . . . . .    | Return-Path Domain |
+ +---------------+                        .    +--------------------+
+     |                                    .               ^
+     V                                    V               .
+ +-----------+     +--------+       +----------+          v
+ |   MSA     |&lt;***&gt;|  DKIM  |       |   DMARC  |     +----------+
+ |  Service  |     | Signer |       | Verifier |&lt;***&gt;|    SPF   |
+ +-----------+     +--------+       +----------+  *  | Verifier |
+     |                                    ^       *  +----------+
+     |                                    *       *
+     V                                    v       *
+  +------+        (~~~~~~~~~~~~)      +------+    *  +----------+
+  | sMTA |-------&gt;( other MTAs )-----&gt;| rMTA |    **&gt;|   DKIM   |
+  +------+        (~~~~~~~~~~~~)      +------+       | Verifier |
+                                         |           +----------+
+                                         |                ^
+                                         V                .
+                                  +-----------+           .
+                    +---------+   |    MDA    |           v
+                    |  User   |&lt;--| Filtering |      +-----------+
+                    | Mailbox |   |  Engine   |      |   DKIM    |
+                    +---------+   +-----------+      |  Signing  |
+                                                     | Domain(s) |
+                                                     +-----------+
+
+  MSA = Mail Submission Agent
+  MDA = Mail Delivery Agent
+</pre><a href="#section-4.3-1" class="pilcrow">¶</a>
+</div>
+<p id="section-4.3-2">The above diagram shows a simple flow of messages through a DMARC-
+aware system.  Solid lines denote the actual message flow, dotted
+lines involve DNS queries used to retrieve message policy related to
+the supported message authentication schemes, and asterisk lines
+indicate data exchange between message-handling modules and message
+authentication modules.  "sMTA" is the sending MTA, and "rMTA" is the
+receiving MTA.<a href="#section-4.3-2" class="pilcrow">¶</a></p>
+<p id="section-4.3-3">Put simply, when a message reaches a DMARC-aware rMTA, a DNS query
+will be initiated to determine if the author domain has published
+a DMARC policy. If a policy is found, the rMTA will use the results
+of SPF and DKIM verification checks to determine the ultimate DMARC
+authentication status. The DMARC status can then factor into the
+message handling decision made by the recipient's mail sytsem.<a href="#section-4.3-3" class="pilcrow">¶</a></p>
+<p id="section-4.3-4">More details on specific actions for the parties involved can be
+found in <a href="#domain-owner-actions" class="xref">Section 6.5</a> and <a href="#mail-receiver-actions" class="xref">Section 6.7</a>.<a href="#section-4.3-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="use-of-rfc5322-from">
+<section id="section-5">
+      <h2 id="name-use-of-rfc5322from">
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-use-of-rfc5322from" class="section-name selfRef">Use of RFC5322.From</a>
+      </h2>
+<p id="section-5-1">One of the most obvious points of security scrutiny for DMARC is the
+choice to focus on an identifier, namely the RFC5322.From address,
+which is part of a body of data that has been trivially forged
+throughout the history of email. This field is the one used by end
+users to identify the source of the message, and so it has always
+been a prime target for abuse through such forgery and other means.<a href="#section-5-1" class="pilcrow">¶</a></p>
+<p id="section-5-2">Several points suggest that it is the most correct and safest thing
+to do in this context:<a href="#section-5-2" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-5-3.1">
+          <p id="section-5-3.1.1">Of all the identifiers that are part of the message itself, this
+is the only one guaranteed to be present.<a href="#section-5-3.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-5-3.2">
+          <p id="section-5-3.2.1">It seems the best choice of an identifier on which to focus, as
+most MUAs display some or all of the contents of that field in a
+manner strongly suggesting those data as reflective of the true
+originator of the message.<a href="#section-5-3.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-5-3.3">
+          <p id="section-5-3.3.1">Many high-profile email sources, such as email service providers,
+require that the sending agent have authenticated before email
+can be generated.  Thus, for these mailboxes, the mechanism
+described in this document provides recipient end users with strong
+evidence that the message was indeed originated by the agent they
+associate with that mailbox, if the end user knows that these
+various protections have been provided.<a href="#section-5-3.3.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+<p id="section-5-4">The absence of a single, properly formed RFC5322.From header field renders
+the message invalid.  Handling of such a message is outside of the
+scope of this specification.<a href="#section-5-4" class="pilcrow">¶</a></p>
+<p id="section-5-5">Since the sorts of mail typically protected by DMARC participants
+tend to only have single Authors, DMARC participants generally
+operate under a slightly restricted profile of RFC5322 with respect
+to the expected syntax of this field.  See <a href="#mail-receiver-actions" class="xref">Section 6.7</a>
+for details.<a href="#section-5-5" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="policy">
+<section id="section-6">
+      <h2 id="name-policy">
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-policy" class="section-name selfRef">Policy</a>
+      </h2>
+<p id="section-6-1">DMARC policies are published by Domain Owners and PSOs and can be
+used by Mail Receivers to inform their message handling decisions.<a href="#section-6-1" class="pilcrow">¶</a></p>
+<p id="section-6-2">A Domain Owner or PSO advertises DMARC participation of one or more of its
+domains by adding a DNS TXT record (described in <a href="#dmarc-policy-record" class="xref">Section 6.1</a>) to
+those domains.  In doing so, Domain Owners and PSOs indicate their severity of
+concern regarding failed authentication for email messages making use
+of their domain in the RFC5322.From header field as well as the provision
+of feedback about those messages. Mail Receivers in turn can take into
+account the Domain Owner's severity of concern when making handling
+decisions about email messages that fail DMARC authentication checks.<a href="#section-6-2" class="pilcrow">¶</a></p>
+<p id="section-6-3">A Domain Owner or PSO may choose not to participate in DMARC evaluation by
+Mail Receivers.  In this case, the Domain Owner simply declines to
+advertise participation in those schemes.  For example, if the
+results of path authorization checks ought not be considered as part
+of the overall DMARC result for a given Author Domain, then the
+Domain Owner does not publish an SPF policy record that can produce
+an SPF pass result.<a href="#section-6-3" class="pilcrow">¶</a></p>
+<p id="section-6-4">A Mail Receiver implementing the DMARC mechanism SHOULD make a
+best-effort attempt to adhere to the Domain Owner's or PSO's published DMARC
+Domain Owner Assessment Policy when a message fails the DMARC test.<br>
+Since email streams can be complicated (due to forwarding, existing RFC5322.From
+domain-spoofing services, etc.), Mail Receivers MAY deviate from a published
+Domain Owner Assessment Policy during message processing and SHOULD
+make available the fact of and reason for the deviation to the Domain
+Owner via feedback reporting, specifically using the "PolicyOverride"
+feature of the aggregate report defined in <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-6-4" class="pilcrow">¶</a></p>
+<div id="dmarc-policy-record">
+<section id="section-6.1">
+        <h3 id="name-dmarc-policy-record">
+<a href="#section-6.1" class="section-number selfRef">6.1. </a><a href="#name-dmarc-policy-record" class="section-name selfRef">DMARC Policy Record</a>
+        </h3>
+<p id="section-6.1-1">Domain Owner and PSO DMARC preferences are stored as DNS TXT records in
+subdomains named "_dmarc".  For example, the Domain Owner of
+"example.com" would post DMARC preferences in a TXT record at
+"_dmarc.example.com".  Similarly, a Mail Receiver wishing to query
+for DMARC preferences regarding mail with an RFC5322.From domain of
+"example.com" would issue a TXT query to the DNS for the subdomain of
+"_dmarc.example.com".  The DNS-located DMARC preference data will
+hereafter be called the "DMARC record".<a href="#section-6.1-1" class="pilcrow">¶</a></p>
+<p id="section-6.1-2">DMARC's use of the Domain Name Service is driven by DMARC's use of
+domain names and the nature of the query it performs.  The query
+requirement matches with the DNS, for obtaining simple parametric
+information.  It uses an established method of storing the
+information, associated with the target domain name, namely an
+isolated TXT record that is restricted to the DMARC context.  Use of
+the DNS as the query service has the benefit of reusing an extremely
+well-established operations, administration, and management
+infrastructure, rather than creating a new one.<a href="#section-6.1-2" class="pilcrow">¶</a></p>
+<p id="section-6.1-3">Per <span>[<a href="#RFC1035" class="xref">RFC1035</a>]</span>, a TXT record can comprise several "character-string"
+objects.  Where this is the case, the module performing DMARC
+evaluation MUST concatenate these strings by joining together the
+objects in order and parsing the result as a single string.<a href="#section-6.1-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="dmarc-uris">
+<section id="section-6.2">
+        <h3 id="name-dmarc-uris">
+<a href="#section-6.2" class="section-number selfRef">6.2. </a><a href="#name-dmarc-uris" class="section-name selfRef">DMARC URIs</a>
+        </h3>
+<p id="section-6.2-1"><span>[<a href="#RFC3986" class="xref">RFC3986</a>]</span> defines a generic syntax for identifying a resource.  The DMARC
+mechanism uses this as the format by which a Domain Owner or PSO specifies
+the destination for the two report types that are supported.<a href="#section-6.2-1" class="pilcrow">¶</a></p>
+<p id="section-6.2-2">The place such URIs are specified (see <a href="#general-record-format" class="xref">Section 6.3</a>) allows
+a list of these to be provided.  The list of URIs is separated by commas
+(ASCII 0x2c).  A report SHOULD be sent to each listed URI provided in
+the DMARC record.<a href="#section-6.2-2" class="pilcrow">¶</a></p>
+<p id="section-6.2-3">A formal definition is provided in <a href="#formal-definition" class="xref">Section 6.4</a>.<a href="#section-6.2-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="general-record-format">
+<section id="section-6.3">
+        <h3 id="name-general-record-format">
+<a href="#section-6.3" class="section-number selfRef">6.3. </a><a href="#name-general-record-format" class="section-name selfRef">General Record Format</a>
+        </h3>
+<p id="section-6.3-1">DMARC records follow the extensible "tag-value" syntax for DNS-based
+key records defined in DKIM <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>.<a href="#section-6.3-1" class="pilcrow">¶</a></p>
+<p id="section-6.3-2"><a href="#iana-considerations" class="xref">Section 9</a> creates a registry for known DMARC tags and
+registers the initial set defined in this document.  Only tags defined
+in this document or in later extensions, and thus added to that registry,
+are to be processed; unknown tags MUST be ignored.<a href="#section-6.3-2" class="pilcrow">¶</a></p>
+<p id="section-6.3-3">The following tags are valid DMARC tags:<a href="#section-6.3-3" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-6.3-4">
+          <dt id="section-6.3-4.1">adkim:</dt>
+<dd id="section-6.3-4.2">
+            <p id="section-6.3-4.2.1">(plain-text; OPTIONAL; default is "r".)  Indicates whether
+strict or relaxed DKIM Identifier Alignment mode is required by
+the Domain Owner.  See <a href="#dkim-identifiers" class="xref">Section 3.14.1</a> for details.  Valid values
+are as follows:<a href="#section-6.3-4.2.1" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-6.3-4.2.2">
+              <dt id="section-6.3-4.2.2.1">r:</dt>
+<dd id="section-6.3-4.2.2.2">relaxed mode<a href="#section-6.3-4.2.2.2" class="pilcrow">¶</a>
+</dd>
+<dd class="break"></dd>
+<dt id="section-6.3-4.2.2.3">s:</dt>
+<dd id="section-6.3-4.2.2.4">strict mode<a href="#section-6.3-4.2.2.4" class="pilcrow">¶</a>
+</dd>
+<dd class="break"></dd>
+</dl>
+</dd>
+<dd class="break"></dd>
+<dt id="section-6.3-4.3">aspf:</dt>
+<dd id="section-6.3-4.4">
+            <p id="section-6.3-4.4.1">(plain-text; OPTIONAL; default is "r".)  Indicates whether
+strict or relaxed SPF Identifier Alignment mode is required by the
+Domain Owner.  See <a href="#spf-identifiers" class="xref">Section 3.14.2</a> for details.  Valid values are as
+follows:<a href="#section-6.3-4.4.1" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-6.3-4.4.2">
+              <dt id="section-6.3-4.4.2.1">r:</dt>
+<dd id="section-6.3-4.4.2.2">relaxed mode<a href="#section-6.3-4.4.2.2" class="pilcrow">¶</a>
+</dd>
+<dd class="break"></dd>
+<dt id="section-6.3-4.4.2.3">s:</dt>
+<dd id="section-6.3-4.4.2.4">strict mode<a href="#section-6.3-4.4.2.4" class="pilcrow">¶</a>
+</dd>
+<dd class="break"></dd>
+</dl>
+</dd>
+<dd class="break"></dd>
+<dt id="section-6.3-4.5">fo:</dt>
+<dd id="section-6.3-4.6">
+            <p id="section-6.3-4.6.1">Failure reporting options (plain-text; OPTIONAL; default is "0")
+Provides requested options for generation of failure reports.
+Report generators MAY choose to adhere to the requested options.
+This tag's content MUST be ignored if a "ruf" tag (below) is not
+also specified.  Failure reporting options are shown below. The value
+of this tag is either "0", "1", or a colon-separated list of the
+options represented by alphabetic characters.<a href="#section-6.3-4.6.1" class="pilcrow">¶</a></p>
+</dd>
+<dd class="break"></dd>
+</dl>
+<p id="section-6.3-5">The valid values and their meanings are:<a href="#section-6.3-5" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-6.3-6">
+<pre>0:
+:  Generate a DMARC failure report if all underlying
+   authentication mechanisms fail to produce an aligned "pass"
+   result.
+
+1:
+:  Generate a DMARC failure report if any underlying
+   authentication mechanism produced something other than an
+   aligned "pass" result.
+
+d:
+:  Generate a DKIM failure report if the message had a signature
+   that failed evaluation, regardless of its alignment.  DKIM-
+   specific reporting is described in [@!RFC6651].
+
+s:
+:  Generate an SPF failure report if the message failed SPF
+   evaluation, regardless of its alignment.  SPF-specific
+   reporting is described in [@!RFC6652].
+</pre><a href="#section-6.3-6" class="pilcrow">¶</a>
+</div>
+<dl class="dlParallel" id="section-6.3-7">
+          <dt id="section-6.3-7.1">np:</dt>
+<dd id="section-6.3-7.2">Domain Owner Assessment Policy for non-existent subdomains
+(plain-text; OPTIONAL).  Indicates the severity of concern the
+Domain Owner or PSO has for mail using non-existent subdomains of the
+domain queried. It applies only to non-existent subdomains of
+the domain queried and not to either existing subdomains or
+the domain itself.  Its syntax is identical to that of the "p"
+tag defined below.  If the "np" tag is absent, the policy
+specified by the "sp" tag (if the "sp" tag is present) or the
+policy specified by the "p" tag, if the "sp" tag is not present,
+MUST be applied for non-existent subdomains.  Note that "np" will
+be ignored for DMARC records published on subdomains of Organizational
+Domains and PSDs due to the effect of the DMARC policy discovery
+mechanism described in <a href="#policy-discovery" class="xref">Section 6.7.3</a>.<a href="#section-6.3-7.2" class="pilcrow">¶</a>
+</dd>
+<dd class="break"></dd>
+<dt id="section-6.3-7.3">p:</dt>
+<dd id="section-6.3-7.4">
+            <p id="section-6.3-7.4.1">Domain Owner Assessment Policy (plain-text; RECOMMENDED for policy
+records). Indicates the severity of concern the Domain Owner or PSO
+has for mail using its domain but not passing DMARC verification.
+Policy applies to the domain queried and to subdomains, unless
+subdomain policy is explicitly described using the "sp" or "np" tags.
+This tag is mandatory for policy records only, but not for third-party
+reporting records (see <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> and <span>[<a href="#DMARC-Failure-Reporting" class="xref">DMARC-Failure-Reporting</a>]</span>)
+Possible values are as follows:<a href="#section-6.3-7.4.1" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-6.3-7.4.2">
+              <dt id="section-6.3-7.4.2.1">none:</dt>
+<dd id="section-6.3-7.4.2.2">The Domain Owner offers no expression of concern.<a href="#section-6.3-7.4.2.2" class="pilcrow">¶</a>
+</dd>
+<dd class="break"></dd>
+<dt id="section-6.3-7.4.2.3">quarantine:</dt>
+<dd id="section-6.3-7.4.2.4">The Domain Owner considers such mail to be suspicious. It
+is possible the mail is valid, although the failure creates
+a significant concern.<a href="#section-6.3-7.4.2.4" class="pilcrow">¶</a>
+</dd>
+<dd class="break"></dd>
+<dt id="section-6.3-7.4.2.5">reject:</dt>
+<dd id="section-6.3-7.4.2.6">The Domain Owner considers all such failures to be a clear
+indication that the use of the domain name is not valid. See
+<a href="#rejecting-messages" class="xref">Section 8.3</a> for some discussion of SMTP rejection
+methods and their implications.<a href="#section-6.3-7.4.2.6" class="pilcrow">¶</a>
+</dd>
+<dd class="break"></dd>
+</dl>
+</dd>
+<dd class="break"></dd>
+<dt id="section-6.3-7.5">rua:</dt>
+<dd id="section-6.3-7.6">
+            <p id="section-6.3-7.6.1">Addresses to which aggregate feedback is to be sent (comma-
+separated plain-text list of DMARC URIs; OPTIONAL).  Section 3 of <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span>
+discusses considerations that apply when the domain name of a URI differs
+from that of the domain advertising the policy.  See <a href="#external-report-addresses" class="xref">Section 10.5</a>
+for additional considerations.  Any valid URI can be specified.<br>
+A Mail Receiver MUST implement support for a "mailto:" URI, i.e., the
+ability to send a DMARC report via electronic mail.  If not provided,
+Mail Receivers MUST NOT generate aggregate feedback reports.  URIs
+not supported by Mail Receivers MUST be ignored.  The aggregate
+feedback report format is described in <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-6.3-7.6.1" class="pilcrow">¶</a></p>
+</dd>
+<dd class="break"></dd>
+<dt id="section-6.3-7.7">ruf:</dt>
+<dd id="section-6.3-7.8">
+            <p id="section-6.3-7.8.1">Addresses to which message-specific failure information is to
+be reported (comma-separated plain-text list of DMARC URIs;
+OPTIONAL).  If present, the Domain Owner or PSO is requesting Mail
+Receivers to send detailed failure reports about messages that
+fail the DMARC evaluation in specific ways (see the "fo" tag
+above).  The format of the message to be generated MUST follow the
+format specified for the "rf" tag. Section 3 of <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> discusses
+considerations that apply when the domain name of a URI differs
+from that of the domain advertising the policy.  A Mail Receiver
+MUST implement support for a "mailto:" URI, i.e., the ability to
+send a DMARC report via electronic mail.  If not provided, Mail
+Receivers MUST NOT generate failure reports.  See <a href="#external-report-addresses" class="xref">Section 10.5</a> for
+additional considerations.<a href="#section-6.3-7.8.1" class="pilcrow">¶</a></p>
+</dd>
+<dd class="break"></dd>
+<dt id="section-6.3-7.9">sp:</dt>
+<dd id="section-6.3-7.10">
+            <p id="section-6.3-7.10.1">Domain Owner Assessment Policy for all subdomains (plain-text;
+OPTIONAL). Indicates the severity of concern the Domain Owner or PSO has
+for mail using an existing subdomain of the domain queried but not
+passing DMARC verification.  It applies only to subdomains of
+the domain queried and not to the domain itself.  Its syntax is
+identical to that of the "p" tag defined above.  If both the "sp"
+tag is absent and the "np" tag is either absent or not applicable,
+the policy specified by the "p" tag MUST be applied for subdomains.
+Note that "sp" will be ignored for DMARC records published on
+subdomains of Organizational Domains due to the effect of the
+DMARC policy discovery mechanism described in <a href="#policy-discovery" class="xref">Section 6.7.3</a>.<a href="#section-6.3-7.10.1" class="pilcrow">¶</a></p>
+</dd>
+<dd class="break"></dd>
+<dt id="section-6.3-7.11">t:</dt>
+<dd id="section-6.3-7.12">
+            <p id="section-6.3-7.12.1">DMARC policy test mode (plain-text; OPTIONAL; default is 'n'). For
+the RFC5322.From domain to which the DMARC record applies, the "t"
+tag serves as a signal to the actor performing DMARC verification checks
+as to whether or not the domain owner wishes the assessment policy
+declared in the "p=", "sp=", and/or "np=" tags to actually be applied. This
+parameter does not affect the generation of DMARC reports.  Possible values
+are as follows:<a href="#section-6.3-7.12.1" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-6.3-7.12.2">
+              <dt id="section-6.3-7.12.2.1">y:</dt>
+<dd id="section-6.3-7.12.2.2">A request that the actor performing the DMARC verification check not
+apply the policy, but instead apply any special handling rules it might have
+in place, such as rewriting the RFC5322.From header.  The domain owner is
+currently testing its specified DMARC assessment policy.<a href="#section-6.3-7.12.2.2" class="pilcrow">¶</a>
+</dd>
+<dd class="break"></dd>
+<dt id="section-6.3-7.12.2.3">n:</dt>
+<dd id="section-6.3-7.12.2.4">The default, a request to apply the policy as specified to any
+message that produces a DMARC "fail" result.<a href="#section-6.3-7.12.2.4" class="pilcrow">¶</a>
+</dd>
+<dd class="break"></dd>
+</dl>
+</dd>
+<dd class="break"></dd>
+<dt id="section-6.3-7.13">v:</dt>
+<dd id="section-6.3-7.14">
+            <p id="section-6.3-7.14.1">Version (plain-text; REQUIRED).  Identifies the record retrieved
+as a DMARC record.  It MUST have the value of "DMARC1".  The value
+of this tag MUST match precisely; if it does not or it is absent,
+the entire retrieved record MUST be ignored.  It MUST be the first
+tag in the list.<a href="#section-6.3-7.14.1" class="pilcrow">¶</a></p>
+</dd>
+<dd class="break"></dd>
+</dl>
+<p id="section-6.3-8">A DMARC policy record MUST comply with the formal specification found
+in <a href="#formal-definition" class="xref">Section 6.4</a> in that the "v" tag MUST be present and MUST
+appear first.  Unknown tags MUST be ignored.  Syntax errors
+in the remainder of the record SHOULD be discarded in favor of
+default values (if any) or ignored outright.<a href="#section-6.3-8" class="pilcrow">¶</a></p>
+<p id="section-6.3-9">Note that given the rules of the previous paragraph, addition of a
+new tag into the registered list of tags does not itself require a
+new version of DMARC to be generated (with a corresponding change to
+the "v" tag's value), but a change to any existing tags does require
+a new version of DMARC.<a href="#section-6.3-9" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="formal-definition">
+<section id="section-6.4">
+        <h3 id="name-formal-definition">
+<a href="#section-6.4" class="section-number selfRef">6.4. </a><a href="#name-formal-definition" class="section-name selfRef">Formal Definition</a>
+        </h3>
+<p id="section-6.4-1">The formal definition of the DMARC format, using <span>[<a href="#RFC5234" class="xref">RFC5234</a>]</span>, is as
+follows:<a href="#section-6.4-1" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-6.4-2">
+<pre>  dmarc-uri       = URI
+                    ; "URI" is imported from [RFC3986]; commas (ASCII
+                    ; 0x2C) and exclamation points (ASCII 0x21)
+                    ; MUST be encoded
+
+  dmarc-record    = dmarc-version dmarc-sep *(dmarc-tag dmarc-sep)
+
+  dmarc-tag       = dmarc-request /
+                    dmarc-test /
+                    dmarc-srequest /
+                    dmarc-nprequest /
+                    dmarc-adkim /
+                    dmarc-aspf /
+                    dmarc-auri /
+                    dmarc-furi /
+                    dmarc-fo /
+                    dmarc-rfmt
+                    ; components other than dmarc-version and
+                    ; dmarc-request may appear in any order
+
+  dmarc-version   = "v" *WSP "=" *WSP %x44 %x4d %x41 %x52 %x43 %x31
+
+  dmarc-sep       = *WSP %x3b *WSP
+
+  dmarc-request   = "p" *WSP "=" *WSP
+                    ( "none" / "quarantine" / "reject" )
+
+  dmarc-test      = "t" *WSP "=" ( "y" / "n" )
+
+  dmarc-srequest  = "sp" *WSP "=" *WSP
+                    ( "none" / "quarantine" / "reject" )
+
+  dmarc-nprequest  = "np" *WSP "=" *WSP
+                    ( "none" / "quarantine" / "reject" )
+
+  dmarc-adkim     = "adkim" *WSP "=" *WSP ( "r" / "s" )
+
+  dmarc-aspf      = "aspf" *WSP "=" *WSP ( "r" / "s" )
+
+  dmarc-auri      = "rua" *WSP "=" *WSP
+                    dmarc-uri *(*WSP "," *WSP dmarc-uri)
+
+  dmarc-furi      = "ruf" *WSP "=" *WSP
+                    dmarc-uri *(*WSP "," *WSP dmarc-uri)
+
+  dmarc-fo        = "fo" *WSP "=" *WSP
+                    ( "0" / "1" / ( "d" / "s" / "d:s" / "s:d" ) )
+
+  dmarc-rfmt      = "rf"  *WSP "=" *WSP Keyword *(*WSP ":" Keyword)
+                    ; registered reporting formats only
+
+</pre><a href="#section-6.4-2" class="pilcrow">¶</a>
+</div>
+<p id="section-6.4-3">"Keyword" is imported from Section 4.1.2 of <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span>.<a href="#section-6.4-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="domain-owner-actions">
+<section id="section-6.5">
+        <h3 id="name-domain-owner-actions">
+<a href="#section-6.5" class="section-number selfRef">6.5. </a><a href="#name-domain-owner-actions" class="section-name selfRef">Domain Owner Actions</a>
+        </h3>
+<p id="section-6.5-1">This section describes Domain Owner actions to fully implement the
+DMARC mechanism.<a href="#section-6.5-1" class="pilcrow">¶</a></p>
+<div id="publish-an-spf-policy-for-an-aligned-domain">
+<section id="section-6.5.1">
+          <h4 id="name-publish-an-spf-policy-for-a">
+<a href="#section-6.5.1" class="section-number selfRef">6.5.1. </a><a href="#name-publish-an-spf-policy-for-a" class="section-name selfRef">Publish an SPF Policy for an Aligned Domain</a>
+          </h4>
+<p id="section-6.5.1-1">Because DMARC relies on SPF <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span> and DKIM <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>, in
+order to take full advantage of DMARC, a Domain Owner SHOULD first
+ensure that SPF and DKIM authentication are properly configured.
+The easiest first step here is to choose a domain to use as the
+RFC5321.From domain (i.e., the Return-Path domain) for its mail,
+one that aligns with the Author Domain, and then publish an SPF
+policy in DNS for that domain.<a href="#section-6.5.1-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="configure-sending-system-for-dkim-signing-using-an-aligned-domain">
+<section id="section-6.5.2">
+          <h4 id="name-configure-sending-system-fo">
+<a href="#section-6.5.2" class="section-number selfRef">6.5.2. </a><a href="#name-configure-sending-system-fo" class="section-name selfRef">Configure Sending System for DKIM Signing Using an Aligned Domain</a>
+          </h4>
+<p id="section-6.5.2-1">While it is possible to secure a DMARC pass verdict based on only
+SPF or DKIM, it is commonly accepted best practice to ensure that
+both authentication mechanisms are in place in order to guard
+against failure of just one of them. The Domain Owner SHOULD choose
+a DKIM-Signing domain (i.e., the d= domain in the DKIM-Signature
+header) that aligns with the Author Domain and configure its system
+to sign using that domain.<a href="#section-6.5.2-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="setup-a-mailbox-to-receive-aggregate-reports">
+<section id="section-6.5.3">
+          <h4 id="name-setup-a-mailbox-to-receive-">
+<a href="#section-6.5.3" class="section-number selfRef">6.5.3. </a><a href="#name-setup-a-mailbox-to-receive-" class="section-name selfRef">Setup a Mailbox to Receive Aggregate Reports</a>
+          </h4>
+<p id="section-6.5.3-1">Proper consumption and analysis of DMARC aggregate reports is the
+key to any successful DMARC deployment for a Domain Owner. DMARC
+aggregate reports, which are XML documents and are defined in
+<span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span>, contain valuable data for the Domain
+Owner, showing sources of mail using the Author Domain. Depending
+on how mature the Domain Owner's DMARC rollout is, some of these
+sources could be legitimate ones that were overlooked during the
+intial deployment of SPF and/or DKIM.<a href="#section-6.5.3-1" class="pilcrow">¶</a></p>
+<p id="section-6.5.3-2">Because the aggregate reports are XML documents, it is strongly
+advised that they be machine-parsed, so setting up a mailbox
+involves more than just the physical creation of the mailbox. Many
+third-party services exist that will process DMARC aggregate reports,
+or the Domain Owner can create its own set of tools. No matter which
+method is chosen, the ability to parse these reports and consume
+the data contained in them will go a long way to ensuring a
+successful deployment.<a href="#section-6.5.3-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="publish-a-dmarc-policy-for-the-author-domain">
+<section id="section-6.5.4">
+          <h4 id="name-publish-a-dmarc-policy-for-">
+<a href="#section-6.5.4" class="section-number selfRef">6.5.4. </a><a href="#name-publish-a-dmarc-policy-for-" class="section-name selfRef">Publish a DMARC Policy for the Author Domain</a>
+          </h4>
+<p id="section-6.5.4-1">Once SPF, DKIM, and the aggregate reports mailbox are all in place,
+it's time to publish a DMARC record. For best results, Domain Owners
+SHOULD start with "p=none", with the rua tag containg the mailbox
+created in the previous step.<a href="#section-6.5.4-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="collect-and-analyze-reports-and-adjust-authentication">
+<section id="section-6.5.5">
+          <h4 id="name-collect-and-analyze-reports">
+<a href="#section-6.5.5" class="section-number selfRef">6.5.5. </a><a href="#name-collect-and-analyze-reports" class="section-name selfRef">Collect and Analyze Reports and Adjust Authentication</a>
+          </h4>
+<p id="section-6.5.5-1">The reason for starting at "p=none" is to ensure that nothing's been
+missed in the initial SPF and DKIM deployments. In all but the most
+trivial setups, it is possible for a Domain Owner to overlook a
+server here or be unaware of a third party sending agreeement there.
+Starting at "p=none", therefore, takes advantage of DMARC's aggregate
+reporting function, with the Domain Owner using the reports to audit
+its own mail streams. Should any overlooked systems be found in the
+reports, the Domain Owner can adjust the SPF record and/or configure
+DKIM signing for those systems.<a href="#section-6.5.5-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="decide-if-and-when-to-update-dmarc-policy">
+<section id="section-6.5.6">
+          <h4 id="name-decide-if-and-when-to-updat">
+<a href="#section-6.5.6" class="section-number selfRef">6.5.6. </a><a href="#name-decide-if-and-when-to-updat" class="section-name selfRef">Decide If and When to Update DMARC Policy</a>
+          </h4>
+<p id="section-6.5.6-1">Once the Domain Owner is satisfied that it is properly authenticating
+all of its mail, then it is time to decide if it is appropriate to
+change the p= value in its DMARC record to p=quarantine or p=reject.
+Depending on its cadence for sending mail, it may take many months
+of consuming DMARC aggregate reports before a Domain Owner reaches
+the point where it is sure that it is properly authenticating all
+of its mail, and the decision on which p= value to use will depend
+on its needs.<a href="#section-6.5.6-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="pso-actions">
+<section id="section-6.6">
+        <h3 id="name-pso-actions">
+<a href="#section-6.6" class="section-number selfRef">6.6. </a><a href="#name-pso-actions" class="section-name selfRef">PSO Actions</a>
+        </h3>
+<p id="section-6.6-1">In addition to the DMARC Domain Owner actions, PSOs that require use
+of DMARC and participate in PSD DMARC ought to make that information
+availablle to Mail Receivers. <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span> is an experimental
+method for doing so, and the experiment is described in Appendix B
+of that document.<a href="#section-6.6-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="mail-receiver-actions">
+<section id="section-6.7">
+        <h3 id="name-mail-receiver-actions">
+<a href="#section-6.7" class="section-number selfRef">6.7. </a><a href="#name-mail-receiver-actions" class="section-name selfRef">Mail Receiver Actions</a>
+        </h3>
+<p id="section-6.7-1">This section describes receiver actions in the DMARC environment.<a href="#section-6.7-1" class="pilcrow">¶</a></p>
+<div id="extract-author-domain">
+<section id="section-6.7.1">
+          <h4 id="name-extract-author-domain">
+<a href="#section-6.7.1" class="section-number selfRef">6.7.1. </a><a href="#name-extract-author-domain" class="section-name selfRef">Extract Author Domain</a>
+          </h4>
+<p id="section-6.7.1-1">The domain in the RFC5322.From header field is extracted as the domain
+to be evaluated by DMARC.  If the domain is encoded with UTF-8, the
+domain name must be converted to an A-label, as described in Section
+2.3 of <span>[<a href="#RFC5890" class="xref">RFC5890</a>]</span>, for further processing.<a href="#section-6.7.1-1" class="pilcrow">¶</a></p>
+<p id="section-6.7.1-2">In order to be processed by DMARC, a message typically needs to
+contain exactly one RFC5322.From domain (a single From: field with a
+single domain in it). Not all messages meet this requirement, and
+the handling of those that are forbidden under <span>[<a href="#RFC5322" class="xref">RFC5322</a>]</span> or that
+contain no meaningful domains is outside the scope of this document.<a href="#section-6.7.1-2" class="pilcrow">¶</a></p>
+<p id="section-6.7.1-3">The case of a syntactically valid multi-valued RFC5322.From header
+field presents a particular challenge. When a single RFC5322.From
+header field contains multiple addresses, it is possible that there
+may be multiple domains used in those addresses. The process in this
+case is to only proceed with DMARC checking if the domain is
+identical for all of the addresses in a multi-valued RFC5322.From
+header field. Multi-valued RFC5322.From header fields with multiple
+domains MUST be exempt from DMARC checking.<a href="#section-6.7.1-3" class="pilcrow">¶</a></p>
+<p id="section-6.7.1-4">Note that domain names that appear on a public suffix list are not
+exempt from DMARC policy application and reporting.<a href="#section-6.7.1-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="determine-handling-policy">
+<section id="section-6.7.2">
+          <h4 id="name-determine-handling-policy">
+<a href="#section-6.7.2" class="section-number selfRef">6.7.2. </a><a href="#name-determine-handling-policy" class="section-name selfRef">Determine Handling Policy</a>
+          </h4>
+<p id="section-6.7.2-1">To arrive at a policy for an individual message, Mail Receivers MUST
+perform the following actions or their semantic equivalents.
+Steps 2-4 MAY be done in parallel, whereas steps 5 and 6 require
+input from previous steps.<a href="#section-6.7.2-1" class="pilcrow">¶</a></p>
+<p id="section-6.7.2-2">The steps are as follows:<a href="#section-6.7.2-2" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-6.7.2-3">
+            <li id="section-6.7.2-3.1">
+              <p id="section-6.7.2-3.1.1">Extract the RFC5322.From domain from the message (as above).<a href="#section-6.7.2-3.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-6.7.2-3.2">
+              <p id="section-6.7.2-3.2.1">Query the DNS for a DMARC policy record.  Continue if one is
+found, or terminate DMARC evaluation otherwise.  See
+<a href="#policy-discovery" class="xref">Section 6.7.3</a> for details.<a href="#section-6.7.2-3.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-6.7.2-3.3">
+              <p id="section-6.7.2-3.3.1">Perform DKIM signature verification checks.  A single email could
+contain multiple DKIM signatures.  The results of this step are
+passed to the remainder of the algorithm, MUST include "pass" or
+"fail", and if "fail", SHOULD include information about the reasons
+for failure. The results MUST further include the value of the "d="
+and "s=" tags from each checked DKIM signature.<a href="#section-6.7.2-3.3.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-6.7.2-3.4">
+              <p id="section-6.7.2-3.4.1">Perform SPF verification checks.  The results of this step are
+passed to the remainder of the algorithm, MUST include "pass" or
+"fail", and if "fail", SHOULD include information about the reasons
+for failure. The results MUST further include the domain name used
+to complete the SPF check.<a href="#section-6.7.2-3.4.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-6.7.2-3.5">
+              <p id="section-6.7.2-3.5.1">Conduct Identifier Alignment checks.  With authentication checks
+and policy discovery performed, the Mail Receiver checks to see
+if Authenticated Identifiers fall into alignment as described in
+<a href="#terminology" class="xref">Section 3</a>.  If one or more of the Authenticated Identifiers align
+with the RFC5322.From domain, the message is considered to pass
+the DMARC mechanism check.  All other conditions (authentication
+failures, identifier mismatches) are considered to be DMARC
+mechanism check failures.<a href="#section-6.7.2-3.5.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-6.7.2-3.6">
+              <p id="section-6.7.2-3.6.1">Apply policy.  Emails that fail the DMARC mechanism check are
+handled in accordance with the discovered DMARC policy of the
+Domain Owner and any local policy rules enforced by the Mail Receiver.
+See <a href="#general-record-format" class="xref">Section 6.3</a> for details.<a href="#section-6.7.2-3.6.1" class="pilcrow">¶</a></p>
+</li>
+</ol>
+<p id="section-6.7.2-4">Heuristics applied in the absence of use by a Domain Owner of either
+SPF or DKIM (e.g., <span>[<a href="#Best-Guess-SPF" class="xref">Best-Guess-SPF</a>]</span>) SHOULD NOT be used, as it may be
+the case that the Domain Owner wishes a Message Receiver not to
+consider the results of that underlying authentication protocol at
+all.<a href="#section-6.7.2-4" class="pilcrow">¶</a></p>
+<p id="section-6.7.2-5">DMARC evaluation can only yield a "pass" result after one of the
+underlying authentication mechanisms passes for an aligned
+identifier.  If neither passes and one or both of them fail due to a
+temporary error, the Receiver evaluating the message is unable to
+conclude that the DMARC mechanism had a permanent failure; they
+therefore cannot apply the advertised DMARC policy.  When otherwise
+appropriate, Receivers MAY send feedback reports regarding temporary
+errors.<a href="#section-6.7.2-5" class="pilcrow">¶</a></p>
+<p id="section-6.7.2-6">Handling of messages for which SPF and/or DKIM evaluation encounter a
+permanent DNS error is left to the discretion of the Mail Receiver.<a href="#section-6.7.2-6" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="policy-discovery">
+<section id="section-6.7.3">
+          <h4 id="name-policy-discovery">
+<a href="#section-6.7.3" class="section-number selfRef">6.7.3. </a><a href="#name-policy-discovery" class="section-name selfRef">Policy Discovery</a>
+          </h4>
+<p id="section-6.7.3-1">As stated above, the DMARC mechanism uses DNS TXT records to
+advertise policy.  Policy discovery is accomplished via a method
+similar to the method used for SPF records.  This method, and the
+important differences between DMARC and SPF mechanisms, are discussed
+below.<a href="#section-6.7.3-1" class="pilcrow">¶</a></p>
+<p id="section-6.7.3-2">To balance the conflicting requirements of supporting wildcarding,
+allowing subdomain policy overrides, and limiting DNS query load, the
+following DNS lookup scheme is employed:<a href="#section-6.7.3-2" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-6.7.3-3">
+            <li id="section-6.7.3-3.1">
+              <p id="section-6.7.3-3.1.1">Mail Receivers MUST query the DNS for a DMARC TXT record at the
+DNS domain matching the one found in the RFC5322.From domain in
+the message.  A possibly empty set of records is returned.<a href="#section-6.7.3-3.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-6.7.3-3.2">
+              <p id="section-6.7.3-3.2.1">Records that do not start with a "v=" tag that identifies the
+current version of DMARC are discarded.<a href="#section-6.7.3-3.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-6.7.3-3.3">
+              <p id="section-6.7.3-3.3.1">If the set is now empty, the Mail Receiver MUST query the DNS for
+a DMARC TXT record at the DNS domain matching the Organizational
+Domain in place of the RFC5322.From domain in the message (if
+different).  This record can contain policy to be asserted for
+subdomains of the Organizational Domain.  A possibly empty set of
+records is returned.<a href="#section-6.7.3-3.3.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-6.7.3-3.4">
+              <p id="section-6.7.3-3.4.1">Records that do not start with a "v=" tag that identifies the
+current version of DMARC are discarded.<a href="#section-6.7.3-3.4.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-6.7.3-3.5">
+              <p id="section-6.7.3-3.5.1">If the set is now empty and the longest PSD <a href="#longest-psd" class="xref">Section 3.6</a> of the
+Organizational Domain is one that the receiver has determined is
+acceptable for PSD DMARC (based on the data in one of the DMARC
+PSD Registry Examples decribed in Appendix B of <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>)
+the Mail Receiver MUST query the DNS for a DMARC TXT record at
+the DNS domain matching the longest PSD in place of the RFC5322.From
+domain in the message (if different).  A possibly empty set of records
+is returned.<a href="#section-6.7.3-3.5.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-6.7.3-3.6">
+              <p id="section-6.7.3-3.6.1">Records that do not start with a "v=" tag that identifies the
+current version of DMARC are discarded.<a href="#section-6.7.3-3.6.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-6.7.3-3.7">
+              <p id="section-6.7.3-3.7.1">If the remaining set contains multiple records or no records,
+policy discovery terminates and DMARC processing is not applied
+to this message.<a href="#section-6.7.3-3.7.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-6.7.3-3.8">
+              <p id="section-6.7.3-3.8.1">If a retrieved policy record does not contain a valid "p" tag, or
+contains an "sp" tag that is not valid, then:<a href="#section-6.7.3-3.8.1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-6.7.3-3.8.2">
+                <li id="section-6.7.3-3.8.2.1">
+                  <p id="section-6.7.3-3.8.2.1.1">if a "rua" tag is present and contains at least one
+syntactically valid reporting URI, the Mail Receiver SHOULD
+act as if a record containing a valid "v" tag and "p=none"
+was retrieved, and continue processing;<a href="#section-6.7.3-3.8.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-6.7.3-3.8.2.2">
+                  <p id="section-6.7.3-3.8.2.2.1">otherwise, the Mail Receiver applies no DMARC processing to
+this message.<a href="#section-6.7.3-3.8.2.2.1" class="pilcrow">¶</a></p>
+</li>
+</ol>
+</li>
+</ol>
+<p id="section-6.7.3-4">If the set produced by the mechanism above contains no DMARC policy
+record (i.e., any indication that there is no such record as opposed
+to a transient DNS error), Mail Receivers SHOULD NOT apply the DMARC
+mechanism to the message.<a href="#section-6.7.3-4" class="pilcrow">¶</a></p>
+<p id="section-6.7.3-5">Handling of DNS errors when querying for the DMARC policy record is
+left to the discretion of the Mail Receiver.  For example, to ensure
+minimal disruption of mail flow, transient errors could result in
+delivery of the message ("fail open"), or they could result in the
+message being temporarily rejected (i.e., an SMTP 4yx reply), which
+invites the sending MTA to try again after the condition has possibly
+cleared, allowing a definite DMARC conclusion to be reached ("fail
+closed").<a href="#section-6.7.3-5" class="pilcrow">¶</a></p>
+<div id="longest-psd-example">
+<section id="section-6.7.3.1">
+            <h5 id="name-longest-psd-example">
+<a href="#section-6.7.3.1" class="section-number selfRef">6.7.3.1. </a><a href="#name-longest-psd-example" class="section-name selfRef">Longest PSD Example</a>
+            </h5>
+<p id="section-6.7.3.1-1">As an example of step 5 above, for a message with the Organizational
+Domain of "example.compute.cloudcompany.com.example", the query for
+PSD DMARC would use "compute.cloudcompany.com.example" as the longest
+PSD. The receiver would check to see if that PSD is listed in the DMARC
+PSD Registry, and if so, perform the policy lookup at
+"_dmarc.compute.cloudcompany.com.example".<a href="#section-6.7.3.1-1" class="pilcrow">¶</a></p>
+<p id="section-6.7.3.1-2">Note: Because the PSD policy query comes after the Organizational
+Domain policy query, PSD policy is not used for Organizational
+domains that have published a DMARC policy.  Specifically, this is
+not a mechanism to provide feedback addresses (RUA/RUF) when an
+Organizational Domain has declined to do so.<a href="#section-6.7.3.1-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="store-results-of-dmarc-processing">
+<section id="section-6.7.4">
+          <h4 id="name-store-results-of-dmarc-proc">
+<a href="#section-6.7.4" class="section-number selfRef">6.7.4. </a><a href="#name-store-results-of-dmarc-proc" class="section-name selfRef">Store Results of DMARC Processing</a>
+          </h4>
+<p id="section-6.7.4-1">The results of Mail Receiver-based DMARC processing should be stored
+for eventual presentation back to the Domain Owner in the form of
+aggregate feedback reports.  <a href="#general-record-format" class="xref">Section 6.3</a> and
+<span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> discuss aggregate feedback.<a href="#section-6.7.4-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="send-aggregate-reports">
+<section id="section-6.7.5">
+          <h4 id="name-send-aggregate-reports">
+<a href="#section-6.7.5" class="section-number selfRef">6.7.5. </a><a href="#name-send-aggregate-reports" class="section-name selfRef">Send Aggregate Reports</a>
+          </h4>
+<p id="section-6.7.5-1">For a Domain Owner, DMARC aggregate reports provide data about all
+mailstreams making use of its domain in email, to include not only
+illegitimate uses but also, and perhaps more importantly, all
+legitimate uses. Domain Owners can use aggregate reports to ensure
+that all legitimate uses of their domain for sending email are
+properly authenticated, and once they are, increase the severity of
+concern expressed in the p= tag in their DMARC policy records from
+none to quarantine to reject, if appropriate. In turn, DMARC policy
+records with p= tag values of 'quarantine' or 'reject' are higher
+value signals to Mail Receivers, ones that can assist Mail Receivers
+with handling decisions for a message in ways that p= tag values of
+'none' cannot.<a href="#section-6.7.5-1" class="pilcrow">¶</a></p>
+<p id="section-6.7.5-2">In order to ensure maximum usefulness for DMARC across the email
+ecosystem, then, Mail Receivers MUST generate and send aggregate
+reports with a frequency of at least once every 24 hours.<a href="#section-6.7.5-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="policy-enforcement-considerations">
+<section id="section-6.8">
+        <h3 id="name-policy-enforcement-consider">
+<a href="#section-6.8" class="section-number selfRef">6.8. </a><a href="#name-policy-enforcement-consider" class="section-name selfRef">Policy Enforcement Considerations</a>
+        </h3>
+<p id="section-6.8-1">Mail Receivers MAY choose to reject or quarantine email even if email
+passes the DMARC mechanism check. The DMARC mechanism does not
+inform Mail Receivers whether an email stream is "good"; a DMARC result
+of "pass" only means that the domain in the RFC5322.From header has been
+verified by the DMARC mechanism. Mail Receivers are encouraged to maintain
+anti-abuse technologies to combat the possibility of DMARC-enabled criminal
+campaigns.<a href="#section-6.8-1" class="pilcrow">¶</a></p>
+<p id="section-6.8-2">Mail Receivers MAY choose to accept email that fails the DMARC
+mechanism check even if the published Domain Owner Assessment Policy
+is "reject".  Mail Receivers need to make a best effort not to increase
+the likelihood of accepting abusive mail if they choose not to honor
+the published Domain Owner Assessment Policy.  At a minimum, addition
+of the Authentication-Results header field (see <span>[<a href="#RFC8601" class="xref">RFC8601</a>]</span>) is
+RECOMMENDED when delivery of failing mail is done.  When this is
+done, the DNS domain name thus recorded MUST be encoded as an
+A-label.<a href="#section-6.8-2" class="pilcrow">¶</a></p>
+<p id="section-6.8-3">Mail Receivers are only obligated to report reject or quarantine
+policy actions in aggregate feedback reports that are due to published
+DMARC Domain Owner Assessment Policy. They are not required to report
+reject or quarantine actions that are the result of local policy. If
+local policy information is exposed, abusers can gain insight into the
+effectiveness and delivery rates of spam campaigns.<a href="#section-6.8-3" class="pilcrow">¶</a></p>
+<p id="section-6.8-4">Final handling of a message is always a matter of local policy.
+An operator that wishes to favor DMARC policy over SPF policy, for
+example, will disregard the SPF policy, since enacting an
+SPF-determined rejection prevents evaluation of DKIM; DKIM might
+otherwise pass, satisfying the DMARC evaluation.  There is a
+trade-off to doing so, namely acceptance and processing of the entire
+message body in exchange for the enhanced protection DMARC provides.<a href="#section-6.8-4" class="pilcrow">¶</a></p>
+<p id="section-6.8-5">DMARC-compliant Mail Receivers typically disregard any mail-handling
+directive discovered as part of an authentication mechanism (e.g.,
+Author Domain Signing Practices (ADSP), SPF) where a DMARC record is
+also discovered that specifies a policy other than "none".  Deviating
+from this practice introduces inconsistency among DMARC operators in
+terms of handling of the message.  However, such deviation is not
+proscribed.<a href="#section-6.8-5" class="pilcrow">¶</a></p>
+<p id="section-6.8-6">To enable Domain Owners to receive DMARC feedback without impacting
+existing mail processing, discovered policies of "p=none" SHOULD NOT
+modify existing mail handling processes.<a href="#section-6.8-6" class="pilcrow">¶</a></p>
+<p id="section-6.8-7">Mail Receivers MUST also implement reporting instructions of DMARC,
+even in the absence of a request for DKIM reporting <span>[<a href="#RFC6651" class="xref">RFC6651</a>]</span> or
+SPF reporting <span>[<a href="#RFC6652" class="xref">RFC6652</a>]</span>.  Furthermore, the presence of such requests
+SHOULD NOT affect DMARC reporting.<a href="#section-6.8-7" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="dmarc-feedback">
+<section id="section-7">
+      <h2 id="name-dmarc-feedback">
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-dmarc-feedback" class="section-name selfRef">DMARC Feedback</a>
+      </h2>
+<p id="section-7-1">Providing Domain Owners with visibility into how Mail Receivers
+implement and enforce the DMARC mechanism in the form of feedback is
+critical to establishing and maintaining accurate authentication
+deployments.  When Domain Owners can see what effect their policies
+and practices are having, they are better willing and able to use
+quarantine and reject policies.<a href="#section-7-1" class="pilcrow">¶</a></p>
+<p id="section-7-2">The details of this feedback are described in <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-7-2" class="pilcrow">¶</a></p>
+<p id="section-7-3">Operational note for PSD DMARC: For PSOs, feedback for non-existent
+domains is desirable and useful, just as it is for org-level DMARC
+operators.  See Section 4 of <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span> for discussion of
+Privacy Considerations for PSD DMARC<a href="#section-7-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="other-topics">
+<section id="section-8">
+      <h2 id="name-other-topics">
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-other-topics" class="section-name selfRef">Other Topics</a>
+      </h2>
+<p id="section-8-1">This section discusses some topics regarding choices made in the
+development of DMARC, largely to commit the history to record.<a href="#section-8-1" class="pilcrow">¶</a></p>
+<div id="issues-specific-to-spf">
+<section id="section-8.1">
+        <h3 id="name-issues-specific-to-spf">
+<a href="#section-8.1" class="section-number selfRef">8.1. </a><a href="#name-issues-specific-to-spf" class="section-name selfRef">Issues Specific to SPF</a>
+        </h3>
+<p id="section-8.1-1">Though DMARC does not inherently change the semantics of an SPF
+policy record, historically lax enforcement of such policies has led
+many to publish extremely broad records containing many large network
+ranges.  Domain Owners are strongly encouraged to carefully review
+their SPF records to understand which networks are authorized to send
+on behalf of the Domain Owner before publishing a DMARC record.<a href="#section-8.1-1" class="pilcrow">¶</a></p>
+<p id="section-8.1-2">Some receiver architectures might implement SPF in advance of any
+DMARC operations.  This means that a "-" prefix on a sender's SPF
+mechanism, such as "-all", could cause that rejection to go into
+effect early in handling, causing message rejection before any DMARC
+processing takes place.  Operators choosing to use "-all" should be
+aware of this.<a href="#section-8.1-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="dns-load-and-caching">
+<section id="section-8.2">
+        <h3 id="name-dns-load-and-caching">
+<a href="#section-8.2" class="section-number selfRef">8.2. </a><a href="#name-dns-load-and-caching" class="section-name selfRef">DNS Load and Caching</a>
+        </h3>
+<p id="section-8.2-1">DMARC policies are communicated using the DNS and therefore inherit a
+number of considerations related to DNS caching.  The inherent
+conflict between freshness and the impact of caching on the reduction
+of DNS-lookup overhead should be considered from the Mail Receiver's
+point of view.  Should Domain Owners or PSOs publish a DNS record with a very
+short TTL, Mail Receivers can be provoked through the injection of
+large volumes of messages to overwhelm the publisher's DNS.
+Although this is not a concern specific to DMARC, the implications of
+a very short TTL should be considered when publishing DMARC policies.<a href="#section-8.2-1" class="pilcrow">¶</a></p>
+<p id="section-8.2-2">Conversely, long TTLs will cause records to be cached for long
+periods of time.  This can cause a critical change to DMARC
+parameters advertised by a Domain Owner or PSO to go unnoticed for the
+length of the TTL (while waiting for DNS caches to expire).  Avoiding
+this problem can mean shorter TTLs, with the potential problems
+described above.  A balance should be sought to maintain
+responsiveness of DMARC preference changes while preserving the
+benefits of DNS caching.<a href="#section-8.2-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="rejecting-messages">
+<section id="section-8.3">
+        <h3 id="name-rejecting-messages">
+<a href="#section-8.3" class="section-number selfRef">8.3. </a><a href="#name-rejecting-messages" class="section-name selfRef">Rejecting Messages</a>
+        </h3>
+<p id="section-8.3-1">This protocol calls for rejection of a message during the SMTP
+session under certain circumstances.  This is preferable to
+generation of a Delivery Status Notification (<span>[<a href="#RFC3464" class="xref">RFC3464</a>]</span>), since
+fraudulent messages caught and rejected using DMARC would then result
+in annoying generation of such failure reports that go back to the
+RFC5321.MailFrom address.<a href="#section-8.3-1" class="pilcrow">¶</a></p>
+<p id="section-8.3-2">This synchronous rejection is typically done in one of two ways:<a href="#section-8.3-2" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-8.3-3.1">
+            <p id="section-8.3-3.1.1">Full rejection, wherein the SMTP server issues a 5xy reply code as
+an indication to the SMTP client that the transaction failed; the
+SMTP client is then responsible for generating notification that
+delivery failed (see Section 4.2.5 of <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span>).<a href="#section-8.3-3.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-8.3-3.2">
+            <p id="section-8.3-3.2.1">A "silent discard", wherein the SMTP server returns a 2xy reply
+code implying to the client that delivery (or, at least, relay)
+was successfully completed, but then simply discarding the message
+with no further action.<a href="#section-8.3-3.2.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+<p id="section-8.3-4">Each of these has a cost.  For instance, a silent discard can help to
+prevent backscatter, but it also effectively means that the SMTP
+server has to be programmed to give a false result, which can
+confound external debugging efforts.<a href="#section-8.3-4" class="pilcrow">¶</a></p>
+<p id="section-8.3-5">Similarly, the text portion of the SMTP reply may be important to
+consider.  For example, when rejecting a message, revealing the
+reason for the rejection might give an attacker enough information to
+bypass those efforts on a later attempt, though it might also assist
+a legitimate client to determine the source of some local issue that
+caused the rejection.<a href="#section-8.3-5" class="pilcrow">¶</a></p>
+<p id="section-8.3-6">In the latter case, when doing an SMTP rejection, providing a clear
+hint can be useful in resolving issues.  A receiver might indicate in
+plain text the reason for the rejection by using the word "DMARC"
+somewhere in the reply text.  Many systems are able to scan the SMTP
+reply text to determine the nature of the rejection.  Thus, providing
+a machine-detectable reason for rejection allows the problems causing
+rejections to be properly addressed by automated systems.  For
+example:<a href="#section-8.3-6" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-8.3-7">
+<pre>550 5.7.1 Email rejected per DMARC policy for example.com
+</pre><a href="#section-8.3-7" class="pilcrow">¶</a>
+</div>
+<p id="section-8.3-8">If a Mail Receiver elects to defer delivery due to inability to
+retrieve or apply DMARC policy, this is best done with a 4xy SMTP
+reply code.<a href="#section-8.3-8" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="identifier-alignment-considerations">
+<section id="section-8.4">
+        <h3 id="name-identifier-alignment-consid">
+<a href="#section-8.4" class="section-number selfRef">8.4. </a><a href="#name-identifier-alignment-consid" class="section-name selfRef">Identifier Alignment Considerations</a>
+        </h3>
+<p id="section-8.4-1">The DMARC mechanism allows both DKIM and SPF-authenticated
+identifiers to authenticate email on behalf of a Domain Owner and,
+possibly, on behalf of different subdomains.  If malicious or unaware
+users can gain control of the SPF record or DKIM selector records for
+a subdomain, the subdomain can be used to generate DMARC-passing
+email on behalf of the Organizational Domain.<a href="#section-8.4-1" class="pilcrow">¶</a></p>
+<p id="section-8.4-2">For example, an attacker who controls the SPF record for
+"evil.example.com" can send mail with an RFC5322.From header field
+containing "foo@example.com" that can pass both authentication and
+the DMARC check against "example.com".<a href="#section-8.4-2" class="pilcrow">¶</a></p>
+<p id="section-8.4-3">The Organizational Domain administrator should be careful not to
+delegate control of subdomains if this is an issue, and to consider
+using the "strict" Identifier Alignment option if appropriate.<a href="#section-8.4-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="interoperability-issues">
+<section id="section-8.5">
+        <h3 id="name-interoperability-issues">
+<a href="#section-8.5" class="section-number selfRef">8.5. </a><a href="#name-interoperability-issues" class="section-name selfRef">Interoperability Issues</a>
+        </h3>
+<p id="section-8.5-1">DMARC limits which end-to-end scenarios can achieve a "pass" result.<a href="#section-8.5-1" class="pilcrow">¶</a></p>
+<p id="section-8.5-2">Because DMARC relies on SPF <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span> and/or DKIM <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span> to achieve
+a "pass", their limitations also apply.<a href="#section-8.5-2" class="pilcrow">¶</a></p>
+<p id="section-8.5-3">Additional DMARC constraints occur when a message is processed by
+some Mediators, such as mailing lists.  Transiting a Mediator often
+causes either the authentication to fail or Identifier Alignment to
+be lost.  These transformations may conform to standards but will
+still prevent a DMARC "pass".<a href="#section-8.5-3" class="pilcrow">¶</a></p>
+<p id="section-8.5-4">In addition to Mediators, mail that is sent by authorized,
+independent third parties might not be sent with Identifier
+Alignment, also preventing a "pass" result.<a href="#section-8.5-4" class="pilcrow">¶</a></p>
+<p id="section-8.5-5">Issues specific to the use of policy mechanisms alongside DKIM are
+further discussed in <span>[<a href="#RFC6377" class="xref">RFC6377</a>]</span>, particularly Section 5.2.<a href="#section-8.5-5" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="iana-considerations">
+<section id="section-9">
+      <h2 id="name-iana-considerations">
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
+      </h2>
+<p id="section-9-1">This section describes actions completed by IANA.<a href="#section-9-1" class="pilcrow">¶</a></p>
+<div id="authentication-results-method-registry-update">
+<section id="section-9.1">
+        <h3 id="name-authentication-results-meth">
+<a href="#section-9.1" class="section-number selfRef">9.1. </a><a href="#name-authentication-results-meth" class="section-name selfRef">Authentication-Results Method Registry Update</a>
+        </h3>
+<p id="section-9.1-1">IANA has added the following to the "Email Authentication Methods"
+registry:<a href="#section-9.1-1" class="pilcrow">¶</a></p>
+<span id="name-authentication-results-metho"></span><table class="left" id="table-1">
+          <caption>
+<a href="#table-1" class="selfRef">Table 1</a>:
+<a href="#name-authentication-results-metho" class="selfRef">"Authentication-Results Method Registry Update"</a>
+          </caption>
+<thead>
+            <tr>
+              <th class="text-left" rowspan="1" colspan="1">Method</th>
+              <th class="text-left" rowspan="1" colspan="1">Defined</th>
+              <th class="text-left" rowspan="1" colspan="1">ptype</th>
+              <th class="text-left" rowspan="1" colspan="1">Property</th>
+              <th class="text-left" rowspan="1" colspan="1">Value</th>
+              <th class="text-left" rowspan="1" colspan="1">Status</th>
+              <th class="text-left" rowspan="1" colspan="1">Version</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">dmarc</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <span>[<a href="#RFC7489" class="xref">RFC7489</a>]</span>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">header</td>
+              <td class="text-left" rowspan="1" colspan="1">from</td>
+              <td class="text-left" rowspan="1" colspan="1">the domain portion of the RFC5322.From header field</td>
+              <td class="text-left" rowspan="1" colspan="1">active</td>
+              <td class="text-left" rowspan="1" colspan="1">1</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">dmarc</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <span>[<a href="#RFC7489" class="xref">RFC7489</a>]</span>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">polrec</td>
+              <td class="text-left" rowspan="1" colspan="1">p</td>
+              <td class="text-left" rowspan="1" colspan="1">the p= value read from the discovered policy record</td>
+              <td class="text-left" rowspan="1" colspan="1">active</td>
+              <td class="text-left" rowspan="1" colspan="1">1</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">dmarc</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <span>[<a href="#RFC7489" class="xref">RFC7489</a>]</span>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">polrec</td>
+              <td class="text-left" rowspan="1" colspan="1">domain</td>
+              <td class="text-left" rowspan="1" colspan="1">the domain at which the policy record was discovered, if different from the RFC5322.From domain</td>
+              <td class="text-left" rowspan="1" colspan="1">active</td>
+              <td class="text-left" rowspan="1" colspan="1">1</td>
+            </tr>
+          </tbody>
+        </table>
+</section>
+</div>
+<div id="authentication-results-result-registry-update">
+<section id="section-9.2">
+        <h3 id="name-authentication-results-resu">
+<a href="#section-9.2" class="section-number selfRef">9.2. </a><a href="#name-authentication-results-resu" class="section-name selfRef">Authentication-Results Result Registry Update</a>
+        </h3>
+<p id="section-9.2-1">IANA has added the following in the "Email Authentication Result
+Names" registry:<a href="#section-9.2-1" class="pilcrow">¶</a></p>
+<span id="name-authentication-results-resul"></span><table class="left" id="table-2">
+          <caption>
+<a href="#table-2" class="selfRef">Table 2</a>:
+<a href="#name-authentication-results-resul" class="selfRef">"Authentication-Results Result Registry Update"</a>
+          </caption>
+<thead>
+            <tr>
+              <th class="text-left" rowspan="1" colspan="1">Code</th>
+              <th class="text-left" rowspan="1" colspan="1">Existing/New Code</th>
+              <th class="text-left" rowspan="1" colspan="1">Defined</th>
+              <th class="text-left" rowspan="1" colspan="1">Auth Method</th>
+              <th class="text-left" rowspan="1" colspan="1">Meaning</th>
+              <th class="text-left" rowspan="1" colspan="1">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">none</td>
+              <td class="text-left" rowspan="1" colspan="1">existing</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <span>[<a href="#RFC8601" class="xref">RFC8601</a>]</span>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">dmarc (added)</td>
+              <td class="text-left" rowspan="1" colspan="1">No DMARC policy record was published for the aligned identifier, or no aligned identifier could be extracted.</td>
+              <td class="text-left" rowspan="1" colspan="1">active</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">pass</td>
+              <td class="text-left" rowspan="1" colspan="1">existing</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <span>[<a href="#RFC8601" class="xref">RFC8601</a>]</span>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">dmarc (added)</td>
+              <td class="text-left" rowspan="1" colspan="1">A DMARC policy record was published for the aligned identifier, and at least one of the authentication mechanisms passed.</td>
+              <td class="text-left" rowspan="1" colspan="1">active</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">fail</td>
+              <td class="text-left" rowspan="1" colspan="1">existing</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <span>[<a href="#RFC8601" class="xref">RFC8601</a>]</span>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">dmarc (added)</td>
+              <td class="text-left" rowspan="1" colspan="1">A DMARC policy record was published for the aligned identifier, and none of the authentication mechanisms passed.</td>
+              <td class="text-left" rowspan="1" colspan="1">active</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">temperror</td>
+              <td class="text-left" rowspan="1" colspan="1">existing</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <span>[<a href="#RFC8601" class="xref">RFC8601</a>]</span>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">dmarc (added)</td>
+              <td class="text-left" rowspan="1" colspan="1">A temporary error occurred during DMARC evaluation. A later attempt might produce a final result.</td>
+              <td class="text-left" rowspan="1" colspan="1">active</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">permerror</td>
+              <td class="text-left" rowspan="1" colspan="1">existing</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <span>[<a href="#RFC8601" class="xref">RFC8601</a>]</span>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">dmarc (added)</td>
+              <td class="text-left" rowspan="1" colspan="1">A permanent error occurred during DMARC evaluation, such as encountering a syntactically incorrect DMARC record. A later attempt is unlikely to produce a final result.</td>
+              <td class="text-left" rowspan="1" colspan="1">active</td>
+            </tr>
+          </tbody>
+        </table>
+</section>
+</div>
+<div id="feedback-report-header-fields-registry-update">
+<section id="section-9.3">
+        <h3 id="name-feedback-report-header-fiel">
+<a href="#section-9.3" class="section-number selfRef">9.3. </a><a href="#name-feedback-report-header-fiel" class="section-name selfRef">Feedback Report Header Fields Registry Update</a>
+        </h3>
+<p id="section-9.3-1">The following has been added to the "Feedback Report Header Fields"
+registry:<a href="#section-9.3-1" class="pilcrow">¶</a></p>
+<p id="section-9.3-2">Field Name:  Identity-Alignment<a href="#section-9.3-2" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-9.3-3">
+          <dt id="section-9.3-3.1">Description:</dt>
+<dd id="section-9.3-3.2">indicates whether the message about which a report is
+being generated had any identifiers in alignment as defined in
+RFC 7489<a href="#section-9.3-3.2" class="pilcrow">¶</a>
+</dd>
+<dd class="break"></dd>
+</dl>
+<p id="section-9.3-4">Multiple Appearances:  No<a href="#section-9.3-4" class="pilcrow">¶</a></p>
+<p id="section-9.3-5">Related "Feedback-Type":  auth-failure<a href="#section-9.3-5" class="pilcrow">¶</a></p>
+<p id="section-9.3-6">Reference:  RFC 7489<a href="#section-9.3-6" class="pilcrow">¶</a></p>
+<p id="section-9.3-7">Status:  current<a href="#section-9.3-7" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="dmarc-tag-registry">
+<section id="section-9.4">
+        <h3 id="name-dmarc-tag-registry">
+<a href="#section-9.4" class="section-number selfRef">9.4. </a><a href="#name-dmarc-tag-registry" class="section-name selfRef">DMARC Tag Registry</a>
+        </h3>
+<p id="section-9.4-1">A new registry tree called "Domain-based Message Authentication,
+Reporting, and Conformance (DMARC) Parameters" has been created.
+Within it, a new sub-registry called the "DMARC Tag Registry" has
+been created.<a href="#section-9.4-1" class="pilcrow">¶</a></p>
+<p id="section-9.4-2">Names of DMARC tags must be registered with IANA in this new
+sub-registry.  New entries are assigned only for values that have
+been documented in a manner that satisfies the terms of Specification
+Required, per <span>[<a href="#RFC8126" class="xref">RFC8126</a>]</span>.  Each registration must include
+the tag name; the specification that defines it; a brief description;
+and its status, which must be one of "current", "experimental", or
+"historic".  The Designated Expert needs to confirm that the provided
+specification adequately describes the new tag and clearly presents
+how it would be used within the DMARC context by Domain Owners and
+Mail Receivers.<a href="#section-9.4-2" class="pilcrow">¶</a></p>
+<p id="section-9.4-3">To avoid version compatibility issues, tags added to the DMARC
+specification are to avoid changing the semantics of existing records
+when processed by implementations conforming to prior specifications.<a href="#section-9.4-3" class="pilcrow">¶</a></p>
+<p id="section-9.4-4">The initial set of entries in this registry is as follows:<a href="#section-9.4-4" class="pilcrow">¶</a></p>
+<span id="name-dmarc-tag-registry-2"></span><table class="left" id="table-3">
+          <caption>
+<a href="#table-3" class="selfRef">Table 3</a>:
+<a href="#name-dmarc-tag-registry-2" class="selfRef">"DMARC Tag Registry"</a>
+          </caption>
+<thead>
+            <tr>
+              <th class="text-left" rowspan="1" colspan="1">Tag Name</th>
+              <th class="text-left" rowspan="1" colspan="1">Reference</th>
+              <th class="text-left" rowspan="1" colspan="1">Status</th>
+              <th class="text-left" rowspan="1" colspan="1">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">adkim</td>
+              <td class="text-left" rowspan="1" colspan="1">RFC 7489</td>
+              <td class="text-left" rowspan="1" colspan="1">current</td>
+              <td class="text-left" rowspan="1" colspan="1">DKIM alignment mode</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">aspf</td>
+              <td class="text-left" rowspan="1" colspan="1">RFC 7489</td>
+              <td class="text-left" rowspan="1" colspan="1">current</td>
+              <td class="text-left" rowspan="1" colspan="1">SPF alignment mode</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">fo</td>
+              <td class="text-left" rowspan="1" colspan="1">RFC 7489</td>
+              <td class="text-left" rowspan="1" colspan="1">current</td>
+              <td class="text-left" rowspan="1" colspan="1">Failure reporting options</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">p</td>
+              <td class="text-left" rowspan="1" colspan="1">RFC 7489</td>
+              <td class="text-left" rowspan="1" colspan="1">current</td>
+              <td class="text-left" rowspan="1" colspan="1">Requested handling policy</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">pct</td>
+              <td class="text-left" rowspan="1" colspan="1">RFC 7489</td>
+              <td class="text-left" rowspan="1" colspan="1">historic</td>
+              <td class="text-left" rowspan="1" colspan="1">Sampling rate</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">rf</td>
+              <td class="text-left" rowspan="1" colspan="1">RFC 7489</td>
+              <td class="text-left" rowspan="1" colspan="1">historic</td>
+              <td class="text-left" rowspan="1" colspan="1">Failure reporting format(s)</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">ri</td>
+              <td class="text-left" rowspan="1" colspan="1">RFC 7489</td>
+              <td class="text-left" rowspan="1" colspan="1">historic</td>
+              <td class="text-left" rowspan="1" colspan="1">Aggregate Reporting interval</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">rua</td>
+              <td class="text-left" rowspan="1" colspan="1">RFC 7489</td>
+              <td class="text-left" rowspan="1" colspan="1">current</td>
+              <td class="text-left" rowspan="1" colspan="1">Reporting URI(s) for aggregate data</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">ruf</td>
+              <td class="text-left" rowspan="1" colspan="1">RFC 7489</td>
+              <td class="text-left" rowspan="1" colspan="1">current</td>
+              <td class="text-left" rowspan="1" colspan="1">Reporting URI(s) for failure data</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">sp</td>
+              <td class="text-left" rowspan="1" colspan="1">RFC 7489</td>
+              <td class="text-left" rowspan="1" colspan="1">current</td>
+              <td class="text-left" rowspan="1" colspan="1">Requested handling policy for subdomains</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">t</td>
+              <td class="text-left" rowspan="1" colspan="1">RFC 7489</td>
+              <td class="text-left" rowspan="1" colspan="1">current</td>
+              <td class="text-left" rowspan="1" colspan="1">Test mode for the specified policy</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">v</td>
+              <td class="text-left" rowspan="1" colspan="1">RFC 7489</td>
+              <td class="text-left" rowspan="1" colspan="1">current</td>
+              <td class="text-left" rowspan="1" colspan="1">Specification version</td>
+            </tr>
+          </tbody>
+        </table>
+</section>
+</div>
+<div id="dmarc-report-format-registry">
+<section id="section-9.5">
+        <h3 id="name-dmarc-report-format-registr">
+<a href="#section-9.5" class="section-number selfRef">9.5. </a><a href="#name-dmarc-report-format-registr" class="section-name selfRef">DMARC Report Format Registry</a>
+        </h3>
+<p id="section-9.5-1">Also within "Domain-based Message Authentication, Reporting, and
+Conformance (DMARC) Parameters", a new sub-registry called "DMARC
+Report Format Registry" has been created.<a href="#section-9.5-1" class="pilcrow">¶</a></p>
+<p id="section-9.5-2">Names of DMARC failure reporting formats must be registered with IANA
+in this registry.  New entries are assigned only for values that
+satisfy the definition of Specification Required, per
+<span>[<a href="#RFC8126" class="xref">RFC8126</a>]</span>.  In addition to a reference to a permanent
+specification, each registration must include the format name; a
+brief description; and its status, which must be one of "current",
+"experimental", or "historic".  The Designated Expert needs to
+confirm that the provided specification adequately describes the
+report format and clearly presents how it would be used within the
+DMARC context by Domain Owners and Mail Receivers.<a href="#section-9.5-2" class="pilcrow">¶</a></p>
+<p id="section-9.5-3">The initial entry in this registry is as follows:<a href="#section-9.5-3" class="pilcrow">¶</a></p>
+<span id="name-dmarc-report-format-registry"></span><table class="left" id="table-4">
+          <caption>
+<a href="#table-4" class="selfRef">Table 4</a>:
+<a href="#name-dmarc-report-format-registry" class="selfRef">"DMARC Report Format Registry"</a>
+          </caption>
+<thead>
+            <tr>
+              <th class="text-left" rowspan="1" colspan="1">Format Name</th>
+              <th class="text-left" rowspan="1" colspan="1">Reference</th>
+              <th class="text-left" rowspan="1" colspan="1">Status</th>
+              <th class="text-left" rowspan="1" colspan="1">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">afrf</td>
+              <td class="text-left" rowspan="1" colspan="1">RFC 7489</td>
+              <td class="text-left" rowspan="1" colspan="1">current</td>
+              <td class="text-left" rowspan="1" colspan="1">Authentication Failure Reporting Format (see <span>[<a href="#RFC6591" class="xref">RFC6591</a>]</span>)</td>
+            </tr>
+          </tbody>
+        </table>
+</section>
+</div>
+<div id="underscored-and-globally-scoped-dns-node-names-registry">
+<section id="section-9.6">
+        <h3 id="name-underscored-and-globally-sc">
+<a href="#section-9.6" class="section-number selfRef">9.6. </a><a href="#name-underscored-and-globally-sc" class="section-name selfRef">Underscored and Globally Scoped DNS Node Names Registry</a>
+        </h3>
+<p id="section-9.6-1">Per <span>[<a href="#RFC8552" class="xref">RFC8552</a>]</span>, please add the following entry to the "Underscored
+and Globally Scoped DNS Node Names" registry:<a href="#section-9.6-1" class="pilcrow">¶</a></p>
+<span id="name-underscored-and-globally-sco"></span><table class="left" id="table-5">
+          <caption>
+<a href="#table-5" class="selfRef">Table 5</a>:
+<a href="#name-underscored-and-globally-sco" class="selfRef">"Underscored and Globally Scoped DNS Node Names" registry</a>
+          </caption>
+<thead>
+            <tr>
+              <th class="text-left" rowspan="1" colspan="1">RR Type</th>
+              <th class="text-left" rowspan="1" colspan="1">_NODE NAME</th>
+              <th class="text-left" rowspan="1" colspan="1">Reference</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">TXT</td>
+              <td class="text-left" rowspan="1" colspan="1">_dmarc</td>
+              <td class="text-left" rowspan="1" colspan="1">RFC 7489</td>
+            </tr>
+          </tbody>
+        </table>
+</section>
+</div>
+</section>
+</div>
+<div id="security-considerations">
+<section id="section-10">
+      <h2 id="name-security-considerations">
+<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
+      </h2>
+<p id="section-10-1">This section discusses security issues and possible remediations
+(where available) for DMARC.<a href="#section-10-1" class="pilcrow">¶</a></p>
+<div id="authentication-methods">
+<section id="section-10.1">
+        <h3 id="name-authentication-methods">
+<a href="#section-10.1" class="section-number selfRef">10.1. </a><a href="#name-authentication-methods" class="section-name selfRef">Authentication Methods</a>
+        </h3>
+<p id="section-10.1-1">Security considerations from the authentication methods used by DMARC
+are incorporated here by reference.<a href="#section-10.1-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="attacks-on-reporting-uris">
+<section id="section-10.2">
+        <h3 id="name-attacks-on-reporting-uris">
+<a href="#section-10.2" class="section-number selfRef">10.2. </a><a href="#name-attacks-on-reporting-uris" class="section-name selfRef">Attacks on Reporting URIs</a>
+        </h3>
+<p id="section-10.2-1">URIs published in DNS TXT records are well-understood possible
+targets for attack.  Specifications such as <span>[<a href="#RFC1035" class="xref">RFC1035</a>]</span> and <span>[<a href="#RFC2142" class="xref">RFC2142</a>]</span> either
+expose or cause the exposure of email addresses that could be flooded
+by an attacker, for example; MX, NS, and other records found in the
+DNS advertise potential attack destinations; common DNS names such as
+"www" plainly identify the locations at which particular services can
+be found, providing destinations for targeted denial-of-service or
+penetration attacks.<a href="#section-10.2-1" class="pilcrow">¶</a></p>
+<p id="section-10.2-2">Thus, Domain Owners will need to harden these addresses against
+various attacks, including but not limited to:<a href="#section-10.2-2" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-10.2-3.1">
+            <p id="section-10.2-3.1.1">high-volume denial-of-service attacks;<a href="#section-10.2-3.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-10.2-3.2">
+            <p id="section-10.2-3.2.1">deliberate construction of malformed reports intended to identify
+or exploit parsing or processing vulnerabilities;<a href="#section-10.2-3.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-10.2-3.3">
+            <p id="section-10.2-3.3.1">deliberate construction of reports containing false claims for the
+Submitter or Reported-Domain fields, including the possibility of
+false data from compromised but known Mail Receivers.<a href="#section-10.2-3.3.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</section>
+</div>
+<div id="dns-security">
+<section id="section-10.3">
+        <h3 id="name-dns-security">
+<a href="#section-10.3" class="section-number selfRef">10.3. </a><a href="#name-dns-security" class="section-name selfRef">DNS Security</a>
+        </h3>
+<p id="section-10.3-1">The DMARC mechanism and its underlying technologies (SPF, DKIM)
+depend on the security of the DNS. Examples of how hostile parties can
+have an adverse impact on DNS traffic include:
+*  If they can snoop on DNS traffic, they can get an idea of who is
+   sending mail.<a href="#section-10.3-1" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-10.3-2.1">
+            <p id="section-10.3-2.1.1">If they can block outgoing or reply DNS messages, they can prevent
+systems from discovering senders' DMARC policies, causing recipients
+to assume p=none by default.<a href="#section-10.3-2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-10.3-2.2">
+            <p id="section-10.3-2.2.1">If they can send forged response packets, they can make aligned mail
+appear unaligned or vice-versa.<a href="#section-10.3-2.2.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+<p id="section-10.3-3">None of these threats are unique to DMARC, and they can be addressed using
+a variety of techniques, including, but not limited to:<a href="#section-10.3-3" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-10.3-4.1">
+            <p id="section-10.3-4.1.1">Signing DNS records with DNSSEC <span>[<a href="#RFC4033" class="xref">RFC4033</a>]</span>, which enables recipients to
+detect and discard forged responses.<a href="#section-10.3-4.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-10.3-4.2">
+            <p id="section-10.3-4.2.1">DNS over TLS <span>[<a href="#RFC7858" class="xref">RFC7858</a>]</span> or DNS over HTTPS <span>[<a href="#RFC8484" class="xref">RFC8484</a>]</span> can mitigate snooping
+and forged responses.<a href="#section-10.3-4.2.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</section>
+</div>
+<div id="display-name-attacks">
+<section id="section-10.4">
+        <h3 id="name-display-name-attacks">
+<a href="#section-10.4" class="section-number selfRef">10.4. </a><a href="#name-display-name-attacks" class="section-name selfRef">Display Name Attacks</a>
+        </h3>
+<p id="section-10.4-1">A common attack in messaging abuse is the presentation of false
+information in the display-name portion of the RFC5322.From header field.
+For example, it is possible for the email address in that field to be
+an arbitrary address or domain name, while containing a well-known
+name (a person, brand, role, etc.) in the display name, intending to
+fool the end user into believing that the name is used legitimately.
+The attack is predicated on the notion that most common MUAs will
+show the display name and not the email address when both are
+available.<a href="#section-10.4-1" class="pilcrow">¶</a></p>
+<p id="section-10.4-2">Generally, display name attacks are out of scope for DMARC, as
+further exploration of possible defenses against these attacks needs
+to be undertaken.<a href="#section-10.4-2" class="pilcrow">¶</a></p>
+<p id="section-10.4-3">There are a few possible mechanisms that attempt mitigation of these
+attacks, such as the following:<a href="#section-10.4-3" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-10.4-4.1">
+            <p id="section-10.4-4.1.1">If the display name is found to include an email address (as
+specified in <span>[<a href="#RFC5322" class="xref">RFC5322</a>]</span>), execute the DMARC mechanism on the domain
+name found there rather than the domain name discovered
+originally.  However, this addresses only a very specific attack
+space, and spoofers can easily circumvent it by simply not using
+an email address in the display name.  There are also known cases
+of legitimate uses of an email address in the display name with a
+domain different from the one in the address portion, e.g.,<a href="#section-10.4-4.1.1" class="pilcrow">¶</a></p>
+<p id="section-10.4-4.1.2">From: "user@example.org via Bug Tracker" <a href="mailto:support@example.com">support@example.com</a><a href="#section-10.4-4.1.2" class="pilcrow">¶</a></p>
+</li>
+<li id="section-10.4-4.2">
+            <p id="section-10.4-4.2.1">In the MUA, only show the display name if the DMARC mechanism
+succeeds.  This too is easily defeated, as an attacker could
+arrange to pass the DMARC tests while fraudulently using another
+domain name in the display name.<a href="#section-10.4-4.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-10.4-4.3">
+            <p id="section-10.4-4.3.1">In the MUA, only show the display name if the DMARC mechanism
+passes and the email address thus verified matches one found in
+the receiving user's list of known addresses.<a href="#section-10.4-4.3.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</section>
+</div>
+<div id="external-report-addresses">
+<section id="section-10.5">
+        <h3 id="name-external-reporting-addresse">
+<a href="#section-10.5" class="section-number selfRef">10.5. </a><a href="#name-external-reporting-addresse" class="section-name selfRef">External Reporting Addresses</a>
+        </h3>
+<p id="section-10.5-1">To avoid abuse by bad actors, reporting addresses generally have to
+be inside the domains about which reports are requested.  In order to
+accommodate special cases such as a need to get reports about domains
+that cannot actually receive mail, Section 3 of <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> describes
+a DNS-based mechanism for verifying approved external reporting.<a href="#section-10.5-1" class="pilcrow">¶</a></p>
+<p id="section-10.5-2">The obvious consideration here is an increased DNS load against
+domains that are claimed as external recipients.  Negative caching
+will mitigate this problem, but only to a limited extent, mostly
+dependent on the default TTL in the domain's SOA record.<a href="#section-10.5-2" class="pilcrow">¶</a></p>
+<p id="section-10.5-3">Where possible, external reporting is best achieved by having the
+report be directed to domains that can receive mail and simply having
+it automatically forwarded to the desired external destination.<a href="#section-10.5-3" class="pilcrow">¶</a></p>
+<p id="section-10.5-4">Note that the addresses shown in the "ruf" tag receive more
+information that might be considered private data, since it is
+possible for actual email content to appear in the failure reports.
+The URIs identified there are thus more attractive targets for
+intrusion attempts than those found in the "rua" tag.  Moreover,
+attacking the DNS of the subject domain to cause failure data to be
+routed fraudulently to an attacker's systems may be an attractive
+prospect.  Deployment of <span>[<a href="#RFC4033" class="xref">RFC4033</a>]</span> is advisable if this is a concern.<a href="#section-10.5-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="secure-protocols">
+<section id="section-10.6">
+        <h3 id="name-secure-protocols">
+<a href="#section-10.6" class="section-number selfRef">10.6. </a><a href="#name-secure-protocols" class="section-name selfRef">Secure Protocols</a>
+        </h3>
+<p id="section-10.6-1">This document encourages use of secure transport mechanisms to
+prevent loss of private data to third parties that may be able to
+monitor such transmissions.  Unencrypted mechanisms should be
+avoided.<a href="#section-10.6-1" class="pilcrow">¶</a></p>
+<p id="section-10.6-2">In particular, a message that was originally encrypted or otherwise
+secured might appear in a report that is not sent securely, which
+could reveal private information.<a href="#section-10.6-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<section id="section-11">
+      <h2 id="name-normative-references">
+<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+      </h2>
+<dl class="references">
+<dt id="DMARC-Aggregate-Reporting">[DMARC-Aggregate-Reporting]</dt>
+<dd>
+<span class="refAuthor">Brotman, A., Ed.</span>, <span class="refTitle">"DMARC Aggregate Reporting"</span>, <time datetime="2021-02">February 2021</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/draft-ietf-dmarc-aggregate-reporting/">https://datatracker.ietf.org/doc/draft-ietf-dmarc-aggregate-reporting/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="DMARC-Failure-Reporting">[DMARC-Failure-Reporting]</dt>
+<dd>
+<span class="refAuthor">Jones, S.M., Ed.</span><span class="refAuthor"> and A. Vesely, Ed.</span>, <span class="refTitle">"DMARC Failure Reporting"</span>, <time datetime="2021-02">February 2021</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/draft-ietf-dmarc-failure-reporting/">https://datatracker.ietf.org/doc/draft-ietf-dmarc-failure-reporting/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC1035">[RFC1035]</dt>
+<dd>
+<span class="refAuthor">Mockapetris, P.</span>, <span class="refTitle">"Domain names - implementation and specification"</span>, <span class="seriesInfo">STD 13</span>, <span class="seriesInfo">RFC 1035</span>, <span class="seriesInfo">DOI 10.17487/RFC1035</span>, <time datetime="1987-11">November 1987</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc1035">https://www.rfc-editor.org/info/rfc1035</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC2119">[RFC2119]</dt>
+<dd>
+<span class="refAuthor">Bradner, S.</span>, <span class="refTitle">"Key words for use in RFCs to Indicate Requirement Levels"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 2119</span>, <span class="seriesInfo">DOI 10.17487/RFC2119</span>, <time datetime="1997-03">March 1997</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc2119">https://www.rfc-editor.org/info/rfc2119</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC3986">[RFC3986]</dt>
+<dd>
+<span class="refAuthor">Berners-Lee, T.</span><span class="refAuthor">, Fielding, R.</span><span class="refAuthor">, and L. Masinter</span>, <span class="refTitle">"Uniform Resource Identifier (URI): Generic Syntax"</span>, <span class="seriesInfo">STD 66</span>, <span class="seriesInfo">RFC 3986</span>, <span class="seriesInfo">DOI 10.17487/RFC3986</span>, <time datetime="2005-01">January 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc3986">https://www.rfc-editor.org/info/rfc3986</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC4343">[RFC4343]</dt>
+<dd>
+<span class="refAuthor">Eastlake 3rd, D.</span>, <span class="refTitle">"Domain Name System (DNS) Case Insensitivity Clarification"</span>, <span class="seriesInfo">RFC 4343</span>, <span class="seriesInfo">DOI 10.17487/RFC4343</span>, <time datetime="2006-01">January 2006</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4343">https://www.rfc-editor.org/info/rfc4343</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC5234">[RFC5234]</dt>
+<dd>
+<span class="refAuthor">Crocker, D., Ed.</span><span class="refAuthor"> and P. Overell</span>, <span class="refTitle">"Augmented BNF for Syntax Specifications: ABNF"</span>, <span class="seriesInfo">STD 68</span>, <span class="seriesInfo">RFC 5234</span>, <span class="seriesInfo">DOI 10.17487/RFC5234</span>, <time datetime="2008-01">January 2008</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc5234">https://www.rfc-editor.org/info/rfc5234</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC5321">[RFC5321]</dt>
+<dd>
+<span class="refAuthor">Klensin, J.</span>, <span class="refTitle">"Simple Mail Transfer Protocol"</span>, <span class="seriesInfo">RFC 5321</span>, <span class="seriesInfo">DOI 10.17487/RFC5321</span>, <time datetime="2008-10">October 2008</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc5321">https://www.rfc-editor.org/info/rfc5321</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC5322">[RFC5322]</dt>
+<dd>
+<span class="refAuthor">Resnick, P., Ed.</span>, <span class="refTitle">"Internet Message Format"</span>, <span class="seriesInfo">RFC 5322</span>, <span class="seriesInfo">DOI 10.17487/RFC5322</span>, <time datetime="2008-10">October 2008</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc5322">https://www.rfc-editor.org/info/rfc5322</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC5890">[RFC5890]</dt>
+<dd>
+<span class="refAuthor">Klensin, J.</span>, <span class="refTitle">"Internationalized Domain Names for Applications (IDNA): Definitions and Document Framework"</span>, <span class="seriesInfo">RFC 5890</span>, <span class="seriesInfo">DOI 10.17487/RFC5890</span>, <time datetime="2010-08">August 2010</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc5890">https://www.rfc-editor.org/info/rfc5890</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC6376">[RFC6376]</dt>
+<dd>
+<span class="refAuthor">Crocker, D., Ed.</span><span class="refAuthor">, Hansen, T., Ed.</span><span class="refAuthor">, and M. Kucherawy, Ed.</span>, <span class="refTitle">"DomainKeys Identified Mail (DKIM) Signatures"</span>, <span class="seriesInfo">STD 76</span>, <span class="seriesInfo">RFC 6376</span>, <span class="seriesInfo">DOI 10.17487/RFC6376</span>, <time datetime="2011-09">September 2011</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc6376">https://www.rfc-editor.org/info/rfc6376</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC6591">[RFC6591]</dt>
+<dd>
+<span class="refAuthor">Fontana, H.</span>, <span class="refTitle">"Authentication Failure Reporting Using the Abuse Reporting Format"</span>, <span class="seriesInfo">RFC 6591</span>, <span class="seriesInfo">DOI 10.17487/RFC6591</span>, <time datetime="2012-04">April 2012</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc6591">https://www.rfc-editor.org/info/rfc6591</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC6651">[RFC6651]</dt>
+<dd>
+<span class="refAuthor">Kucherawy, M.</span>, <span class="refTitle">"Extensions to DomainKeys Identified Mail (DKIM) for Failure Reporting"</span>, <span class="seriesInfo">RFC 6651</span>, <span class="seriesInfo">DOI 10.17487/RFC6651</span>, <time datetime="2012-06">June 2012</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc6651">https://www.rfc-editor.org/info/rfc6651</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC6652">[RFC6652]</dt>
+<dd>
+<span class="refAuthor">Kitterman, S.</span>, <span class="refTitle">"Sender Policy Framework (SPF) Authentication Failure Reporting Using the Abuse Reporting Format"</span>, <span class="seriesInfo">RFC 6652</span>, <span class="seriesInfo">DOI 10.17487/RFC6652</span>, <time datetime="2012-06">June 2012</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc6652">https://www.rfc-editor.org/info/rfc6652</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC7208">[RFC7208]</dt>
+<dd>
+<span class="refAuthor">Kitterman, S.</span>, <span class="refTitle">"Sender Policy Framework (SPF) for Authorizing Use of Domains in Email, Version 1"</span>, <span class="seriesInfo">RFC 7208</span>, <span class="seriesInfo">DOI 10.17487/RFC7208</span>, <time datetime="2014-04">April 2014</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc7208">https://www.rfc-editor.org/info/rfc7208</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC7489">[RFC7489]</dt>
+<dd>
+<span class="refAuthor">Kucherawy, M., Ed.</span><span class="refAuthor"> and E. Zwicky, Ed.</span>, <span class="refTitle">"Domain-based Message Authentication, Reporting, and Conformance (DMARC)"</span>, <span class="seriesInfo">RFC 7489</span>, <span class="seriesInfo">DOI 10.17487/RFC7489</span>, <time datetime="2015-03">March 2015</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc7489">https://www.rfc-editor.org/info/rfc7489</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8552">[RFC8552]</dt>
+<dd>
+<span class="refAuthor">Crocker, D.</span>, <span class="refTitle">"Scoped Interpretation of DNS Resource Records through "Underscored" Naming of Attribute Leaves"</span>, <span class="seriesInfo">BCP 222</span>, <span class="seriesInfo">RFC 8552</span>, <span class="seriesInfo">DOI 10.17487/RFC8552</span>, <time datetime="2019-03">March 2019</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8552">https://www.rfc-editor.org/info/rfc8552</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC9091">[RFC9091]</dt>
+<dd>
+<span class="refAuthor">Kitterman, S.</span><span class="refAuthor"> and T. Wicinski, Ed.</span>, <span class="refTitle">"Experimental Domain-Based Message Authentication, Reporting, and Conformance (DMARC) Extension for Public Suffix Domains"</span>, <span class="seriesInfo">RFC 9091</span>, <span class="seriesInfo">DOI 10.17487/RFC9091</span>, <time datetime="2021-07">July 2021</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc9091">https://www.rfc-editor.org/info/rfc9091</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+</dl>
+</section>
+<section id="section-12">
+      <h2 id="name-informative-references">
+<a href="#section-12" class="section-number selfRef">12. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
+      </h2>
+<dl class="references">
+<dt id="Best-Guess-SPF">[Best-Guess-SPF]</dt>
+<dd>
+<span class="refAuthor">Kitterman, S.</span>, <span class="refTitle">"Sender Policy Framework: Best guess record (FAQ entry)"</span>, <time datetime="2010-05">May 2010</time>, <span>&lt;<a href="http://www.openspf.org/FAQ/Best_guess_record">http://www.openspf.org/FAQ/Best_guess_record</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC2142">[RFC2142]</dt>
+<dd>
+<span class="refAuthor">Crocker, D.</span>, <span class="refTitle">"Mailbox Names for Common Services, Roles and Functions"</span>, <span class="seriesInfo">RFC 2142</span>, <span class="seriesInfo">DOI 10.17487/RFC2142</span>, <time datetime="1997-05">May 1997</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc2142">https://www.rfc-editor.org/info/rfc2142</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC3464">[RFC3464]</dt>
+<dd>
+<span class="refAuthor">Moore, K.</span><span class="refAuthor"> and G. Vaudreuil</span>, <span class="refTitle">"An Extensible Message Format for Delivery Status Notifications"</span>, <span class="seriesInfo">RFC 3464</span>, <span class="seriesInfo">DOI 10.17487/RFC3464</span>, <time datetime="2003-01">January 2003</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc3464">https://www.rfc-editor.org/info/rfc3464</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC4033">[RFC4033]</dt>
+<dd>
+<span class="refAuthor">Arends, R.</span><span class="refAuthor">, Austein, R.</span><span class="refAuthor">, Larson, M.</span><span class="refAuthor">, Massey, D.</span><span class="refAuthor">, and S. Rose</span>, <span class="refTitle">"DNS Security Introduction and Requirements"</span>, <span class="seriesInfo">RFC 4033</span>, <span class="seriesInfo">DOI 10.17487/RFC4033</span>, <time datetime="2005-03">March 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4033">https://www.rfc-editor.org/info/rfc4033</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC5598">[RFC5598]</dt>
+<dd>
+<span class="refAuthor">Crocker, D.</span>, <span class="refTitle">"Internet Mail Architecture"</span>, <span class="seriesInfo">RFC 5598</span>, <span class="seriesInfo">DOI 10.17487/RFC5598</span>, <time datetime="2009-07">July 2009</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc5598">https://www.rfc-editor.org/info/rfc5598</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC5617">[RFC5617]</dt>
+<dd>
+<span class="refAuthor">Allman, E.</span><span class="refAuthor">, Fenton, J.</span><span class="refAuthor">, Delany, M.</span><span class="refAuthor">, and J. Levine</span>, <span class="refTitle">"DomainKeys Identified Mail (DKIM) Author Domain Signing Practices (ADSP)"</span>, <span class="seriesInfo">RFC 5617</span>, <span class="seriesInfo">DOI 10.17487/RFC5617</span>, <time datetime="2009-08">August 2009</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc5617">https://www.rfc-editor.org/info/rfc5617</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC6377">[RFC6377]</dt>
+<dd>
+<span class="refAuthor">Kucherawy, M.</span>, <span class="refTitle">"DomainKeys Identified Mail (DKIM) and Mailing Lists"</span>, <span class="seriesInfo">BCP 167</span>, <span class="seriesInfo">RFC 6377</span>, <span class="seriesInfo">DOI 10.17487/RFC6377</span>, <time datetime="2011-09">September 2011</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc6377">https://www.rfc-editor.org/info/rfc6377</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC7858">[RFC7858]</dt>
+<dd>
+<span class="refAuthor">Hu, Z.</span><span class="refAuthor">, Zhu, L.</span><span class="refAuthor">, Heidemann, J.</span><span class="refAuthor">, Mankin, A.</span><span class="refAuthor">, Wessels, D.</span><span class="refAuthor">, and P. Hoffman</span>, <span class="refTitle">"Specification for DNS over Transport Layer Security (TLS)"</span>, <span class="seriesInfo">RFC 7858</span>, <span class="seriesInfo">DOI 10.17487/RFC7858</span>, <time datetime="2016-05">May 2016</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc7858">https://www.rfc-editor.org/info/rfc7858</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8020">[RFC8020]</dt>
+<dd>
+<span class="refAuthor">Bortzmeyer, S.</span><span class="refAuthor"> and S. Huque</span>, <span class="refTitle">"NXDOMAIN: There Really Is Nothing Underneath"</span>, <span class="seriesInfo">RFC 8020</span>, <span class="seriesInfo">DOI 10.17487/RFC8020</span>, <time datetime="2016-11">November 2016</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8020">https://www.rfc-editor.org/info/rfc8020</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8126">[RFC8126]</dt>
+<dd>
+<span class="refAuthor">Cotton, M.</span><span class="refAuthor">, Leiba, B.</span><span class="refAuthor">, and T. Narten</span>, <span class="refTitle">"Guidelines for Writing an IANA Considerations Section in RFCs"</span>, <span class="seriesInfo">BCP 26</span>, <span class="seriesInfo">RFC 8126</span>, <span class="seriesInfo">DOI 10.17487/RFC8126</span>, <time datetime="2017-06">June 2017</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8126">https://www.rfc-editor.org/info/rfc8126</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8174">[RFC8174]</dt>
+<dd>
+<span class="refAuthor">Leiba, B.</span>, <span class="refTitle">"Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 8174</span>, <span class="seriesInfo">DOI 10.17487/RFC8174</span>, <time datetime="2017-05">May 2017</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8174">https://www.rfc-editor.org/info/rfc8174</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8484">[RFC8484]</dt>
+<dd>
+<span class="refAuthor">Hoffman, P.</span><span class="refAuthor"> and P. McManus</span>, <span class="refTitle">"DNS Queries over HTTPS (DoH)"</span>, <span class="seriesInfo">RFC 8484</span>, <span class="seriesInfo">DOI 10.17487/RFC8484</span>, <time datetime="2018-10">October 2018</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8484">https://www.rfc-editor.org/info/rfc8484</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8601">[RFC8601]</dt>
+<dd>
+<span class="refAuthor">Kucherawy, M.</span>, <span class="refTitle">"Message Header Field for Indicating Message Authentication Status"</span>, <span class="seriesInfo">RFC 8601</span>, <span class="seriesInfo">DOI 10.17487/RFC8601</span>, <time datetime="2019-05">May 2019</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8601">https://www.rfc-editor.org/info/rfc8601</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+</dl>
+</section>
+<div id="technology-considerations">
+<section id="section-appendix.a">
+      <h2 id="name-technology-considerations">
+<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-technology-considerations" class="section-name selfRef">Technology Considerations</a>
+      </h2>
+<p id="section-appendix.a-1">This section documents some design decisions that were made in the
+development of DMARC.  Specifically, addressed here are some
+suggestions that were considered but not included in the design.
+This text is included to explain why they were considered and not
+included in this version.<a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
+<div id="s-mime">
+<section id="section-a.1">
+        <h2 id="name-s-mime">
+<a href="#section-a.1" class="section-number selfRef">A.1. </a><a href="#name-s-mime" class="section-name selfRef">S/MIME</a>
+        </h2>
+<p id="section-a.1-1">S/MIME, or Secure Multipurpose Internet Mail Extensions, is a
+standard for encryption and signing of MIME data in a message.  This
+was suggested and considered as a third security protocol for
+authenticating the source of a message.<a href="#section-a.1-1" class="pilcrow">¶</a></p>
+<p id="section-a.1-2">DMARC is focused on authentication at the domain level (i.e., the
+Domain Owner taking responsibility for the message), while S/MIME is
+really intended for user-to-user authentication and encryption.  This
+alone appears to make it a bad fit for DMARC's goals.<a href="#section-a.1-2" class="pilcrow">¶</a></p>
+<p id="section-a.1-3">S/MIME also suffers from the heavyweight problem of Public Key
+Infrastructure, which means that distribution of keys used to verify
+signatures needs to be incorporated.  In many instances, this alone
+is a showstopper.  There have been consistent promises that PKI
+usability and deployment will improve, but these have yet to
+materialize.  DMARC can revisit this choice after those barriers are
+addressed.<a href="#section-a.1-3" class="pilcrow">¶</a></p>
+<p id="section-a.1-4">S/MIME has extensive deployment in specific market segments
+(government, for example) but does not enjoy similar widespread
+deployment over the general Internet, and this shows no signs of
+changing.  DKIM and SPF both are deployed widely over the general
+Internet, and their adoption rates continue to be positive.<a href="#section-a.1-4" class="pilcrow">¶</a></p>
+<p id="section-a.1-5">Finally, experiments have shown that including S/MIME support in the
+initial version of DMARC would neither cause nor enable a substantial
+increase in the accuracy of the overall mechanism.<a href="#section-a.1-5" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="method-exclusion">
+<section id="section-a.2">
+        <h2 id="name-method-exclusion">
+<a href="#section-a.2" class="section-number selfRef">A.2. </a><a href="#name-method-exclusion" class="section-name selfRef">Method Exclusion</a>
+        </h2>
+<p id="section-a.2-1">It was suggested that DMARC include a mechanism by which a Domain
+Owner could tell Message Receivers not to attempt verification by one
+of the supported methods (e.g., "check DKIM, but not SPF").<a href="#section-a.2-1" class="pilcrow">¶</a></p>
+<p id="section-a.2-2">Specifically, consider a Domain Owner that has deployed one of the
+technologies, and that technology fails for some messages, but such
+failures don't cause enforcement action.  Deploying DMARC would cause
+enforcement action for policies other than "none", which would appear
+to exclude participation by that Domain Owner.<a href="#section-a.2-2" class="pilcrow">¶</a></p>
+<p id="section-a.2-3">The DMARC development team evaluated the idea of policy exception
+mechanisms on several occasions and invariably concluded that there
+was not a strong enough use case to include them.  The specific
+target audience for DMARC does not appear to have concerns about the
+failure modes of one or the other being a barrier to DMARC's
+adoption.<a href="#section-a.2-3" class="pilcrow">¶</a></p>
+<p id="section-a.2-4">In the scenario described above, the Domain Owner has a few options:<a href="#section-a.2-4" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-a.2-5">
+          <li id="section-a.2-5.1">
+            <p id="section-a.2-5.1.1">Tighten up its infrastructure to minimize the failure modes of
+the single deployed technology.<a href="#section-a.2-5.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-a.2-5.2">
+            <p id="section-a.2-5.2.1">Deploy the other supported authentication mechanism, to offset
+the failure modes of the first.<a href="#section-a.2-5.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-a.2-5.3">
+            <p id="section-a.2-5.3.1">Deploy DMARC in a reporting-only mode.<a href="#section-a.2-5.3.1" class="pilcrow">¶</a></p>
+</li>
+</ol>
+</section>
+</div>
+<div id="sender-header-field">
+<section id="section-a.3">
+        <h2 id="name-sender-header-field">
+<a href="#section-a.3" class="section-number selfRef">A.3. </a><a href="#name-sender-header-field" class="section-name selfRef">Sender Header Field</a>
+        </h2>
+<p id="section-a.3-1">It has been suggested in several message authentication efforts that
+the Sender header field be checked for an identifier of interest, as
+the standards indicate this as the proper way to indicate a
+re-mailing of content such as through a mailing list.  Most recently,
+it was a protocol-level option for DomainKeys, but on evolution to
+DKIM, this property was removed.<a href="#section-a.3-1" class="pilcrow">¶</a></p>
+<p id="section-a.3-2">The DMARC development team considered this and decided not to include
+support for doing so, for the following reasons:<a href="#section-a.3-2" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-a.3-3">
+          <li id="section-a.3-3.1">
+            <p id="section-a.3-3.1.1">The main user protection approach is to be concerned with what
+the user sees when a message is rendered.  There is no consistent
+behavior among MUAs regarding what to do with the content of the
+Sender field, if present.  Accordingly, supporting checking of
+the Sender identifier would mean applying policy to an identifier
+the end user might never actually see, which can create a vector
+for attack against end users by simply forging a Sender field
+containing some identifier that DMARC will like.<a href="#section-a.3-3.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-a.3-3.2">
+            <p id="section-a.3-3.2.1">Although it is certainly true that this is what the Sender field
+is for, its use in this way is also unreliable, making it a poor
+candidate for inclusion in the DMARC evaluation algorithm.<a href="#section-a.3-3.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-a.3-3.3">
+            <p id="section-a.3-3.3.1">Allowing multiple ways to discover policy introduces unacceptable
+ambiguity into the DMARC evaluation algorithm in terms of which
+policy is to be applied and when.<a href="#section-a.3-3.3.1" class="pilcrow">¶</a></p>
+</li>
+</ol>
+</section>
+</div>
+<div id="domain-existence-test">
+<section id="section-a.4">
+        <h2 id="name-domain-existence-test">
+<a href="#section-a.4" class="section-number selfRef">A.4. </a><a href="#name-domain-existence-test" class="section-name selfRef">Domain Existence Test</a>
+        </h2>
+<p id="section-a.4-1">A common practice among MTA operators, and indeed one documented in
+<span>[<a href="#RFC5617" class="xref">RFC5617</a>]</span>, is a test to determine domain existence prior to any more
+expensive processing.  This is typically done by querying the DNS for
+MX, A, or AAAA resource records for the name being evaluated and
+assuming that the domain is nonexistent if it could be determined
+that no such records were published for that domain name.<a href="#section-a.4-1" class="pilcrow">¶</a></p>
+<p id="section-a.4-2">The original pre-standardization version of this protocol included a
+mandatory check of this nature.  It was ultimately removed, as the
+method's error rate was too high without substantial manual tuning
+and heuristic work.  There are indeed use cases this work needs to
+address where such a method would return a negative result about a
+domain for which reporting is desired, such as a registered domain
+name that never sends legitimate mail and thus has none of these
+records present in the DNS. The addition of the "np=" tag in this
+version of the protocol is one way to address these use cases.<a href="#section-a.4-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="issues-with-adsp-in-operation">
+<section id="section-a.5">
+        <h2 id="name-issues-with-adsp-in-operati">
+<a href="#section-a.5" class="section-number selfRef">A.5. </a><a href="#name-issues-with-adsp-in-operati" class="section-name selfRef">Issues with ADSP in Operation</a>
+        </h2>
+<p id="section-a.5-1">DMARC has been characterized as a "super-ADSP" of sorts.<a href="#section-a.5-1" class="pilcrow">¶</a></p>
+<p id="section-a.5-2">Contributors to DMARC have compiled a list of issues associated with
+ADSP, gained from operational experience, that have influenced the
+direction of DMARC:<a href="#section-a.5-2" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-a.5-3">
+          <li id="section-a.5-3.1">
+            <p id="section-a.5-3.1.1">ADSP has no support for subdomains, i.e., the ADSP record for
+example.com does not explicitly or implicitly apply to
+subdomain.example.com.  If wildcarding is not applied, then
+spammers can trivially bypass ADSP by sending from a subdomain
+with no ADSP record.<a href="#section-a.5-3.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-a.5-3.2">
+            <p id="section-a.5-3.2.1">Nonexistent subdomains are explicitly out of scope in ADSP.
+There is nothing in ADSP that states receivers should simply
+reject mail from NXDOMAINs regardless of ADSP policy (which of
+course allows spammers to trivially bypass ADSP by sending email
+from nonexistent subdomains).<a href="#section-a.5-3.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-a.5-3.3">
+            <p id="section-a.5-3.3.1">ADSP has no operational advice on when to look up the ADSP
+record.<a href="#section-a.5-3.3.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-a.5-3.4">
+            <p id="section-a.5-3.4.1">ADSP has no support for using SPF as an auxiliary mechanism to
+DKIM.<a href="#section-a.5-3.4.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-a.5-3.5">
+            <p id="section-a.5-3.5.1">ADSP has no support for a slow rollout, i.e., no way to configure
+a percentage of email on which the receiver should apply the
+policy.  This is important for large-volume senders.<a href="#section-a.5-3.5.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-a.5-3.6">
+            <p id="section-a.5-3.6.1">ADSP has no explicit support for an intermediate phase where the
+receiver quarantines (e.g., sends to the recipient's "spam"
+folder) rather than rejects the email.<a href="#section-a.5-3.6.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-a.5-3.7">
+            <p id="section-a.5-3.7.1">The binding between the "From" header domain and DKIM is too
+tight for ADSP; they must match exactly.<a href="#section-a.5-3.7.1" class="pilcrow">¶</a></p>
+</li>
+</ol>
+</section>
+</div>
+<div id="organizational-domain-discovery-issues">
+<section id="section-a.6">
+        <h2 id="name-organizational-domain-disco">
+<a href="#section-a.6" class="section-number selfRef">A.6. </a><a href="#name-organizational-domain-disco" class="section-name selfRef">Organizational Domain Discovery Issues</a>
+        </h2>
+<p id="section-a.6-1">Although protocols like ADSP are useful for "protecting" a specific
+domain name, they are not helpful at protecting subdomains.  If one
+wished to protect "example.com" by requiring via ADSP that all mail
+bearing an RFC5322.From domain of "example.com" be signed, this would
+"protect" that domain; however, one could then craft an email whose
+RFC5322.From domain is "security.example.com", and ADSP would not
+provide any protection.  One could use a DNS wildcard, but this can
+undesirably interfere with other DNS activity; one could add ADSP
+records as fraudulent domains are discovered, but this solution does
+not scale and is a purely reactive measure against abuse.<a href="#section-a.6-1" class="pilcrow">¶</a></p>
+<p id="section-a.6-2">The DNS does not provide a method by which the "domain of record", or
+the domain that was actually registered with a domain registrar, can
+be determined given an arbitrary domain name.  Suggestions have been
+made that attempt to glean such information from SOA or NS resource
+records, but these too are not fully reliable, as the partitioning of
+the DNS is not always done at administrative boundaries.<a href="#section-a.6-2" class="pilcrow">¶</a></p>
+<p id="section-a.6-3">When seeking domain-specific policy based on an arbitrary domain
+name, one could "climb the tree", dropping labels off the left end of
+the name until the root is reached or a policy is discovered, but
+then one could craft a name that has a large number of nonsense
+labels; this would cause a Mail Receiver to attempt a large number of
+queries in search of a policy record.  Sending many such messages
+constitutes an amplified denial-of-service attack.<a href="#section-a.6-3" class="pilcrow">¶</a></p>
+<p id="section-a.6-4">The Organizational Domain mechanism is a necessary component to the
+goals of DMARC.  The method described in <a href="#determining-the-organizational-domain" class="xref">Section 3.15</a> is far from
+perfect but serves this purpose reasonably well without adding undue
+burden or semantics to the DNS.  If a method is created to do so that
+is more reliable and secure than the use of a public suffix list,
+DMARC should be amended to use that method as soon as it is generally
+available.<a href="#section-a.6-4" class="pilcrow">¶</a></p>
+<div id="public-suffix-lists">
+<section id="section-a.6.1">
+          <h3 id="name-public-suffix-lists">
+<a href="#section-a.6.1" class="section-number selfRef">A.6.1. </a><a href="#name-public-suffix-lists" class="section-name selfRef">Public Suffix Lists</a>
+          </h3>
+<p id="section-a.6.1-1">A public suffix list for the purposes of determining the
+Organizational Domain can be obtained from various sources.  The most
+common one is maintained by the Mozilla Foundation and made public at
+<a href="http://publicsuffix.org">http://publicsuffix.org</a>.  License terms governing the use of that
+list are available at that URI.<a href="#section-a.6.1-1" class="pilcrow">¶</a></p>
+<p id="section-a.6.1-2">Note that if operators use a variety of public suffix lists,
+interoperability will be difficult or impossible to guarantee.<a href="#section-a.6.1-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="removal-of-the-pct-tag">
+<section id="section-a.7">
+        <h2 id="name-removal-of-the-pct-tag">
+<a href="#section-a.7" class="section-number selfRef">A.7. </a><a href="#name-removal-of-the-pct-tag" class="section-name selfRef">Removal of the "pct" Tag</a>
+        </h2>
+<p id="section-a.7-1">An earlier informational version of the DMARC protocol <span>[<a href="#RFC7489" class="xref">RFC7489</a>]</span>
+included a "pct" tag and specified all integers from 0 to 100 inclusive
+as valid values for the tag. The intent of the tag was to provide domain
+owners with a method to gradually change their preferred assessment policy
+(the p= tag) from 'none' to 'quarantine' or from 'quarantine' to 'reject'
+by requesting the stricter treatment for just a percentage of messages
+that produced DMARC results of "fail".<a href="#section-a.7-1" class="pilcrow">¶</a></p>
+<p id="section-a.7-2">Operational experience and mathematics (specifically the Probability Mass
+Function as applied to Binomial Distributions) showed that the pct tag
+was usually not accurately applied, unless the value specified was either "0"
+or "100" (the default), and the inaccuracies with other values varied widely
+from implementation to implementation. The default value was easily implemented,
+as it required no special processing on the part of the message receiver, while
+the value of "0" took on unintended significance as a value used by some
+intermediaries and mailbox providers as an indicator to deviate from
+standard handling of the message, usually by rewriting the RFC5322.From
+header in an effort to avoid DMARC failures downstream.<a href="#section-a.7-2" class="pilcrow">¶</a></p>
+<p id="section-a.7-3">These custom actions when the pct= tag was set to "0" proved valuable to the
+email community. In particular, header rewriting by an intermediary meant
+that a Domain Owner's aggregate reports could reveal to the Domain Owner
+how much of its traffic was routing through intermediaries that don't rewrite
+the RFC5322.From header. It required work on the part of the Domain Owner to
+compare aggregate reports from before and after the p= value was changed
+and pct= was included in the DMARC policy record with a value of "0", but
+the data was there. Consequently, knowing how much mail was subject to
+possible DMARC failure due to lack of RFC5322.From header rewriting by
+intermediaries could assist the Domain Owner in choosing whether or not
+to proceed from an applied policy of p=none to p=quarantine or p=reject.
+Armed with this knowledge, the Domain Owner could make an informed decision
+regarding subjecting its mail traffic to possible DMARC failures based on
+the Domain Owner's tolerance for such things.<a href="#section-a.7-3" class="pilcrow">¶</a></p>
+<p id="section-a.7-4">Because of the value provided by "pct=0" to Domain Owners, it was logical
+to keep this functionality in the protocol; at the same time it didn't make
+sense to support a tag named "pct" that had only two valid values. This version
+of the DMARC protocol therefore introduces the "t" tag as shorthand for "testing",
+with the valid values of "y" and "n", which are meant to be analogous in their
+application by mailbox providers and intermediaries to the "pct" tag values
+"0" and "100", respectively.<a href="#section-a.7-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="examples">
+<section id="section-appendix.b">
+      <h2 id="name-examples">
+<a href="#section-appendix.b" class="section-number selfRef">Appendix B. </a><a href="#name-examples" class="section-name selfRef">Examples</a>
+      </h2>
+<p id="section-appendix.b-1">This section illustrates both the Domain Owner side and the Mail
+Receiver side of a DMARC exchange.<a href="#section-appendix.b-1" class="pilcrow">¶</a></p>
+<div id="identifier-alignment-examples">
+<section id="section-b.1">
+        <h2 id="name-identifier-alignment-exampl">
+<a href="#section-b.1" class="section-number selfRef">B.1. </a><a href="#name-identifier-alignment-exampl" class="section-name selfRef">Identifier Alignment Examples</a>
+        </h2>
+<p id="section-b.1-1">The following examples illustrate the DMARC mechanism's use of
+Identifier Alignment.  For brevity's sake, only message headers are
+shown, as message bodies are not considered when conducting DMARC
+checks.<a href="#section-b.1-1" class="pilcrow">¶</a></p>
+<div id="spf">
+<section id="section-b.1.1">
+          <h3 id="name-spf">
+<a href="#section-b.1.1" class="section-number selfRef">B.1.1. </a><a href="#name-spf" class="section-name selfRef">SPF</a>
+          </h3>
+<p id="section-b.1.1-1">The following SPF examples assume that SPF produces a passing result.
+Alignment cannot exist if SPF does not produce a passing result.<a href="#section-b.1.1-1" class="pilcrow">¶</a></p>
+<p id="section-b.1.1-2">Example 1: SPF in alignment:<a href="#section-b.1.1-2" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.1.1-3">
+<pre>     MAIL FROM: &lt;sender@example.com&gt;
+
+     From: sender@example.com
+     Date: Fri, Feb 15 2002 16:54:30 -0800
+     To: receiver@example.org
+     Subject: here's a sample
+</pre><a href="#section-b.1.1-3" class="pilcrow">¶</a>
+</div>
+<p id="section-b.1.1-4">In this case, the RFC5321.MailFrom parameter and the RFC5322.From
+header field have identical DNS domains.  Thus, the identifiers are in
+strict alignment.<a href="#section-b.1.1-4" class="pilcrow">¶</a></p>
+<p id="section-b.1.1-5">Example 2: SPF in alignment (parent):<a href="#section-b.1.1-5" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.1.1-6">
+<pre>     MAIL FROM: &lt;sender@child.example.com&gt;
+
+     From: sender@example.com
+     Date: Fri, Feb 15 2002 16:54:30 -0800
+     To: receiver@example.org
+     Subject: here's a sample
+</pre><a href="#section-b.1.1-6" class="pilcrow">¶</a>
+</div>
+<p id="section-b.1.1-7">In this case, the RFC5322.From header parameter includes a DNS
+domain that is a parent of the RFC5321.MailFrom domain.  Thus, the
+identifiers are in relaxed alignment, because they both have the
+same Organizational Domain (example.com).<a href="#section-b.1.1-7" class="pilcrow">¶</a></p>
+<p id="section-b.1.1-8">Example 3: SPF not in alignment:<a href="#section-b.1.1-8" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.1.1-9">
+<pre>     MAIL FROM: &lt;sender@example.net&gt;
+
+     From: sender@child.example.com
+     Date: Fri, Feb 15 2002 16:54:30 -0800
+     To: receiver@example.org
+     Subject: here's a sample
+</pre><a href="#section-b.1.1-9" class="pilcrow">¶</a>
+</div>
+<p id="section-b.1.1-10">In this case, the RFC5321.MailFrom parameter includes a DNS domain
+that is neither the same as, a parent of, nor a child of the
+RFC5322.From domain.  Thus, the identifiers are not in alignment.<a href="#section-b.1.1-10" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="dkim">
+<section id="section-b.1.2">
+          <h3 id="name-dkim">
+<a href="#section-b.1.2" class="section-number selfRef">B.1.2. </a><a href="#name-dkim" class="section-name selfRef">DKIM</a>
+          </h3>
+<p id="section-b.1.2-1">The examples below assume that the DKIM signatures pass verification.
+Alignment cannot exist with a DKIM signature that does not verify.<a href="#section-b.1.2-1" class="pilcrow">¶</a></p>
+<p id="section-b.1.2-2">Example 1: DKIM in alignment:<a href="#section-b.1.2-2" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.1.2-3">
+<pre>     DKIM-Signature: v=1; ...; d=example.com; ...
+     From: sender@example.com
+     Date: Fri, Feb 15 2002 16:54:30 -0800
+     To: receiver@example.org
+     Subject: here's a sample
+</pre><a href="#section-b.1.2-3" class="pilcrow">¶</a>
+</div>
+<p id="section-b.1.2-4">In this case, the DKIM "d=" parameter and the RFC5322.From header field have
+identical DNS domains.  Thus, the identifiers are in strict alignment.<a href="#section-b.1.2-4" class="pilcrow">¶</a></p>
+<p id="section-b.1.2-5">Example 2: DKIM in alignment (parent):<a href="#section-b.1.2-5" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.1.2-6">
+<pre>     DKIM-Signature: v=1; ...; d=example.com; ...
+     From: sender@child.example.com
+     Date: Fri, Feb 15 2002 16:54:30 -0800
+     To: receiver@example.org
+     Subject: here's a sample
+</pre><a href="#section-b.1.2-6" class="pilcrow">¶</a>
+</div>
+<p id="section-b.1.2-7">In this case, the DKIM signature's "d=" parameter includes a DNS
+domain that is a parent of the RFC5322.From domain.  Thus, the
+identifiers are in relaxed alignment, as they have the same
+Organizational Domain (example.com).<a href="#section-b.1.2-7" class="pilcrow">¶</a></p>
+<p id="section-b.1.2-8">Example 3: DKIM not in alignment:<a href="#section-b.1.2-8" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.1.2-9">
+<pre>     DKIM-Signature: v=1; ...; d=sample.net; ...
+     From: sender@child.example.com
+     Date: Fri, Feb 15 2002 16:54:30 -0800
+     To: receiver@example.org
+     Subject: here's a sample
+</pre><a href="#section-b.1.2-9" class="pilcrow">¶</a>
+</div>
+<p id="section-b.1.2-10">In this case, the DKIM signature's "d=" parameter includes a DNS
+domain that is neither the same as, a parent of, nor a child of the
+RFC5322.From domain.  Thus, the identifiers are not in alignment.<a href="#section-b.1.2-10" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="domain-owner-example">
+<section id="section-b.2">
+        <h2 id="name-domain-owner-example">
+<a href="#section-b.2" class="section-number selfRef">B.2. </a><a href="#name-domain-owner-example" class="section-name selfRef">Domain Owner Example</a>
+        </h2>
+<p id="section-b.2-1">A Domain Owner that wants to use DMARC should have already deployed
+and tested SPF and DKIM.  The next step is to publish a DNS record
+that advertises a DMARC policy for the Domain Owner's Organizational
+Domain.<a href="#section-b.2-1" class="pilcrow">¶</a></p>
+<div id="entire-domain-monitoring-only">
+<section id="section-b.2.1">
+          <h3 id="name-entire-domain-monitoring-on">
+<a href="#section-b.2.1" class="section-number selfRef">B.2.1. </a><a href="#name-entire-domain-monitoring-on" class="section-name selfRef">Entire Domain, Monitoring Only</a>
+          </h3>
+<p id="section-b.2.1-1">The owner of the domain "example.com" has deployed SPF and DKIM on
+its messaging infrastructure.  The owner wishes to begin using DMARC
+with a policy that will solicit aggregate feedback from receivers
+without affecting how the messages are processed, in order to:<a href="#section-b.2.1-1" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-b.2.1-2.1">
+              <p id="section-b.2.1-2.1.1">Confirm that its legitimate messages are authenticating correctly<a href="#section-b.2.1-2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-b.2.1-2.2">
+              <p id="section-b.2.1-2.2.1">Verify that all authorized message sources have implemented
+authentication measures<a href="#section-b.2.1-2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-b.2.1-2.3">
+              <p id="section-b.2.1-2.3.1">Determine how many messages from other sources would be affected
+by a blocking policy<a href="#section-b.2.1-2.3.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+<p id="section-b.2.1-3">The Domain Owner accomplishes this by constructing a policy record
+indicating that:<a href="#section-b.2.1-3" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-b.2.1-4.1">
+              <p id="section-b.2.1-4.1.1">The version of DMARC being used is "DMARC1" ("v=DMARC1;")<a href="#section-b.2.1-4.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-b.2.1-4.2">
+              <p id="section-b.2.1-4.2.1">Receivers should not alter how they treat these messages because
+of this DMARC policy record ("p=none")<a href="#section-b.2.1-4.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-b.2.1-4.3">
+              <p id="section-b.2.1-4.3.1">Aggregate feedback reports should be sent via email to the address
+"dmarc-feedback@example.com"
+("rua=mailto:dmarc-feedback@example.com")<a href="#section-b.2.1-4.3.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-b.2.1-4.4">
+              <p id="section-b.2.1-4.4.1">All messages from this Organizational Domain are subject to this
+policy (no "t" tag present, so the default of "n" applies).<a href="#section-b.2.1-4.4.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+<p id="section-b.2.1-5">The DMARC policy record might look like this when retrieved using a
+common command-line tool:<a href="#section-b.2.1-5" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.2.1-6">
+<pre>  % dig +short TXT _dmarc.example.com.
+  "v=DMARC1; p=none; rua=mailto:dmarc-feedback@example.com"
+</pre><a href="#section-b.2.1-6" class="pilcrow">¶</a>
+</div>
+<p id="section-b.2.1-7">To publish such a record, the DNS administrator for the Domain Owner
+creates an entry like the following in the appropriate zone file
+(following the conventional zone file format):<a href="#section-b.2.1-7" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.2.1-8">
+<pre>  ; DMARC record for the domain example.com
+
+  _dmarc  IN TXT ( "v=DMARC1; p=none; "
+                   "rua=mailto:dmarc-feedback@example.com" )
+</pre><a href="#section-b.2.1-8" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+<div id="entire-domain-monitoring-only-per-message-reports">
+<section id="section-b.2.2">
+          <h3 id="name-entire-domain-monitoring-onl">
+<a href="#section-b.2.2" class="section-number selfRef">B.2.2. </a><a href="#name-entire-domain-monitoring-onl" class="section-name selfRef">Entire Domain, Monitoring Only, Per-Message Reports</a>
+          </h3>
+<p id="section-b.2.2-1">The Domain Owner from the previous example has used the aggregate
+reporting to discover some messaging systems that had not yet
+implemented DKIM correctly, but they are still seeing periodic
+authentication failures.  In order to diagnose these intermittent
+problems, they wish to request per-message failure reports when
+authentication failures occur.<a href="#section-b.2.2-1" class="pilcrow">¶</a></p>
+<p id="section-b.2.2-2">Not all Receivers will honor such a request, but the Domain Owner
+feels that any reports it does receive will be helpful enough to
+justify publishing this record.  The default per-message report
+format (<span>[<a href="#RFC6591" class="xref">RFC6591</a>]</span>) meets the Domain Owner's needs in this scenario.<a href="#section-b.2.2-2" class="pilcrow">¶</a></p>
+<p id="section-b.2.2-3">The Domain Owner accomplishes this by adding the following to its
+policy record from <a href="#domain-owner-example" class="xref">Appendix B.2</a>:<a href="#section-b.2.2-3" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-b.2.2-4.1">Per-message failure reports should be sent via email to the
+address "auth-reports@example.com"
+("ruf=mailto:auth-reports@example.com")<a href="#section-b.2.2-4.1" class="pilcrow">¶</a>
+</li>
+</ul>
+<p id="section-b.2.2-5">The DMARC policy record might look like this when retrieved using a
+common command-line tool (the output shown would appear on a single
+line but is wrapped here for publication):<a href="#section-b.2.2-5" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.2.2-6">
+<pre>  % dig +short TXT _dmarc.example.com.
+  "v=DMARC1; p=none; rua=mailto:dmarc-feedback@example.com;
+   ruf=mailto:auth-reports@example.com"
+</pre><a href="#section-b.2.2-6" class="pilcrow">¶</a>
+</div>
+<p id="section-b.2.2-7">To publish such a record, the DNS administrator for the Domain Owner
+might create an entry like the following in the appropriate zone file
+(following the conventional zone file format):<a href="#section-b.2.2-7" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.2.2-8">
+<pre>  ; DMARC record for the domain example.com
+
+  _dmarc  IN TXT ( "v=DMARC1; p=none; "
+                    "rua=mailto:dmarc-feedback@example.com; "
+                    "ruf=mailto:auth-reports@example.com" )
+</pre><a href="#section-b.2.2-8" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+<div id="per-message-failure-reports-directed-to-third-party">
+<section id="section-b.2.3">
+          <h3 id="name-per-message-failure-reports">
+<a href="#section-b.2.3" class="section-number selfRef">B.2.3. </a><a href="#name-per-message-failure-reports" class="section-name selfRef">Per-Message Failure Reports Directed to Third Party</a>
+          </h3>
+<p id="section-b.2.3-1">The Domain Owner from the previous example is maintaining the same
+policy but now wishes to have a third party receive and process the
+per-message failure reports.  Again, not all Receivers will honor
+this request, but those that do may implement additional checks to
+verify that the third party wishes to receive the failure reports
+for this domain.<a href="#section-b.2.3-1" class="pilcrow">¶</a></p>
+<p id="section-b.2.3-2">The Domain Owner needs to alter its policy record from <a href="#entire-domain-monitoring-only-per-message-reports" class="xref">Appendix B.2.2</a>
+as follows:<a href="#section-b.2.3-2" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-b.2.3-3.1">Per-message failure reports should be sent via email to the
+address "auth-reports@thirdparty.example.net"
+("ruf=mailto:auth-reports@thirdparty.example.net")<a href="#section-b.2.3-3.1" class="pilcrow">¶</a>
+</li>
+</ul>
+<p id="section-b.2.3-4">The DMARC policy record might look like this when retrieved using a
+common command-line tool (the output shown would appear on a single
+line but is wrapped here for publication):<a href="#section-b.2.3-4" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.2.3-5">
+<pre>  % dig +short TXT _dmarc.example.com.
+  "v=DMARC1; p=none; rua=mailto:dmarc-feedback@example.com;
+   ruf=mailto:auth-reports@thirdparty.example.net"
+</pre><a href="#section-b.2.3-5" class="pilcrow">¶</a>
+</div>
+<p id="section-b.2.3-6">To publish such a record, the DNS administrator for the Domain Owner
+might create an entry like the following in the appropriate zone file
+(following the conventional zone file format):<a href="#section-b.2.3-6" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.2.3-7">
+<pre>  ; DMARC record for the domain example.com
+
+  _dmarc IN TXT ( "v=DMARC1; p=none; "
+                  "rua=mailto:dmarc-feedback@example.com; "
+                  "ruf=mailto:auth-reports@thirdparty.example.net" )
+</pre><a href="#section-b.2.3-7" class="pilcrow">¶</a>
+</div>
+<p id="section-b.2.3-8">Because the address used in the "ruf" tag is outside the
+Organizational Domain in which this record is published, conforming
+Receivers will implement additional checks as described in Section 3 of
+<span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span>.  In order to pass these additional
+checks, the third party will need to publish an additional DNS record
+as follows:<a href="#section-b.2.3-8" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-b.2.3-9.1">Given the DMARC record published by the Domain Owner at
+"_dmarc.example.com", the DNS administrator for the third party
+will need to publish a TXT resource record at
+"example.com._report._dmarc.thirdparty.example.net" with the value
+"v=DMARC1;".<a href="#section-b.2.3-9.1" class="pilcrow">¶</a>
+</li>
+</ul>
+<p id="section-b.2.3-10">The resulting DNS record might look like this when retrieved using a
+common command-line tool (the output shown would appear on a single
+line but is wrapped here for publication):<a href="#section-b.2.3-10" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.2.3-11">
+<pre>  % dig +short TXT example.com._report._dmarc.thirdparty.example.net
+  "v=DMARC1;"
+</pre><a href="#section-b.2.3-11" class="pilcrow">¶</a>
+</div>
+<p id="section-b.2.3-12">To publish such a record, the DNS administrator for example.net might
+create an entry like the following in the appropriate zone file
+(following the conventional zone file format):<a href="#section-b.2.3-12" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.2.3-13">
+<pre>  ; zone file for thirdparty.example.net
+  ; Accept DMARC failure reports on behalf of example.com
+
+  example.com._report._dmarc   IN   TXT    "v=DMARC1;"
+</pre><a href="#section-b.2.3-13" class="pilcrow">¶</a>
+</div>
+<p id="section-b.2.3-14">Mediators and other third parties should refer to Section 3 of <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span>
+for the full details of this mechanism.<a href="#section-b.2.3-14" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="subdomain-sampling-and-multiple-aggregate-report-uris">
+<section id="section-b.2.4">
+          <h3 id="name-subdomain-testing-and-multi">
+<a href="#section-b.2.4" class="section-number selfRef">B.2.4. </a><a href="#name-subdomain-testing-and-multi" class="section-name selfRef">Subdomain, Testing, and Multiple Aggregate Report URIs</a>
+          </h3>
+<p id="section-b.2.4-1">The Domain Owner has implemented SPF and DKIM in a subdomain used for
+pre-production testing of messaging services.  It now wishes to express
+a severity of concern for messages from this subdomain that fail to
+authenticate to indicate to participating receivers that use of this
+domain is not valid.<a href="#section-b.2.4-1" class="pilcrow">¶</a></p>
+<p id="section-b.2.4-2">As a first step, it will express that it considers to be suspicious
+messages using this subdomain that fail authentication. The goal here
+will be to enable examination of messages sent to mailboxes hosted by
+participating receivers as method for troubleshooting any existing
+authentication issues.  Aggregate feedback reports will be sent to
+a mailbox within the Organizational Domain, and to a mailbox at a third
+party selected and authorized to receive same by the Domain Owner.<a href="#section-b.2.4-2" class="pilcrow">¶</a></p>
+<p id="section-b.2.4-3">The Domain Owner will accomplish this by constructing a policy record
+indicating that:<a href="#section-b.2.4-3" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-b.2.4-4.1">
+              <p id="section-b.2.4-4.1.1">The version of DMARC being used is "DMARC1" ("v=DMARC1;")<a href="#section-b.2.4-4.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-b.2.4-4.2">
+              <p id="section-b.2.4-4.2.1">It is applied only to this subdomain (record is published at
+"_dmarc.test.example.com" and not "_dmarc.example.com")<a href="#section-b.2.4-4.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-b.2.4-4.3">
+              <p id="section-b.2.4-4.3.1">Receivers are advised that the Domain Owner considers messages
+that fail to authenticate to be suspicious ("p=quarantine")<a href="#section-b.2.4-4.3.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-b.2.4-4.4">
+              <p id="section-b.2.4-4.4.1">Aggregate feedback reports should be sent via email to the
+addresses "dmarc-feedback@example.com" and
+"example-tld-test@thirdparty.example.net"
+("rua=mailto:dmarc-feedback@example.com,
+ mailto:tld-test@thirdparty.example.net")<a href="#section-b.2.4-4.4.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-b.2.4-4.5">
+              <p id="section-b.2.4-4.5.1">The Domain Owner desires only that an actor performing a DMARC
+verification check apply any special handling rules it might have
+in place, such as rewriting the RFC53322.From header; the Domain
+Owner is testing its setup at this point, and so does not want
+the handling policy to be applied. ("t=y")<a href="#section-b.2.4-4.5.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+<p id="section-b.2.4-5">The DMARC policy record might look like this when retrieved using a
+common command-line tool (the output shown would appear on a single
+line but is wrapped here for publication):<a href="#section-b.2.4-5" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.2.4-6">
+<pre>  % dig +short TXT _dmarc.test.example.com
+  "v=DMARC1; p=quarantine; rua=mailto:dmarc-feedback@example.com,
+   mailto:tld-test@thirdparty.example.net t=y"
+</pre><a href="#section-b.2.4-6" class="pilcrow">¶</a>
+</div>
+<p id="section-b.2.4-7">To publish such a record, the DNS administrator for the Domain Owner
+might create an entry like the following in the appropriate zone
+file:<a href="#section-b.2.4-7" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.2.4-8">
+<pre>  ; DMARC record for the domain test.example.com
+
+  _dmarc IN  TXT  ( "v=DMARC1; p=quarantine; "
+                    "rua=mailto:dmarc-feedback@example.com,"
+                    "mailto:tld-test@thirdparty.example.net;"
+                    "t=y" )
+</pre><a href="#section-b.2.4-8" class="pilcrow">¶</a>
+</div>
+<p id="section-b.2.4-9">Once enough time has passed to allow for collecting enough reports to
+give the Domain Owner confidence that all legitimate email sent using
+the subdomain is properly authenticating and passing DMARC checks, then
+the Domain Owner can update the policy record to indicate that it considers
+authentication failures to be a clear indication that use of the subdomain
+is not valid. It would do this by altering the DNS record to advise
+receivers of its position on such messages ("p=reject").<a href="#section-b.2.4-9" class="pilcrow">¶</a></p>
+<p id="section-b.2.4-10">After alteration, the DMARC policy record might look like this when retrieved
+using a common command-line tool (the output shown would appear on a single
+line but is wrapped here for publication):<a href="#section-b.2.4-10" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.2.4-11">
+<pre>  % dig +short TXT _dmarc.test.example.com
+  "v=DMARC1; p=reject; rua=mailto:dmarc-feedback@example.com,
+   mailto:tld-test@thirdparty.example.net"
+</pre><a href="#section-b.2.4-11" class="pilcrow">¶</a>
+</div>
+<p id="section-b.2.4-12">To publish such a record, the DNS administrator for the Domain Owner
+might create an entry like the following in the appropriate zone
+file:<a href="#section-b.2.4-12" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.2.4-13">
+<pre>  ; DMARC record for the domain test.example.com
+
+  _dmarc IN  TXT  ( "v=DMARC1; p=reject; "
+                    "rua=mailto:dmarc-feedback@example.com,"
+                    "mailto:tld-test@thirdparty.example.net" )
+</pre><a href="#section-b.2.4-13" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+</section>
+</div>
+<div id="mail-receiver-example">
+<section id="section-b.3">
+        <h2 id="name-mail-receiver-example">
+<a href="#section-b.3" class="section-number selfRef">B.3. </a><a href="#name-mail-receiver-example" class="section-name selfRef">Mail Receiver Example</a>
+        </h2>
+<p id="section-b.3-1">A Mail Receiver that wants to use DMARC should already be checking
+SPF and DKIM, and possess the ability to collect relevant information
+from various email-processing stages to provide feedback to Domain
+Owners (possibly via Report Receivers).<a href="#section-b.3-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="processing-of-smtp-time">
+<section id="section-b.4">
+        <h2 id="name-processing-of-smtp-time">
+<a href="#section-b.4" class="section-number selfRef">B.4. </a><a href="#name-processing-of-smtp-time" class="section-name selfRef">Processing of SMTP Time</a>
+        </h2>
+<p id="section-b.4-1">An optimal DMARC-enabled Mail Receiver performs authentication and
+Identifier Alignment checking during the SMTP <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span> conversation.<a href="#section-b.4-1" class="pilcrow">¶</a></p>
+<p id="section-b.4-2">Prior to returning a final reply to the DATA command, the Mail
+Receiver's MTA has performed:<a href="#section-b.4-2" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-b.4-3">
+          <li id="section-b.4-3.1">
+            <p id="section-b.4-3.1.1">An SPF check to determine an SPF-authenticated Identifier.<a href="#section-b.4-3.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-b.4-3.2">
+            <p id="section-b.4-3.2.1">DKIM checks that yield one or more DKIM-authenticated
+Identifiers.<a href="#section-b.4-3.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-b.4-3.3">
+            <p id="section-b.4-3.3.1">A DMARC policy lookup.<a href="#section-b.4-3.3.1" class="pilcrow">¶</a></p>
+</li>
+</ol>
+<p id="section-b.4-4">The presence of an Author Domain DMARC record indicates that the Mail
+Receiver should continue with DMARC-specific processing before
+returning a reply to the DATA command.<a href="#section-b.4-4" class="pilcrow">¶</a></p>
+<p id="section-b.4-5">Given a DMARC record and the set of Authenticated Identifiers, the
+Mail Receiver checks to see if the Authenticated Identifiers align
+with the Author Domain (taking into consideration any strict versus
+relaxed options found in the DMARC record).<a href="#section-b.4-5" class="pilcrow">¶</a></p>
+<p id="section-b.4-6">For example, the following sample data is considered to be from a
+piece of email originating from the Domain Owner of "example.com":<a href="#section-b.4-6" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.4-7">
+<pre>  Author Domain: example.com
+  SPF-authenticated Identifier: mail.example.com
+  DKIM-authenticated Identifier: example.com
+  DMARC record:
+    "v=DMARC1; p=reject; aspf=r;
+     rua=mailto:dmarc-feedback@example.com"
+</pre><a href="#section-b.4-7" class="pilcrow">¶</a>
+</div>
+<p id="section-b.4-8">In the above sample, both the SPF-authenticated Identifier and the
+DKIM-authenticated Identifier align with the Author Domain.  The Mail
+Receiver considers the above email to pass the DMARC check, avoiding
+the "reject" policy that is requested to be applied to email that fails
+to pass the DMARC check.<a href="#section-b.4-8" class="pilcrow">¶</a></p>
+<p id="section-b.4-9">If no Authenticated Identifiers align with the Author Domain, then
+the Mail Receiver applies the DMARC-record-specified policy.
+However, before this action is taken, the Mail Receiver can consult
+external information to override the Domain Owner's Assessment Policy.<br>
+For example, if the Mail Receiver knows that this particular email
+came from a known and trusted forwarder (that happens to break both
+SPF and DKIM), then the Mail Receiver may choose to ignore the Domain
+Owner's policy.<a href="#section-b.4-9" class="pilcrow">¶</a></p>
+<p id="section-b.4-10">The Mail Receiver is now ready to reply to the DATA command.  If the
+DMARC check yields that the message is to be rejected, then the Mail
+Receiver replies with a 5xy code to inform the sender of failure.  If
+the DMARC check cannot be resolved due to transient network errors,
+then the Mail Receiver replies with a 4xy code to inform the sender
+as to the need to reattempt delivery later.  If the DMARC check
+yields a passing message, then the Mail Receiver continues on with
+email processing, perhaps using the result of the DMARC check as an
+input to additional processing modules such as a domain reputation
+query.<a href="#section-b.4-10" class="pilcrow">¶</a></p>
+<p id="section-b.4-11">Before exiting DMARC-specific processing, the Mail Receiver checks to
+see if the Author Domain DMARC record requests AFRF-based reporting.
+If so, then the Mail Receiver can emit an AFRF to the reporting
+address supplied in the DMARC record.<a href="#section-b.4-11" class="pilcrow">¶</a></p>
+<p id="section-b.4-12">At the exit of DMARC-specific processing, the Mail Receiver captures
+(through logging or direct insertion into a data store) the result of
+DMARC processing.  Captured information is used to build feedback for
+Domain Owner consumption.  This is not necessary if the Domain Owner
+has not requested aggregate reports, i.e., no "rua" tag was found in
+the policy record.<a href="#section-b.4-12" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="utilization-of-aggregate-feedback-example">
+<section id="section-b.5">
+        <h2 id="name-utilization-of-aggregate-fe">
+<a href="#section-b.5" class="section-number selfRef">B.5. </a><a href="#name-utilization-of-aggregate-fe" class="section-name selfRef">Utilization of Aggregate Feedback: Example</a>
+        </h2>
+<p id="section-b.5-1">Aggregate feedback is consumed by Domain Owners to verify their
+understanding of how a given domain is being processed by the Mail
+Receiver.  Aggregate reporting data on emails that pass all
+DMARC-supporting authentication checks is used by Domain Owners to
+verify that their authentication practices remain accurate.  For
+example, if a third party is sending on behalf of a Domain Owner,
+the Domain Owner can use aggregate report data to verify ongoing
+authentication practices of the third party.<a href="#section-b.5-1" class="pilcrow">¶</a></p>
+<p id="section-b.5-2">Data on email that only partially passes underlying authentication
+checks provides visibility into problems that need to be addressed by
+the Domain Owner.  For example, if either SPF or DKIM fails to pass,
+the Domain Owner is provided with enough information to either
+directly correct the problem or understand where authentication-
+breaking changes are being introduced in the email transmission path.
+If authentication-breaking changes due to email transmission path
+cannot be directly corrected, then the Domain Owner at least
+maintains an understanding of the effect of DMARC-based policies upon
+the Domain Owner's email.<a href="#section-b.5-2" class="pilcrow">¶</a></p>
+<p id="section-b.5-3">Data on email that fails all underlying authentication checks
+provides baseline visibility on how the Domain Owner's domain is
+being received at the Mail Receiver.  Based on this visibility, the
+Domain Owner can begin deployment of authentication technologies
+across uncovered email sources, if the mail that is failing the checks
+was generated by or on behalf of the Domain Owner.  Data regarding
+failing authentication checks can also allow the Domain Owner to
+come to an understanding of how its domain is being misused.<a href="#section-b.5-3" class="pilcrow">¶</a></p>
+<p id="section-b.5-4">(Aggregate report example should be moved to <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span>)<a href="#section-b.5-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="change-log">
+<section id="section-appendix.c">
+      <h2 id="name-change-log">
+<a href="#section-appendix.c" class="section-number selfRef">Appendix C. </a><a href="#name-change-log" class="section-name selfRef">Change Log</a>
+      </h2>
+<div id="january-5-2021">
+<section id="section-c.1">
+        <h2 id="name-january-5-2021">
+<a href="#section-c.1" class="section-number selfRef">C.1. </a><a href="#name-january-5-2021" class="section-name selfRef">January 5, 2021</a>
+        </h2>
+<div id="ticket-80-dmarcbis-should-have-clear-and-concise-defintion-of-dmarc">
+<section id="section-c.1.1">
+          <h3 id="name-ticket-80-dmarcbis-should-h">
+<a href="#section-c.1.1" class="section-number selfRef">C.1.1. </a><a href="#name-ticket-80-dmarcbis-should-h" class="section-name selfRef">Ticket 80 - DMARCbis SHould Have Clear and Concise Defintion of DMARC</a>
+          </h3>
+<ul>
+<li id="section-c.1.1-1.1">Updated text for Abstract and Introduction sections.<a href="#section-c.1.1-1.1" class="pilcrow">¶</a>
+</li>
+<li id="section-c.1.1-1.2">Diffs are recorded here - <a href="https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/1/files">https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/1/files</a><a href="#section-c.1.1-1.2" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+</section>
+</div>
+<div id="february-4-2021">
+<section id="section-c.2">
+        <h2 id="name-february-4-2021">
+<a href="#section-c.2" class="section-number selfRef">C.2. </a><a href="#name-february-4-2021" class="section-name selfRef">February 4, 2021</a>
+        </h2>
+<div id="ticket-1-spf-rfc-4408-vs-7208">
+<section id="section-c.2.1">
+          <h3 id="name-ticket-1-spf-rfc-4408-vs-72">
+<a href="#section-c.2.1" class="section-number selfRef">C.2.1. </a><a href="#name-ticket-1-spf-rfc-4408-vs-72" class="section-name selfRef">Ticket 1 - SPF RFC 4408 vs 7208</a>
+          </h3>
+<ul>
+<li id="section-c.2.1-1.1">Some rearranging of text in the "SPF-Authenticated Identifiers" section<a href="#section-c.2.1-1.1" class="pilcrow">¶</a>
+</li>
+<li id="section-c.2.1-1.2">Clarification of the term "in alignment" in that same section<a href="#section-c.2.1-1.2" class="pilcrow">¶</a>
+</li>
+<li id="section-c.2.1-1.3">Diffs are here - <a href="https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/3/files">https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/3/files</a><a href="#section-c.2.1-1.3" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+</section>
+</div>
+<div id="february-10-2021">
+<section id="section-c.3">
+        <h2 id="name-february-10-2021">
+<a href="#section-c.3" class="section-number selfRef">C.3. </a><a href="#name-february-10-2021" class="section-name selfRef">February 10, 2021</a>
+        </h2>
+<div id="ticket-84-remove-erroneous-references-to-rfc3986">
+<section id="section-c.3.1">
+          <h3 id="name-ticket-84-remove-erroneous-">
+<a href="#section-c.3.1" class="section-number selfRef">C.3.1. </a><a href="#name-ticket-84-remove-erroneous-" class="section-name selfRef">Ticket 84 - Remove Erroneous References to RFC3986</a>
+          </h3>
+<ul>
+<li id="section-c.3.1-1.1">Several references to RFC3986 changed to RFC7208<a href="#section-c.3.1-1.1" class="pilcrow">¶</a>
+</li>
+<li id="section-c.3.1-1.2">Diffs are here - <a href="https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/4/files">https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/4/files</a><a href="#section-c.3.1-1.2" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+</section>
+</div>
+<div id="march-1-2021">
+<section id="section-c.4">
+        <h2 id="name-march-1-2021">
+<a href="#section-c.4" class="section-number selfRef">C.4. </a><a href="#name-march-1-2021" class="section-name selfRef">March 1, 2021</a>
+        </h2>
+<div id="design-team-work-begins">
+<section id="section-c.4.1">
+          <h3 id="name-design-team-work-begins">
+<a href="#section-c.4.1" class="section-number selfRef">C.4.1. </a><a href="#name-design-team-work-begins" class="section-name selfRef">Design Team Work Begins</a>
+          </h3>
+<ul>
+<li id="section-c.4.1-1.1">Added change log section to document<a href="#section-c.4.1-1.1" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+</section>
+</div>
+<div id="march-8-2021">
+<section id="section-c.5">
+        <h2 id="name-march-8-2021">
+<a href="#section-c.5" class="section-number selfRef">C.5. </a><a href="#name-march-8-2021" class="section-name selfRef">March 8, 2021</a>
+        </h2>
+<div id="removed-e-gustafsson-as-editor">
+<section id="section-c.5.1">
+          <h3 id="name-removed-e-gustafsson-as-edi">
+<a href="#section-c.5.1" class="section-number selfRef">C.5.1. </a><a href="#name-removed-e-gustafsson-as-edi" class="section-name selfRef">Removed E. Gustafsson as editor</a>
+          </h3>
+<ul>
+<li id="section-c.5.1-1.1">He withdrew as editor after a job change.<a href="#section-c.5.1-1.1" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+<div id="ticket-3-two-tiny-nits">
+<section id="section-c.5.2">
+          <h3 id="name-ticket-3-two-tiny-nits">
+<a href="#section-c.5.2" class="section-number selfRef">C.5.2. </a><a href="#name-ticket-3-two-tiny-nits" class="section-name selfRef">Ticket 3 - Two tiny nits</a>
+          </h3>
+<ul>
+<li id="section-c.5.2-1.1">Changes to wording in section 6.6.2, Determine Handling Policy, steps
+3 and 4.<a href="#section-c.5.2-1.1" class="pilcrow">¶</a>
+</li>
+<li id="section-c.5.2-1.2">New text documented here - <a href="https://trac.ietf.org/trac/dmarc/ticket/3#comment:6">https://trac.ietf.org/trac/dmarc/ticket/3#comment:6</a><a href="#section-c.5.2-1.2" class="pilcrow">¶</a>
+</li>
+<li id="section-c.5.2-1.3">No change to section 6.6.3, Policy Discovery; ticket seems to pre-date
+current text, which appears to have answered the concern raised.<a href="#section-c.5.2-1.3" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+<div id="ticket-4-definition-of-fo-parameter">
+<section id="section-c.5.3">
+          <h3 id="name-ticket-4-definition-of-fo-p">
+<a href="#section-c.5.3" class="section-number selfRef">C.5.3. </a><a href="#name-ticket-4-definition-of-fo-p" class="section-name selfRef">Ticket 4 - Definition of "fo" parameter</a>
+          </h3>
+<ul>
+<li id="section-c.5.3-1.1">Changes to wording in section 6.3, to bring clarity to use of colon-separated
+list as possible value to "fo"<a href="#section-c.5.3-1.1" class="pilcrow">¶</a>
+</li>
+<li id="section-c.5.3-1.2">New text documented here - <a href="https://trac.ietf.org/trac/dmarc/ticket/4#comment:4">https://trac.ietf.org/trac/dmarc/ticket/4#comment:4</a><a href="#section-c.5.3-1.2" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+</section>
+</div>
+<div id="march-16-2021">
+<section id="section-c.6">
+        <h2 id="name-march-16-2021">
+<a href="#section-c.6" class="section-number selfRef">C.6. </a><a href="#name-march-16-2021" class="section-name selfRef">March 16, 2021</a>
+        </h2>
+<div id="ticket-7-abnf-for-dmarc-record-is-slightly-wrong">
+<section id="section-c.6.1">
+          <h3 id="name-ticket-7-abnf-for-dmarc-rec">
+<a href="#section-c.6.1" class="section-number selfRef">C.6.1. </a><a href="#name-ticket-7-abnf-for-dmarc-rec" class="section-name selfRef">Ticket 7 - ABNF for dmarc-record is slightly wrong</a>
+          </h3>
+<ul>
+<li id="section-c.6.1-1.1">New text documented here - <a href="https://trac.ietf.org/trac/dmarc/ticket/7">https://trac.ietf.org/trac/dmarc/ticket/7</a><a href="#section-c.6.1-1.1" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+<div id="ticket-26-abnf-for-pct-allows-999">
+<section id="section-c.6.2">
+          <h3 id="name-ticket-26-abnf-for-pct-allo">
+<a href="#section-c.6.2" class="section-number selfRef">C.6.2. </a><a href="#name-ticket-26-abnf-for-pct-allo" class="section-name selfRef">Ticket 26 - ABNF for pct allows "999"</a>
+          </h3>
+<ul>
+<li id="section-c.6.2-1.1">Updated ABNF for dmarc-percent<a href="#section-c.6.2-1.1" class="pilcrow">¶</a>
+</li>
+<li id="section-c.6.2-1.2">New text documented here - <a href="https://trac.ietf.org/trac/dmarc/ticket/26#comment:6">https://trac.ietf.org/trac/dmarc/ticket/26#comment:6</a><a href="#section-c.6.2-1.2" class="pilcrow">¶</a>
+</li>
+<li id="section-c.6.2-1.3">Ticket 47, Remove pct= tag, rendered change obsolete<a href="#section-c.6.2-1.3" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+</section>
+</div>
+<div id="march-23-2021">
+<section id="section-c.7">
+        <h2 id="name-march-23-2021">
+<a href="#section-c.7" class="section-number selfRef">C.7. </a><a href="#name-march-23-2021" class="section-name selfRef">March 23, 2021</a>
+        </h2>
+<div id="ticket-75-using-wording-alternatives-to-disposition-dispose-and-the-like">
+<section id="section-c.7.1">
+          <h3 id="name-ticket-75-using-wording-alt">
+<a href="#section-c.7.1" class="section-number selfRef">C.7.1. </a><a href="#name-ticket-75-using-wording-alt" class="section-name selfRef">Ticket 75 - Using wording alternatives to 'disposition', 'dispose', and the like</a>
+          </h3>
+<ul>
+<li id="section-c.7.1-1.1">Changed disposition/dispose to "handling"<a href="#section-c.7.1-1.1" class="pilcrow">¶</a>
+</li>
+<li id="section-c.7.1-1.2">Diffs documented here - <a href="https://trac.ietf.org/trac/dmarc/ticket/75#comment:3">https://trac.ietf.org/trac/dmarc/ticket/75#comment:3</a><a href="#section-c.7.1-1.2" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+<div id="ticket-72-remove-absolute-requirement-for-p-tag-in-dmarc-record">
+<section id="section-c.7.2">
+          <h3 id="name-ticket-72-remove-absolute-r">
+<a href="#section-c.7.2" class="section-number selfRef">C.7.2. </a><a href="#name-ticket-72-remove-absolute-r" class="section-name selfRef">Ticket 72 - Remove absolute requirement for p= tag in DMARC record</a>
+          </h3>
+<ul>
+<li id="section-c.7.2-1.1">Changed from REQUIRED to RECOMMENDED, noted default with forward reference to discussion<a href="#section-c.7.2-1.1" class="pilcrow">¶</a>
+</li>
+<li id="section-c.7.2-1.2">Diffs documented here - <a href="https://trac.ietf.org/trac/dmarc/ticket/72#comment:3">https://trac.ietf.org/trac/dmarc/ticket/72#comment:3</a><a href="#section-c.7.2-1.2" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+</section>
+</div>
+<div id="march-29-2021">
+<section id="section-c.8">
+        <h2 id="name-march-29-2021">
+<a href="#section-c.8" class="section-number selfRef">C.8. </a><a href="#name-march-29-2021" class="section-name selfRef">March 29, 2021</a>
+        </h2>
+<div id="ticket-54-remove-or-expand-limits-on-number-of-recipients-per-report">
+<section id="section-c.8.1">
+          <h3 id="name-ticket-54-remove-or-expand-">
+<a href="#section-c.8.1" class="section-number selfRef">C.8.1. </a><a href="#name-ticket-54-remove-or-expand-" class="section-name selfRef">Ticket 54 - Remove or expand limits on number of recipients per report</a>
+          </h3>
+<ul>
+<li id="section-c.8.1-1.1">Removed limit<a href="#section-c.8.1-1.1" class="pilcrow">¶</a>
+</li>
+<li id="section-c.8.1-1.2">Diffs documented here - <a href="https://trac.ietf.org/trac/dmarc/ticket/54#comment:5">https://trac.ietf.org/trac/dmarc/ticket/54#comment:5</a><a href="#section-c.8.1-1.2" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+</section>
+</div>
+<div id="april-12-2021">
+<section id="section-c.9">
+        <h2 id="name-april-12-2021">
+<a href="#section-c.9" class="section-number selfRef">C.9. </a><a href="#name-april-12-2021" class="section-name selfRef">April 12, 2021</a>
+        </h2>
+<div id="ticket-50-remove-ri-tag">
+<section id="section-c.9.1">
+          <h3 id="name-ticket-50-remove-ri-tag">
+<a href="#section-c.9.1" class="section-number selfRef">C.9.1. </a><a href="#name-ticket-50-remove-ri-tag" class="section-name selfRef">Ticket 50 - Remove ri= tag</a>
+          </h3>
+<ul>
+<li id="section-c.9.1-1.1">Updated text to recommend against its usage, a la the ptr mechanism in RFC 7208<a href="#section-c.9.1-1.1" class="pilcrow">¶</a>
+</li>
+<li id="section-c.9.1-1.2">Diffs documented here - <a href="https://trac.ietf.org/trac/dmarc/ticket/50#comment:5">https://trac.ietf.org/trac/dmarc/ticket/50#comment:5</a><a href="#section-c.9.1-1.2" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+<div id="ticket-66-define-what-it-means-to-have-implemented-dmarc">
+<section id="section-c.9.2">
+          <h3 id="name-ticket-66-define-what-it-me">
+<a href="#section-c.9.2" class="section-number selfRef">C.9.2. </a><a href="#name-ticket-66-define-what-it-me" class="section-name selfRef">Ticket 66 - Define what it means to have implemented DMARC</a>
+          </h3>
+<ul>
+<li id="section-c.9.2-1.1">Proposed new text (taken straight from <a href="https://trac.ietf.org/trac/dmarc/ticket/66">https://trac.ietf.org/trac/dmarc/ticket/66</a>
+as replacement for current text in "Minimum Implemenatations"<a href="#section-c.9.2-1.1" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+<div id="ticket-96-tweaks-to-abstract-and-introduction">
+<section id="section-c.9.3">
+          <h3 id="name-ticket-96-tweaks-to-abstrac">
+<a href="#section-c.9.3" class="section-number selfRef">C.9.3. </a><a href="#name-ticket-96-tweaks-to-abstrac" class="section-name selfRef">Ticket 96 - Tweaks to Abstract and Introduction</a>
+          </h3>
+<ul>
+<li id="section-c.9.3-1.1">Changed phrase in Abstract to "an email author's domain name"<a href="#section-c.9.3-1.1" class="pilcrow">¶</a>
+</li>
+<li id="section-c.9.3-1.2">Changed phrase in Introduction to "reports about email use of the domain name"<a href="#section-c.9.3-1.2" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+</section>
+</div>
+<div id="april-13-2021">
+<section id="section-c.10">
+        <h2 id="name-april-13-2021">
+<a href="#section-c.10" class="section-number selfRef">C.10. </a><a href="#name-april-13-2021" class="section-name selfRef">April 13, 2021</a>
+        </h2>
+<div id="ticket-53-remove-reporting-message-size-chunking">
+<section id="section-c.10.1">
+          <h3 id="name-ticket-53-remove-reporting-">
+<a href="#section-c.10.1" class="section-number selfRef">C.10.1. </a><a href="#name-ticket-53-remove-reporting-" class="section-name selfRef">Ticket 53 - Remove reporting message size chunking</a>
+          </h3>
+<ul>
+<li id="section-c.10.1-1.1">Proposed text to remove all references to message size chunking<a href="#section-c.10.1-1.1" class="pilcrow">¶</a>
+</li>
+<li id="section-c.10.1-1.2">Data demonstrating lack of use of feature entered into ticket -
+<a href="https://trac.ietf.org/trac/dmarc/ticket/53#comment:4">https://trac.ietf.org/trac/dmarc/ticket/53#comment:4</a><a href="#section-c.10.1-1.2" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+<div id="ticket-52-remove-strict-alignment-and-adkim-and-aspf-tags">
+<section id="section-c.10.2">
+          <h3 id="name-ticket-52-remove-strict-ali">
+<a href="#section-c.10.2" class="section-number selfRef">C.10.2. </a><a href="#name-ticket-52-remove-strict-ali" class="section-name selfRef">Ticket 52 - Remove strict alignment (and adkim and aspf tags)</a>
+          </h3>
+<ul>
+<li id="section-c.10.2-1.1">Proposed text to remove all references to strict alignment<a href="#section-c.10.2-1.1" class="pilcrow">¶</a>
+</li>
+<li id="section-c.10.2-1.2">Data demonstrating lack of use of feature entered into ticket -
+<a href="https://trac.ietf.org/trac/dmarc/ticket/52#comment:2">https://trac.ietf.org/trac/dmarc/ticket/52#comment:2</a><a href="#section-c.10.2-1.2" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+<div id="ticket-47-remove-pct-tag">
+<section id="section-c.10.3">
+          <h3 id="name-ticket-47-remove-pct-tag">
+<a href="#section-c.10.3" class="section-number selfRef">C.10.3. </a><a href="#name-ticket-47-remove-pct-tag" class="section-name selfRef">Ticket 47 - Remove pct= tag</a>
+          </h3>
+<ul>
+<li id="section-c.10.3-1.1">Proposed text to remove all references to pct and message sampling<a href="#section-c.10.3-1.1" class="pilcrow">¶</a>
+</li>
+<li id="section-c.10.3-1.2">Data demonstrating lack of use of feature entered into ticket -
+<a href="https://trac.ietf.org/trac/dmarc/ticket/47#comment:4">https://trac.ietf.org/trac/dmarc/ticket/47#comment:4</a><a href="#section-c.10.3-1.2" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+<div id="ticket-2-flow-of-operations-text-in-dmarc-base">
+<section id="section-c.10.4">
+          <h3 id="name-ticket-2-flow-of-operations">
+<a href="#section-c.10.4" class="section-number selfRef">C.10.4. </a><a href="#name-ticket-2-flow-of-operations" class="section-name selfRef">Ticket 2 - Flow of operations text in dmarc-base</a>
+          </h3>
+<ul>
+<li id="section-c.10.4-1.1">Update ASCII Art<a href="#section-c.10.4-1.1" class="pilcrow">¶</a>
+</li>
+<li id="section-c.10.4-1.2">Proposed text to replace description of ASCII Art<a href="#section-c.10.4-1.2" class="pilcrow">¶</a>
+</li>
+<li id="section-c.10.4-1.3">Proposed text to update Domain Owner Actions section<a href="#section-c.10.4-1.3" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+</section>
+</div>
+<div id="april-14-2021">
+<section id="section-c.11">
+        <h2 id="name-april-14-2021">
+<a href="#section-c.11" class="section-number selfRef">C.11. </a><a href="#name-april-14-2021" class="section-name selfRef">April 14, 2021</a>
+        </h2>
+<div id="ticket-107-dmarcbis-should-take-a-stand-on-multi-valued-from-fields">
+<section id="section-c.11.1">
+          <h3 id="name-ticket-107-dmarcbis-should-">
+<a href="#section-c.11.1" class="section-number selfRef">C.11.1. </a><a href="#name-ticket-107-dmarcbis-should-" class="section-name selfRef">Ticket 107 - DMARCbis should take a stand on multi-valued From fields</a>
+          </h3>
+<ul>
+<li id="section-c.11.1-1.1">Proposed text that limits processing to only those times when all domains
+are the same.<a href="#section-c.11.1-1.1" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+<div id="ticket-82-deprecate-rf-and-maybe-fo-tag">
+<section id="section-c.11.2">
+          <h3 id="name-ticket-82-deprecate-rf-and-">
+<a href="#section-c.11.2" class="section-number selfRef">C.11.2. </a><a href="#name-ticket-82-deprecate-rf-and-" class="section-name selfRef">Ticket 82 - Deprecate rf= and maybe fo= tag</a>
+          </h3>
+<ul>
+<li id="section-c.11.2-1.1">Proposed text to deprecate rf= tag, while leaving fo= tag as is<a href="#section-c.11.2-1.1" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+<div id="ticket-85-proposed-change-to-wording-describing-p-tag-and-values">
+<section id="section-c.11.3">
+          <h3 id="name-ticket-85-proposed-change-t">
+<a href="#section-c.11.3" class="section-number selfRef">C.11.3. </a><a href="#name-ticket-85-proposed-change-t" class="section-name selfRef">Ticket 85 - Proposed change to wording describing 'p' tag and values</a>
+          </h3>
+<ul>
+<li id="section-c.11.3-1.1">The language expressing the semantics is proposed to be changed to be,
+in a sense, egocentric. How do I, the domain owner feel about (assess)
+the meaning of a DMARC failure?<a href="#section-c.11.3-1.1" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+</section>
+</div>
+<div id="april-15-2021">
+<section id="section-c.12">
+        <h2 id="name-april-15-2021">
+<a href="#section-c.12" class="section-number selfRef">C.12. </a><a href="#name-april-15-2021" class="section-name selfRef">April 15, 2021</a>
+        </h2>
+<div id="ticket-86-a-r-results-for-dmarc">
+<section id="section-c.12.1">
+          <h3 id="name-ticket-86-a-r-results-for-d">
+<a href="#section-c.12.1" class="section-number selfRef">C.12.1. </a><a href="#name-ticket-86-a-r-results-for-d" class="section-name selfRef">Ticket 86 - A-R results for DMARC</a>
+          </h3>
+<ul>
+<li id="section-c.12.1-1.1">Proposed text to add for polrec.p and polrec.domain methods for registry
+update.<a href="#section-c.12.1-1.1" class="pilcrow">¶</a>
+</li>
+<li id="section-c.12.1-1.2">Did not include polrec.pct due to proposal to remove pct tag (Ticket 47)<a href="#section-c.12.1-1.2" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+<div id="ticket-62-make-aggregate-reporting-a-normative-must">
+<section id="section-c.12.2">
+          <h3 id="name-ticket-62-make-aggregate-re">
+<a href="#section-c.12.2" class="section-number selfRef">C.12.2. </a><a href="#name-ticket-62-make-aggregate-re" class="section-name selfRef">Ticket 62 - Make aggregate reporting a normative MUST</a>
+          </h3>
+<ul>
+<li id="section-c.12.2-1.1">Proposed text to do just that in Mail Receiver Actions, section
+titled "Send Aggregate Reports"<a href="#section-c.12.2-1.1" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+</section>
+</div>
+<div id="april-19-2021">
+<section id="section-c.13">
+        <h2 id="name-april-19-2021">
+<a href="#section-c.13" class="section-number selfRef">C.13. </a><a href="#name-april-19-2021" class="section-name selfRef">April 19, 2021</a>
+        </h2>
+<div id="ticket-109-sanity-check-dmarcbis-document">
+<section id="section-c.13.1">
+          <h3 id="name-ticket-109-sanity-check-dma">
+<a href="#section-c.13.1" class="section-number selfRef">C.13.1. </a><a href="#name-ticket-109-sanity-check-dma" class="section-name selfRef">Ticket 109 - Sanity Check DMARCbis Document</a>
+          </h3>
+<ul>
+<li id="section-c.13.1-1.1">Updated document to remove all "original text"/"proposed text" couplets
+in favor of one (hopefully coherent) document full of proposed text
+changes.<a href="#section-c.13.1-1.1" class="pilcrow">¶</a>
+</li>
+<li id="section-c.13.1-1.2">Noted which tickets were the cause of whatever rfcdiff output will show
+in tracker<a href="#section-c.13.1-1.2" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+</section>
+</div>
+<div id="april-20-2021">
+<section id="section-c.14">
+        <h2 id="name-april-20-2021">
+<a href="#section-c.14" class="section-number selfRef">C.14. </a><a href="#name-april-20-2021" class="section-name selfRef">April 20, 2021</a>
+        </h2>
+<div id="ticket-108-changes-to-dmarcbis-for-psd">
+<section id="section-c.14.1">
+          <h3 id="name-ticket-108-changes-to-dmarc">
+<a href="#section-c.14.1" class="section-number selfRef">C.14.1. </a><a href="#name-ticket-108-changes-to-dmarc" class="section-name selfRef">Ticket 108 - Changes to DMARCbis for PSD</a>
+          </h3>
+<ul>
+<li id="section-c.14.1-1.1">Incorporating requests for changes to DMARCbis made in text of
+"Experimental DMARC Extension for Public Suffix Domains"
+(<a href="https://datatracker.ietf.org/doc/draft-ietf-dmarc-psd/">https://datatracker.ietf.org/doc/draft-ietf-dmarc-psd/</a>)<a href="#section-c.14.1-1.1" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+</section>
+</div>
+<div id="april-22-2021">
+<section id="section-c.15">
+        <h2 id="name-april-22-2021">
+<a href="#section-c.15" class="section-number selfRef">C.15. </a><a href="#name-april-22-2021" class="section-name selfRef">April 22, 2021</a>
+        </h2>
+<div id="ticket-104-update-the-security-considerations-section-11-3-on-dns">
+<section id="section-c.15.1">
+          <h3 id="name-ticket-104-update-the-secur">
+<a href="#section-c.15.1" class="section-number selfRef">C.15.1. </a><a href="#name-ticket-104-update-the-secur" class="section-name selfRef">Ticket 104 - Update the Security Considerations section 11.3 on DNS</a>
+          </h3>
+<ul>
+<li id="section-c.15.1-1.1">Updated text. Diffs are here - <a href="https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/31/files">https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/31/files</a><a href="#section-c.15.1-1.1" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+</section>
+</div>
+<div id="june-16-2021">
+<section id="section-c.16">
+        <h2 id="name-june-16-2021">
+<a href="#section-c.16" class="section-number selfRef">C.16. </a><a href="#name-june-16-2021" class="section-name selfRef">June 16, 2021</a>
+        </h2>
+<div id="publication-of-draft-ietf-dmarc-dmarcbis-02">
+<section id="section-c.16.1">
+          <h3 id="name-publication-of-draft-ietf-d">
+<a href="#section-c.16.1" class="section-number selfRef">C.16.1. </a><a href="#name-publication-of-draft-ietf-d" class="section-name selfRef">Publication of draft-ietf-dmarc-dmarcbis-02</a>
+          </h3>
+<ul>
+<li id="section-c.16.1-1.1">Includes final resolution for tickets 4, 47, 50, 52, 53, 54, and 82<a href="#section-c.16.1-1.1" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+</section>
+</div>
+<div id="august-12-2021">
+<section id="section-c.17">
+        <h2 id="name-august-12-2021">
+<a href="#section-c.17" class="section-number selfRef">C.17. </a><a href="#name-august-12-2021" class="section-name selfRef">August 12, 2021</a>
+        </h2>
+<div id="publication-of-draft-ietf-dmarc-dmarcbis-03">
+<section id="section-c.17.1">
+          <h3 id="name-publication-of-draft-ietf-dm">
+<a href="#section-c.17.1" class="section-number selfRef">C.17.1. </a><a href="#name-publication-of-draft-ietf-dm" class="section-name selfRef">Publication of draft-ietf-dmarc-dmarcbis-03</a>
+          </h3>
+<ul>
+<li id="section-c.17.1-1.1">Removal of "pct" tag<a href="#section-c.17.1-1.1" class="pilcrow">¶</a>
+</li>
+<li id="section-c.17.1-1.2">Addition of "t" tag<a href="#section-c.17.1-1.2" class="pilcrow">¶</a>
+</li>
+<li id="section-c.17.1-1.3">Rearranging of some text and formatting for better readability and consistency.<a href="#section-c.17.1-1.3" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+</section>
+</div>
+</section>
+</div>
+<div id="acknowledgements">
+<section id="section-appendix.d">
+      <h2 id="name-acknowledgements">
+<a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
+      </h2>
+<p id="section-appendix.d-1">DMARC and the draft version of this document submitted to the
+Independent Submission Editor were the result of lengthy efforts by
+an informal industry consortium: DMARC.org (see <a href="http://dmarc.org">http://dmarc.org</a>).
+Participating companies included Agari, American Greetings, AOL, Bank
+of America, Cloudmark, Comcast, Facebook, Fidelity Investments,
+Google, JPMorgan Chase &amp; Company, LinkedIn, Microsoft, Netease,
+PayPal, ReturnPath, The Trusted Domain Project, and Yahoo!.  Although
+the contributors and supporters are too numerous to mention, notable
+individual contributions were made by J. Trent Adams, Michael Adkins,
+Monica Chew, Dave Crocker, Tim Draegen, Steve Jones, Franck Martin,
+Brett McDowell, and Paul Midgen.  The contributors would also like to
+recognize the invaluable input and guidance that was provided early
+on by J.D. Falk.<a href="#section-appendix.d-1" class="pilcrow">¶</a></p>
+<p id="section-appendix.d-2">Additional contributions within the IETF context were made by Kurt
+Anderson, Michael Jack Assels, Les Barstow, Anne Bennett, Jim Fenton,
+J. Gomez, Mike Jones, Scott Kitterman, Eliot Lear, John Levine,
+S. Moonesamy, Rolf Sonneveld, Henry Timmes, and Stephen J. Turnbull.<a href="#section-appendix.d-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="authors-addresses">
+<section id="section-appendix.e">
+      <h2 id="name-authors-addresses">
+<a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
+      </h2>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Todd M. Herr</span></div>
+<div dir="auto" class="left"><span class="org">Valimail</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:todd.herr@valimail.com" class="email">todd.herr@valimail.com</a>
+</div>
+</address>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">John Levine</span></div>
+<div dir="auto" class="left"><span class="org">Standcore LLC</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:standards@standore.com" class="email">standards@standore.com</a>
+</div>
+</address>
+</section>
+</div>
+<script>const toc = document.getElementById("toc");
+toc.querySelector("h2").addEventListener("click", e => {
+  toc.classList.toggle("active");
+});
+toc.querySelector("nav").addEventListener("click", e => {
+  toc.classList.remove("active");
+});
+</script>
+</body>
+</html>

--- a/draft-ietf-dmarc-dmarcbis-04.html
+++ b/draft-ietf-dmarc-dmarcbis-04.html
@@ -12,7 +12,7 @@
 Reporting, and Conformance (DMARC) protocol. 
        DMARC permits the owner of an email author's domain name to enable
 verification of the domain's use, to indicate the Domain Owner's or
-Public Suffix Operator's severity of concern regarding failed
+Public Suffix Operator's message handling preference regarding failed
 verification, and to request reports about use of the domain name.
 Mail receiving organizations can use this information when evaluating
 handling choices for incoming mail. 
@@ -1113,7 +1113,7 @@ dd.break {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Herr (ed) &amp; Levine (ed)</td>
-<td class="center">Expires 21 May 2022</td>
+<td class="center">Expires 22 May 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1129,12 +1129,12 @@ dd.break {
 <a href="https://www.rfc-editor.org/rfc/rfc7489" class="eref">7489</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-11-17" class="published">17 November 2021</time>
+<time datetime="2021-11-18" class="published">18 November 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-05-21">21 May 2022</time></dd>
+<dd class="expires"><time datetime="2022-05-22">22 May 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1155,7 +1155,7 @@ dd.break {
 Reporting, and Conformance (DMARC) protocol.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
 <p id="section-abstract-2">DMARC permits the owner of an email author's domain name to enable
 verification of the domain's use, to indicate the Domain Owner's or
-Public Suffix Operator's severity of concern regarding failed
+Public Suffix Operator's message handling preference regarding failed
 verification, and to request reports about use of the domain name.
 Mail receiving organizations can use this information when evaluating
 handling choices for incoming mail.<a href="#section-abstract-2" class="pilcrow">¶</a></p>
@@ -1180,7 +1180,7 @@ handling choices for incoming mail.<a href="#section-abstract-2" class="pilcrow"
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 21 May 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 22 May 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1236,57 +1236,62 @@ handling choices for incoming mail.<a href="#section-abstract-2" class="pilcrow"
                 <p id="section-toc.1-1.3.2.1.1"><a href="#section-3.1" class="xref">3.1</a>.  <a href="#name-conventions-used-in-this-do" class="xref">Conventions Used in This Document</a><a href="#section-toc.1-1.3.2.1.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.3.2.2">
-                <p id="section-toc.1-1.3.2.2.1"><a href="#section-3.2" class="xref">3.2</a>.  <a href="#name-authenticated-identifiers" class="xref">Authenticated Identifiers</a><a href="#section-toc.1-1.3.2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.3">
-                <p id="section-toc.1-1.3.2.3.1"><a href="#section-3.3" class="xref">3.3</a>.  <a href="#name-author-domain" class="xref">Author Domain</a><a href="#section-toc.1-1.3.2.3.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.4">
-                <p id="section-toc.1-1.3.2.4.1"><a href="#section-3.4" class="xref">3.4</a>.  <a href="#name-domain-owner" class="xref">Domain Owner</a><a href="#section-toc.1-1.3.2.4.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.5">
-                <p id="section-toc.1-1.3.2.5.1"><a href="#section-3.5" class="xref">3.5</a>.  <a href="#name-identifier-alignment" class="xref">Identifier Alignment</a><a href="#section-toc.1-1.3.2.5.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.6">
-                <p id="section-toc.1-1.3.2.6.1"><a href="#section-3.6" class="xref">3.6</a>.  <a href="#name-longest-psd" class="xref">Longest PSD</a><a href="#section-toc.1-1.3.2.6.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.7">
-                <p id="section-toc.1-1.3.2.7.1"><a href="#section-3.7" class="xref">3.7</a>.  <a href="#name-mail-receiver" class="xref">Mail Receiver</a><a href="#section-toc.1-1.3.2.7.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.8">
-                <p id="section-toc.1-1.3.2.8.1"><a href="#section-3.8" class="xref">3.8</a>.  <a href="#name-non-existent-domains" class="xref">Non-existent Domains</a><a href="#section-toc.1-1.3.2.8.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.9">
-                <p id="section-toc.1-1.3.2.9.1"><a href="#section-3.9" class="xref">3.9</a>.  <a href="#name-organizational-domain" class="xref">Organizational Domain</a><a href="#section-toc.1-1.3.2.9.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.10">
-                <p id="section-toc.1-1.3.2.10.1"><a href="#section-3.10" class="xref">3.10</a>. <a href="#name-public-suffix-domain-psd" class="xref">Public Suffix Domain (PSD)</a><a href="#section-toc.1-1.3.2.10.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.11">
-                <p id="section-toc.1-1.3.2.11.1"><a href="#section-3.11" class="xref">3.11</a>. <a href="#name-public-suffix-operator-pso" class="xref">Public Suffix Operator (PSO)</a><a href="#section-toc.1-1.3.2.11.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.12">
-                <p id="section-toc.1-1.3.2.12.1"><a href="#section-3.12" class="xref">3.12</a>. <a href="#name-pso-controlled-domain-names" class="xref">PSO Controlled Domain Names</a><a href="#section-toc.1-1.3.2.12.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.13">
-                <p id="section-toc.1-1.3.2.13.1"><a href="#section-3.13" class="xref">3.13</a>. <a href="#name-report-receiver" class="xref">Report Receiver</a><a href="#section-toc.1-1.3.2.13.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.14">
-                <p id="section-toc.1-1.3.2.14.1"><a href="#section-3.14" class="xref">3.14</a>. <a href="#name-more-on-identifier-alignmen" class="xref">More on Identifier Alignment</a><a href="#section-toc.1-1.3.2.14.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.3.2.2.1"><a href="#section-3.2" class="xref">3.2</a>.  <a href="#name-defintions" class="xref">Defintions</a><a href="#section-toc.1-1.3.2.2.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.14.2.1">
-                    <p id="section-toc.1-1.3.2.14.2.1.1"><a href="#section-3.14.1" class="xref">3.14.1</a>.  <a href="#name-dkim-authenticated-identifi" class="xref">DKIM-Authenticated Identifiers</a><a href="#section-toc.1-1.3.2.14.2.1.1" class="pilcrow">¶</a></p>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.1">
+                    <p id="section-toc.1-1.3.2.2.2.1.1"><a href="#section-3.2.1" class="xref">3.2.1</a>.  <a href="#name-authenticated-identifiers" class="xref">Authenticated Identifiers</a><a href="#section-toc.1-1.3.2.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.14.2.2">
-                    <p id="section-toc.1-1.3.2.14.2.2.1"><a href="#section-3.14.2" class="xref">3.14.2</a>.  <a href="#name-spf-authenticated-identifie" class="xref">SPF-Authenticated Identifiers</a><a href="#section-toc.1-1.3.2.14.2.2.1" class="pilcrow">¶</a></p>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.2">
+                    <p id="section-toc.1-1.3.2.2.2.2.1"><a href="#section-3.2.2" class="xref">3.2.2</a>.  <a href="#name-author-domain" class="xref">Author Domain</a><a href="#section-toc.1-1.3.2.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.14.2.3">
-                    <p id="section-toc.1-1.3.2.14.2.3.1"><a href="#section-3.14.3" class="xref">3.14.3</a>.  <a href="#name-alignment-and-extension-tec" class="xref">Alignment and Extension Technologies</a><a href="#section-toc.1-1.3.2.14.2.3.1" class="pilcrow">¶</a></p>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.3">
+                    <p id="section-toc.1-1.3.2.2.2.3.1"><a href="#section-3.2.3" class="xref">3.2.3</a>.  <a href="#name-domain-owner" class="xref">Domain Owner</a><a href="#section-toc.1-1.3.2.2.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.4">
+                    <p id="section-toc.1-1.3.2.2.2.4.1"><a href="#section-3.2.4" class="xref">3.2.4</a>.  <a href="#name-identifier-alignment" class="xref">Identifier Alignment</a><a href="#section-toc.1-1.3.2.2.2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.5">
+                    <p id="section-toc.1-1.3.2.2.2.5.1"><a href="#section-3.2.5" class="xref">3.2.5</a>.  <a href="#name-longest-psd" class="xref">Longest PSD</a><a href="#section-toc.1-1.3.2.2.2.5.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.6">
+                    <p id="section-toc.1-1.3.2.2.2.6.1"><a href="#section-3.2.6" class="xref">3.2.6</a>.  <a href="#name-mail-receiver" class="xref">Mail Receiver</a><a href="#section-toc.1-1.3.2.2.2.6.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.7">
+                    <p id="section-toc.1-1.3.2.2.2.7.1"><a href="#section-3.2.7" class="xref">3.2.7</a>.  <a href="#name-non-existent-domains" class="xref">Non-existent Domains</a><a href="#section-toc.1-1.3.2.2.2.7.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.8">
+                    <p id="section-toc.1-1.3.2.2.2.8.1"><a href="#section-3.2.8" class="xref">3.2.8</a>.  <a href="#name-organizational-domain" class="xref">Organizational Domain</a><a href="#section-toc.1-1.3.2.2.2.8.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.9">
+                    <p id="section-toc.1-1.3.2.2.2.9.1"><a href="#section-3.2.9" class="xref">3.2.9</a>.  <a href="#name-public-suffix-domain-psd" class="xref">Public Suffix Domain (PSD)</a><a href="#section-toc.1-1.3.2.2.2.9.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.10">
+                    <p id="section-toc.1-1.3.2.2.2.10.1"><a href="#section-3.2.10" class="xref">3.2.10</a>. <a href="#name-public-suffix-operator-pso" class="xref">Public Suffix Operator (PSO)</a><a href="#section-toc.1-1.3.2.2.2.10.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.11">
+                    <p id="section-toc.1-1.3.2.2.2.11.1"><a href="#section-3.2.11" class="xref">3.2.11</a>. <a href="#name-pso-controlled-domain-names" class="xref">PSO Controlled Domain Names</a><a href="#section-toc.1-1.3.2.2.2.11.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.12">
+                    <p id="section-toc.1-1.3.2.2.2.12.1"><a href="#section-3.2.12" class="xref">3.2.12</a>. <a href="#name-report-receiver" class="xref">Report Receiver</a><a href="#section-toc.1-1.3.2.2.2.12.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.15">
-                <p id="section-toc.1-1.3.2.15.1"><a href="#section-3.15" class="xref">3.15</a>. <a href="#name-determining-the-organizatio" class="xref">Determining The Organizational Domain</a><a href="#section-toc.1-1.3.2.15.1" class="pilcrow">¶</a></p>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.3">
+                <p id="section-toc.1-1.3.2.3.1"><a href="#section-3.3" class="xref">3.3</a>.  <a href="#name-more-on-identifier-alignmen" class="xref">More on Identifier Alignment</a><a href="#section-toc.1-1.3.2.3.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.3.2.1">
+                    <p id="section-toc.1-1.3.2.3.2.1.1"><a href="#section-3.3.1" class="xref">3.3.1</a>.  <a href="#name-dkim-authenticated-identifi" class="xref">DKIM-Authenticated Identifiers</a><a href="#section-toc.1-1.3.2.3.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.3.2.2">
+                    <p id="section-toc.1-1.3.2.3.2.2.1"><a href="#section-3.3.2" class="xref">3.3.2</a>.  <a href="#name-spf-authenticated-identifie" class="xref">SPF-Authenticated Identifiers</a><a href="#section-toc.1-1.3.2.3.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.3.2.3">
+                    <p id="section-toc.1-1.3.2.3.2.3.1"><a href="#section-3.3.3" class="xref">3.3.3</a>.  <a href="#name-alignment-and-extension-tec" class="xref">Alignment and Extension Technologies</a><a href="#section-toc.1-1.3.2.3.2.3.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.4">
+                <p id="section-toc.1-1.3.2.4.1"><a href="#section-3.4" class="xref">3.4</a>.  <a href="#name-determining-the-organizatio" class="xref">Determining The Organizational Domain</a><a href="#section-toc.1-1.3.2.4.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
@@ -1719,54 +1724,53 @@ The source for this draft is maintained in GitHub at:
 <p id="section-1-2">Abusive email often includes unauthorized and deceptive use of a
 domain name in the RFC5322.From header field. The domain typically
 belongs to an organization expected to be known to - and presumably
-trusted by - the recipient. The Sender Policy Framework (SPF) (<span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span>)
-and DomainKeys Identified Mail (DKIM) (<span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>) protocols provide
+trusted by - the recipient. The Sender Policy Framework (SPF) <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span>
+and DomainKeys Identified Mail (DKIM) <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span> protocols provide
 domain-level authentication but are not directly associated with the
-RFC5322.From domain. DMARC leverages them, so that Domain Owners
-publish a DNS record indicating their RFC5322.From field:<a href="#section-1-2" class="pilcrow">¶</a></p>
-<ul>
-<li id="section-1-3.1">Email authentication policies<a href="#section-1-3.1" class="pilcrow">¶</a>
-</li>
-<li id="section-1-3.2">Level of concern for mail that fails authentication checks<a href="#section-1-3.2" class="pilcrow">¶</a>
-</li>
-<li id="section-1-3.3">Desire for reports about email use of the domain name<a href="#section-1-3.3" class="pilcrow">¶</a>
-</li>
-</ul>
-<p id="section-1-4">DMARC can cover non-existent sub-domains, below the "Organizational
-Domain", as well as domains at the top of the name hierarchy,
-controlled by Public Suffix Operators (PSOs).<a href="#section-1-4" class="pilcrow">¶</a></p>
-<p id="section-1-5">As with SPF and DKIM, DMARC classes results as "pass" or "fail". A
-pass from either SPF or DKIM is required. Depending on the stated
-DMARC policy, the passed domain must be "aligned" with the RFC5322.From
-domain in one of two modes - "relaxed" or "strict".  Domains are said
-to be "in relaxed alignment" if they have the same Organizational Domain,
-which is at the top of the domain hierarchy, while having the same
-administrative authority as the RFC5322.From domain, while domains are
-"in strict alignment" if and only if they are identical.<a href="#section-1-5" class="pilcrow">¶</a></p>
-<p id="section-1-6">A DMARC pass indicates only that the RFC5322.From domain has been
-authenticated for that message; authentication does not carry an
+RFC5322.From domain. DMARC leverages them, and provides a method for
+Domain Owners to publish a DNS record describing the email authentication
+policies for the RFC5322.From domain and to request a specific handling
+for messages using that domain that fail authentication checks.<a href="#section-1-2" class="pilcrow">¶</a></p>
+<p id="section-1-3">As with SPF and DKIM, DMARC classes results as "pass" or "fail". In order
+to get a DMARC result of "pass", a pass from either SPF or DKIM is required.
+In addition, the passed domain must be "aligned" with the RFC5322.From domain
+in one of two modes - "relaxed" or "strict". The mode is expressed in the
+domain's DMARC policy record. Domains are said to be "in relaxed alignment"
+if they have the same "Organizational Domain", which is the domain at the
+top of the domain hierarchy for the RFC5322.From domain while having the
+same administrative authority as the RFC5322.From domain. Domains are "in
+strict alignment" if and only if they are identical.<a href="#section-1-3" class="pilcrow">¶</a></p>
+<p id="section-1-4">A DMARC pass indicates only that the RFC5322.From domain has been
+authenticated for that message. Authentication does not carry an
 explicit or implicit value assertion about that message or about
-the Domain Owner. Indeed, a mail-receiving organization that performs
-DMARC verification can choose to follow the Domain Owner's requested
-disposition for authentication failures, and to inform the Domain
-Owner of the mail handling decision for that message. It also might
-choose different actions.<a href="#section-1-6" class="pilcrow">¶</a></p>
-<p id="section-1-7">For a mail-receiving organization supporting DMARC, a message that
+the Domain Owner. Furthermore, a mail-receiving organization that performs
+DMARC verification can choose to honor the Domain Owner's requested
+message handling for authentication failures, but it is under no
+obligation to do so; it might choose different actions entirely.<a href="#section-1-4" class="pilcrow">¶</a></p>
+<p id="section-1-5">For a mail-receiving organization supporting DMARC, a message that
 passes verification is part of a message stream that is reliably
 associated with the RFC5322.From field Domain Owner. Therefore,
 reputation assessment of that stream by the mail-receiving organization
 is not encumbered by accounting for unauthorized use of that domain
 in the RFC5322.From field.  A message that fails this verification
 is not necessarily associated with the Domain Owner's domain and its
-reputation.<a href="#section-1-7" class="pilcrow">¶</a></p>
-<p id="section-1-8">DMARC, in the associated <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> and <span>[<a href="#DMARC-Failure-Reporting" class="xref">DMARC-Failure-Reporting</a>]</span>
+reputation.<a href="#section-1-5" class="pilcrow">¶</a></p>
+<p id="section-1-6">DMARC policy records can also cover non-existent sub-domains, below the
+"Organizational Domain", as well as domains at the top of the name hierarchy,
+controlled by Public Suffix Operators (PSOs).<a href="#section-1-6" class="pilcrow">¶</a></p>
+<p id="section-1-7">DMARC, in the associated <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> and <span>[<a href="#DMARC-Failure-Reporting" class="xref">DMARC-Failure-Reporting</a>]</span>
 documents, also specifies a reporting framework. Using it, a mail-receiving
 domain can generate regular reports about messages that claim to be from
 a domain publishing DMARC policies, sending those reports to the address(es)
-specified by the Domain Owner.<a href="#section-1-8" class="pilcrow">¶</a></p>
-<p id="section-1-9">Use of DMARC creates some interoperability challenges that require due
+specified by the Domain Owner in the latter's DMARC policy record. Domain
+Owners can use these reports, especially the aggregate reports, to identify
+not only sources of mail attempting to fraudulently use their domain, but also
+(and perhaps more importantly) gaps in their own authentication practices. However,
+as with honoring the Domain Owner's stated mail handling preference, a mail-receiving
+organization supporting DMARC is under no obligation to send requested reports.<a href="#section-1-7" class="pilcrow">¶</a></p>
+<p id="section-1-8">Use of DMARC creates some interoperability challenges that require due
 consideration before deployment, particularly with configurations that
-can cause mail to be rejected.  These are discussed in <a href="#other-topics" class="xref">Section 8</a>.<a href="#section-1-9" class="pilcrow">¶</a></p>
+can cause mail to be rejected.  These are discussed in <a href="#other-topics" class="xref">Section 8</a>.<a href="#section-1-8" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="requirements">
@@ -1785,9 +1789,9 @@ documented as out of scope.<a href="#section-2-1" class="pilcrow">¶</a></p>
 <p id="section-2.1-1">DMARC has the following high-level goals:<a href="#section-2.1-1" class="pilcrow">¶</a></p>
 <ul>
 <li id="section-2.1-2.1">
-            <p id="section-2.1-2.1.1">Allow Domain Owners and PSOs to assert their severity of concern for
-authentication failures for messages purporting to have
-authorship within the domain.<a href="#section-2.1-2.1.1" class="pilcrow">¶</a></p>
+            <p id="section-2.1-2.1.1">Allow Domain Owners and PSOs to assert their desired message handling
+for authentication failures for messages purporting to have authorship
+within the domain.<a href="#section-2.1-2.1.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-2.1-2.2">
             <p id="section-2.1-2.2.1">Allow Domain Owners and PSOs to verify their authentication deployment.<a href="#section-2.1-2.2.1" class="pilcrow">¶</a></p>
@@ -1815,32 +1819,32 @@ messages.<a href="#section-2.1-2.3.1" class="pilcrow">¶</a></p>
 work.  These include the following:<a href="#section-2.2-1" class="pilcrow">¶</a></p>
 <ul>
 <li id="section-2.2-2.1">
-            <p id="section-2.2-2.1.1">different treatment of messages that are not authenticated versus
+            <p id="section-2.2-2.1.1">Different treatment of messages that are not authenticated versus
 those that fail authentication;<a href="#section-2.2-2.1.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-2.2-2.2">
-            <p id="section-2.2-2.2.1">evaluation of anything other than RFC5322.From header field;<a href="#section-2.2-2.2.1" class="pilcrow">¶</a></p>
+            <p id="section-2.2-2.2.1">Evaluation of anything other than RFC5322.From header field;<a href="#section-2.2-2.2.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-2.2-2.3">
-            <p id="section-2.2-2.3.1">multiple reporting formats;<a href="#section-2.2-2.3.1" class="pilcrow">¶</a></p>
+            <p id="section-2.2-2.3.1">Multiple reporting formats;<a href="#section-2.2-2.3.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-2.2-2.4">
-            <p id="section-2.2-2.4.1">publishing policy other than via the DNS;<a href="#section-2.2-2.4.1" class="pilcrow">¶</a></p>
+            <p id="section-2.2-2.4.1">Publishing policy other than via the DNS;<a href="#section-2.2-2.4.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-2.2-2.5">
-            <p id="section-2.2-2.5.1">reporting or otherwise evaluating other than the last-hop IP
+            <p id="section-2.2-2.5.1">Reporting or otherwise evaluating other than the last-hop IP
 address;<a href="#section-2.2-2.5.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-2.2-2.6">
-            <p id="section-2.2-2.6.1">attacks in the From: header field, also known as "display name"
+            <p id="section-2.2-2.6.1">Attacks in the From: header field, also known as "display name"
 attacks;<a href="#section-2.2-2.6.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-2.2-2.7">
-            <p id="section-2.2-2.7.1">authentication of entities other than domains, since DMARC is
+            <p id="section-2.2-2.7.1">Authentication of entities other than domains, since DMARC is
 built upon SPF and DKIM, which authenticate domains; and<a href="#section-2.2-2.7.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-2.2-2.8">
-            <p id="section-2.2-2.8.1">content analysis.<a href="#section-2.2-2.8.1" class="pilcrow">¶</a></p>
+            <p id="section-2.2-2.8.1">Content analysis.<a href="#section-2.2-2.8.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </section>
@@ -1898,7 +1902,7 @@ the RFC5322.From human-readable &lt;display-name&gt;.<a href="#section-2.4-3" cl
         </h3>
 <p id="section-3.1-1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 <span>[<a href="#RFC2119" class="xref">RFC2119</a>]</span> <span>[<a href="#RFC8174" class="xref">RFC8174</a>]</span>
+document are to be interpreted as described in BCP 14 <span>[<a href="#RFC2119" class="xref">RFC2119</a>]</span> and <span>[<a href="#RFC8174" class="xref">RFC8174</a>]</span>
 when, and only when, they appear in all capitals, as shown here.<a href="#section-3.1-1" class="pilcrow">¶</a></p>
 <p id="section-3.1-2">Readers are encouraged to be familiar with the contents of
 <span>[<a href="#RFC5598" class="xref">RFC5598</a>]</span>.  In particular, that document defines various roles in
@@ -1911,30 +1915,36 @@ such roles; the reader is encouraged to become familiar with that
 material before continuing.<a href="#section-3.1-2" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="authenticated-identifiers">
+<div id="definitions">
 <section id="section-3.2">
-        <h3 id="name-authenticated-identifiers">
-<a href="#section-3.2" class="section-number selfRef">3.2. </a><a href="#name-authenticated-identifiers" class="section-name selfRef">Authenticated Identifiers</a>
+        <h3 id="name-defintions">
+<a href="#section-3.2" class="section-number selfRef">3.2. </a><a href="#name-defintions" class="section-name selfRef">Defintions</a>
         </h3>
-<p id="section-3.2-1">Domain-level identifiers that are verified using authentication technologies
+<p id="section-3.2-1">The following sections define terms used in this document.<a href="#section-3.2-1" class="pilcrow">¶</a></p>
+<div id="authenticated-identifiers">
+<section id="section-3.2.1">
+          <h4 id="name-authenticated-identifiers">
+<a href="#section-3.2.1" class="section-number selfRef">3.2.1. </a><a href="#name-authenticated-identifiers" class="section-name selfRef">Authenticated Identifiers</a>
+          </h4>
+<p id="section-3.2.1-1">Domain-level identifiers that are verified using authentication technologies
 are referred to as "Authenticated Identifiers".  See <a href="#authenication-mechanisms" class="xref">Section 4.1</a>
-for details about the supported mechanisms.<a href="#section-3.2-1" class="pilcrow">¶</a></p>
+for details about the supported mechanisms.<a href="#section-3.2.1-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="author-domain">
-<section id="section-3.3">
-        <h3 id="name-author-domain">
-<a href="#section-3.3" class="section-number selfRef">3.3. </a><a href="#name-author-domain" class="section-name selfRef">Author Domain</a>
-        </h3>
-<p id="section-3.3-1">The domain name of the apparent author, as extracted from the From: header field.<a href="#section-3.3-1" class="pilcrow">¶</a></p>
+<section id="section-3.2.2">
+          <h4 id="name-author-domain">
+<a href="#section-3.2.2" class="section-number selfRef">3.2.2. </a><a href="#name-author-domain" class="section-name selfRef">Author Domain</a>
+          </h4>
+<p id="section-3.2.2-1">The domain name of the apparent author, as extracted from the From: header field.<a href="#section-3.2.2-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="domain-owner">
-<section id="section-3.4">
-        <h3 id="name-domain-owner">
-<a href="#section-3.4" class="section-number selfRef">3.4. </a><a href="#name-domain-owner" class="section-name selfRef">Domain Owner</a>
-        </h3>
-<p id="section-3.4-1">An entity or organization that owns a DNS domain.  The
+<section id="section-3.2.3">
+          <h4 id="name-domain-owner">
+<a href="#section-3.2.3" class="section-number selfRef">3.2.3. </a><a href="#name-domain-owner" class="section-name selfRef">Domain Owner</a>
+          </h4>
+<p id="section-3.2.3-1">An entity or organization that owns a DNS domain.  The
 term "owns" here indicates that the entity or organization being
 referenced holds the registration of that DNS domain.  Domain
 Owners range from complex, globally distributed organizations, to
@@ -1943,113 +1953,113 @@ individuals responsible for maintaining personal domains.  This
 specification uses this term as analogous to an Administrative
 Management Domain as defined in <span>[<a href="#RFC5598" class="xref">RFC5598</a>]</span>.  It can also refer
 to delegates, such as Report Receivers, when those are outside of
-their immediate management domain.<a href="#section-3.4-1" class="pilcrow">¶</a></p>
+their immediate management domain.<a href="#section-3.2.3-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="identifier-alignment">
-<section id="section-3.5">
-        <h3 id="name-identifier-alignment">
-<a href="#section-3.5" class="section-number selfRef">3.5. </a><a href="#name-identifier-alignment" class="section-name selfRef">Identifier Alignment</a>
-        </h3>
-<p id="section-3.5-1">When the domain in the address in the From: header field has the
+<section id="section-3.2.4">
+          <h4 id="name-identifier-alignment">
+<a href="#section-3.2.4" class="section-number selfRef">3.2.4. </a><a href="#name-identifier-alignment" class="section-name selfRef">Identifier Alignment</a>
+          </h4>
+<p id="section-3.2.4-1">When the domain in the address in the From: header field has the
 same Organizational Domain as a domain verified by SPF or DKIM
-(or both), it has Identifier Alignment. (see below)<a href="#section-3.5-1" class="pilcrow">¶</a></p>
+(or both), it has Identifier Alignment. (see below)<a href="#section-3.2.4-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="longest-psd">
-<section id="section-3.6">
-        <h3 id="name-longest-psd">
-<a href="#section-3.6" class="section-number selfRef">3.6. </a><a href="#name-longest-psd" class="section-name selfRef">Longest PSD</a>
-        </h3>
-<p id="section-3.6-1">The term Longest PSD is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.6-1" class="pilcrow">¶</a></p>
+<section id="section-3.2.5">
+          <h4 id="name-longest-psd">
+<a href="#section-3.2.5" class="section-number selfRef">3.2.5. </a><a href="#name-longest-psd" class="section-name selfRef">Longest PSD</a>
+          </h4>
+<p id="section-3.2.5-1">The term Longest PSD is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.2.5-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="mail-receiver">
-<section id="section-3.7">
-        <h3 id="name-mail-receiver">
-<a href="#section-3.7" class="section-number selfRef">3.7. </a><a href="#name-mail-receiver" class="section-name selfRef">Mail Receiver</a>
-        </h3>
-<p id="section-3.7-1">The entity or organization that receives and processes email.<br>
+<section id="section-3.2.6">
+          <h4 id="name-mail-receiver">
+<a href="#section-3.2.6" class="section-number selfRef">3.2.6. </a><a href="#name-mail-receiver" class="section-name selfRef">Mail Receiver</a>
+          </h4>
+<p id="section-3.2.6-1">The entity or organization that receives and processes email.<br>
 Mail Receivers operate one or more Internet-facing Mail Transport
-Agents (MTAs).<a href="#section-3.7-1" class="pilcrow">¶</a></p>
+Agents (MTAs).<a href="#section-3.2.6-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="non-existent-domains">
-<section id="section-3.8">
-        <h3 id="name-non-existent-domains">
-<a href="#section-3.8" class="section-number selfRef">3.8. </a><a href="#name-non-existent-domains" class="section-name selfRef">Non-existent Domains</a>
-        </h3>
-<p id="section-3.8-1">For DMARC purposes, a non-existent domain is a domain for which there
+<section id="section-3.2.7">
+          <h4 id="name-non-existent-domains">
+<a href="#section-3.2.7" class="section-number selfRef">3.2.7. </a><a href="#name-non-existent-domains" class="section-name selfRef">Non-existent Domains</a>
+          </h4>
+<p id="section-3.2.7-1">For DMARC purposes, a non-existent domain is a domain for which there
 is an NXDOMAIN or NODATA response for A, AAAA, and MX records.  This
-is a broader definition than that in <span>[<a href="#RFC8020" class="xref">RFC8020</a>]</span>.<a href="#section-3.8-1" class="pilcrow">¶</a></p>
+is a broader definition than that in <span>[<a href="#RFC8020" class="xref">RFC8020</a>]</span>.<a href="#section-3.2.7-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="organizational-domain">
-<section id="section-3.9">
-        <h3 id="name-organizational-domain">
-<a href="#section-3.9" class="section-number selfRef">3.9. </a><a href="#name-organizational-domain" class="section-name selfRef">Organizational Domain</a>
-        </h3>
-<p id="section-3.9-1">The domain that was registered with a domain name registrar.  In
-the absence of more accurate methods, heuristics are used to determine
-this, since it is not always the case that the registered domain name
-is simply a top-level DNS domain plus one component (e.g., "example.com",
-where "com" is a top-level domain).  The Organizational Domain is
-determined by applying the algorithm found in
-<a href="#determining-the-organizational-domain" class="xref">Section 3.15</a>.<a href="#section-3.9-1" class="pilcrow">¶</a></p>
+<section id="section-3.2.8">
+          <h4 id="name-organizational-domain">
+<a href="#section-3.2.8" class="section-number selfRef">3.2.8. </a><a href="#name-organizational-domain" class="section-name selfRef">Organizational Domain</a>
+          </h4>
+<p id="section-3.2.8-1">The Organizational Domain is typically a domain that was registered with
+a domain name registrar.  More formally, it is a Public Suffix Domain
+plus one label. The Organizational Domain for the domain in the
+RFC5322.From domain is determined by applying the algorithm found in
+<a href="#determining-the-organizational-domain" class="xref">Section 3.4</a>.<a href="#section-3.2.8-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="public-suffix-domain">
-<section id="section-3.10">
-        <h3 id="name-public-suffix-domain-psd">
-<a href="#section-3.10" class="section-number selfRef">3.10. </a><a href="#name-public-suffix-domain-psd" class="section-name selfRef">Public Suffix Domain (PSD)</a>
-        </h3>
-<p id="section-3.10-1">The term Public Suffix Domain is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.10-1" class="pilcrow">¶</a></p>
+<section id="section-3.2.9">
+          <h4 id="name-public-suffix-domain-psd">
+<a href="#section-3.2.9" class="section-number selfRef">3.2.9. </a><a href="#name-public-suffix-domain-psd" class="section-name selfRef">Public Suffix Domain (PSD)</a>
+          </h4>
+<p id="section-3.2.9-1">The term Public Suffix Domain is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.2.9-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="public-suffix-operator">
-<section id="section-3.11">
-        <h3 id="name-public-suffix-operator-pso">
-<a href="#section-3.11" class="section-number selfRef">3.11. </a><a href="#name-public-suffix-operator-pso" class="section-name selfRef">Public Suffix Operator (PSO)</a>
-        </h3>
-<p id="section-3.11-1">The term Public Suffix Operator is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.11-1" class="pilcrow">¶</a></p>
+<section id="section-3.2.10">
+          <h4 id="name-public-suffix-operator-pso">
+<a href="#section-3.2.10" class="section-number selfRef">3.2.10. </a><a href="#name-public-suffix-operator-pso" class="section-name selfRef">Public Suffix Operator (PSO)</a>
+          </h4>
+<p id="section-3.2.10-1">The term Public Suffix Operator is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.2.10-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="pso-controlled-domain-names">
-<section id="section-3.12">
-        <h3 id="name-pso-controlled-domain-names">
-<a href="#section-3.12" class="section-number selfRef">3.12. </a><a href="#name-pso-controlled-domain-names" class="section-name selfRef">PSO Controlled Domain Names</a>
-        </h3>
-<p id="section-3.12-1">The term PSO Controlled Domain Names is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.12-1" class="pilcrow">¶</a></p>
+<section id="section-3.2.11">
+          <h4 id="name-pso-controlled-domain-names">
+<a href="#section-3.2.11" class="section-number selfRef">3.2.11. </a><a href="#name-pso-controlled-domain-names" class="section-name selfRef">PSO Controlled Domain Names</a>
+          </h4>
+<p id="section-3.2.11-1">The term PSO Controlled Domain Names is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.2.11-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="report-receiver">
-<section id="section-3.13">
-        <h3 id="name-report-receiver">
-<a href="#section-3.13" class="section-number selfRef">3.13. </a><a href="#name-report-receiver" class="section-name selfRef">Report Receiver</a>
-        </h3>
-<p id="section-3.13-1">An operator that receives reports from another operator
-implementing the reporting mechanisms described in this document
-and/or the documents <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> and <span>[<a href="#DMARC-Failure-Reporting" class="xref">DMARC-Failure-Reporting</a>]</span>.
-Such an operator might be receiving reports about messages related
-to a domain for which it is the Domain Owner or PSO, or reports about
-messages related to another operator's domain.  This term applies
-collectively to the system components that receive and process these
-reports and the organizations that operate them.<a href="#section-3.13-1" class="pilcrow">¶</a></p>
+<section id="section-3.2.12">
+          <h4 id="name-report-receiver">
+<a href="#section-3.2.12" class="section-number selfRef">3.2.12. </a><a href="#name-report-receiver" class="section-name selfRef">Report Receiver</a>
+          </h4>
+<p id="section-3.2.12-1">An operator that receives reports from another operator implementing the
+reporting mechanisms described in this document and/or the documents
+<span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> and <span>[<a href="#DMARC-Failure-Reporting" class="xref">DMARC-Failure-Reporting</a>]</span>. Such an
+operator might be receiving reports about messages related to a domain
+for which it is the Domain Owner or PSO, or reports about messages related
+to another operator's domain.  This term applies collectively to the
+system components that receive and process these reports and the organizations
+that operate them.<a href="#section-3.2.12-1" class="pilcrow">¶</a></p>
+</section>
+</div>
 </section>
 </div>
 <div id="more-on-identifier-alignment">
-<section id="section-3.14">
+<section id="section-3.3">
         <h3 id="name-more-on-identifier-alignmen">
-<a href="#section-3.14" class="section-number selfRef">3.14. </a><a href="#name-more-on-identifier-alignmen" class="section-name selfRef">More on Identifier Alignment</a>
+<a href="#section-3.3" class="section-number selfRef">3.3. </a><a href="#name-more-on-identifier-alignmen" class="section-name selfRef">More on Identifier Alignment</a>
         </h3>
-<p id="section-3.14-1">Email authentication technologies authenticate various (and
+<p id="section-3.3-1">Email authentication technologies authenticate various (and
 disparate) aspects of an individual message.  For example, DKIM <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>
 authenticates the domain that affixed a signature to the message,
 while SPF <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span> can authenticate either the domain that appears in the
 RFC5321.MailFrom (MAIL FROM) portion of an SMTP <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span> conversation or the
 RFC5321.EHLO/HELO domain, or both.  These may be different domains, and they
-are typically not visible to the end user.<a href="#section-3.14-1" class="pilcrow">¶</a></p>
-<p id="section-3.14-2">DMARC authenticates use of the RFC5322.From domain by requiring that
+are typically not visible to the end user.<a href="#section-3.3-1" class="pilcrow">¶</a></p>
+<p id="section-3.3-2">DMARC authenticates use of the RFC5322.From domain by requiring that
 it have the same Organizational Domain as (i.e., be aligned with) an
 Authenticated Identifier. Domain names in this context are to be compared
 in a case-insensitive manner, per <span>[<a href="#RFC4343" class="xref">RFC4343</a>]</span>. The RFC5322.From domain
@@ -2057,160 +2067,159 @@ was selected as the central identity of the DMARC mechanism because it
 is a required message header field and therefore guaranteed to be present
 in compliant messages, and most Mail User Agents (MUAs) represent the
 RFC5322.From header field as the originator of the message and render
-some or all of this header field's content to end users.<a href="#section-3.14-2" class="pilcrow">¶</a></p>
-<p id="section-3.14-3">It is important to note that Identifier Alignment cannot occur with a
+some or all of this header field's content to end users.<a href="#section-3.3-2" class="pilcrow">¶</a></p>
+<p id="section-3.3-3">It is important to note that Identifier Alignment cannot occur with a
 message that is not valid per <span>[<a href="#RFC5322" class="xref">RFC5322</a>]</span>, particularly one with a
 malformed, absent, or repeated RFC5322.From header field, since in that case
 there is no reliable way to determine a DMARC policy that applies to
 the message.  Accordingly, DMARC operation is predicated on the input
 being a valid RFC5322 message object, and handling of such
 non-compliant cases is outside of the scope of this specification.
-Further discussion of this can be found in <a href="#extract-author-domain" class="xref">Section 6.7.1</a>.<a href="#section-3.14-3" class="pilcrow">¶</a></p>
-<p id="section-3.14-4">Each of the underlying authentication technologies that DMARC takes
+Further discussion of this can be found in <a href="#extract-author-domain" class="xref">Section 6.7.1</a>.<a href="#section-3.3-3" class="pilcrow">¶</a></p>
+<p id="section-3.3-4">Each of the underlying authentication technologies that DMARC takes
 as input yields authenticated domains as their outputs when they
-succeed.<a href="#section-3.14-4" class="pilcrow">¶</a></p>
+succeed.<a href="#section-3.3-4" class="pilcrow">¶</a></p>
 <div id="dkim-identifiers">
-<section id="section-3.14.1">
+<section id="section-3.3.1">
           <h4 id="name-dkim-authenticated-identifi">
-<a href="#section-3.14.1" class="section-number selfRef">3.14.1. </a><a href="#name-dkim-authenticated-identifi" class="section-name selfRef">DKIM-Authenticated Identifiers</a>
+<a href="#section-3.3.1" class="section-number selfRef">3.3.1. </a><a href="#name-dkim-authenticated-identifi" class="section-name selfRef">DKIM-Authenticated Identifiers</a>
           </h4>
-<p id="section-3.14.1-1">DMARC requires Identifier Alignment based on the result of a DKIM
+<p id="section-3.3.1-1">DMARC requires Identifier Alignment based on the result of a DKIM
 authentication because a message can bear a valid signature from any
 domain, including domains used by a mailing list or even a bad actor.
 Therefore, merely bearing a valid signature is not enough to infer
-authenticity of the Author Domain.<a href="#section-3.14.1-1" class="pilcrow">¶</a></p>
-<p id="section-3.14.1-2">DMARC permits Identifier Alignment based on the result of a DKIM
+authenticity of the Author Domain.<a href="#section-3.3.1-1" class="pilcrow">¶</a></p>
+<p id="section-3.3.1-2">DMARC permits Identifier Alignment based on the result of a DKIM
 authentication to be strict or relaxed. (Note that these terms are
-not related to DKIM's "simple" and "relaxed" canonicalization modes.)<a href="#section-3.14.1-2" class="pilcrow">¶</a></p>
-<p id="section-3.14.1-3">In relaxed mode, the Organizational Domains of both the DKIM-authenticated
+not related to DKIM's "simple" and "relaxed" canonicalization modes.)<a href="#section-3.3.1-2" class="pilcrow">¶</a></p>
+<p id="section-3.3.1-3">In relaxed mode, the Organizational Domains of both the DKIM-authenticated
 signing domain (taken from the value of the d= tag in the signature)
 and that of the RFC5322.From domain must be equal if the identifiers
 are to be considered to be aligned. In strict mode, only an exact match
 between both Fully Qualified Domain Names (FQDNs) is considered to produce
-Identifier Alignment.<a href="#section-3.14.1-3" class="pilcrow">¶</a></p>
-<p id="section-3.14.1-4">To illustrate, in relaxed mode, if a verified DKIM signature
+Identifier Alignment.<a href="#section-3.3.1-3" class="pilcrow">¶</a></p>
+<p id="section-3.3.1-4">To illustrate, in relaxed mode, if a verified DKIM signature
 successfully verifies with a "d=" domain of "example.com", and the
 RFC5322.From address is "alerts@news.example.com", the DKIM "d="
 domain and the RFC5322.From domain are considered to be "in alignment",
 because both domains have the same Organizational Domain of "example.com".
 In strict mode, this test would fail because the d= domain does not
-exactly match the RFC5322.From domain.<a href="#section-3.14.1-4" class="pilcrow">¶</a></p>
-<p id="section-3.14.1-5">However, a DKIM signature bearing a value of "d=com" would never allow
-an "in alignment" result, as "com" should appear on all public suffix
-lists (see <a href="#public-suffix-lists" class="xref">Appendix A.6.1</a>) and therefore cannot be an Organizational
-Domain.<a href="#section-3.14.1-5" class="pilcrow">¶</a></p>
-<p id="section-3.14.1-6">Note that a single email can contain multiple DKIM signatures, and it
+exactly match the RFC5322.From domain.<a href="#section-3.3.1-4" class="pilcrow">¶</a></p>
+<p id="section-3.3.1-5">However, a DKIM signature bearing a value of "d=com" would never allow
+an "in alignment" result, as "com" should be identified as a PSD and
+therefore cannot be an Organizational Domain.<a href="#section-3.3.1-5" class="pilcrow">¶</a></p>
+<p id="section-3.3.1-6">Note that a single email can contain multiple DKIM signatures, and it
 is considered to produce a DMARC "pass" result if any DKIM signature
-is aligned and verifies.<a href="#section-3.14.1-6" class="pilcrow">¶</a></p>
+is aligned and verifies.<a href="#section-3.3.1-6" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="spf-identifiers">
-<section id="section-3.14.2">
+<section id="section-3.3.2">
           <h4 id="name-spf-authenticated-identifie">
-<a href="#section-3.14.2" class="section-number selfRef">3.14.2. </a><a href="#name-spf-authenticated-identifie" class="section-name selfRef">SPF-Authenticated Identifiers</a>
+<a href="#section-3.3.2" class="section-number selfRef">3.3.2. </a><a href="#name-spf-authenticated-identifie" class="section-name selfRef">SPF-Authenticated Identifiers</a>
           </h4>
-<p id="section-3.14.2-1">DMARC permits Identifier Alignment based on the result of an SPF
+<p id="section-3.3.2-1">DMARC permits Identifier Alignment based on the result of an SPF
 authentication. As with DKIM, Identifier Alignement can be either
-strict or relaxed.<a href="#section-3.14.2-1" class="pilcrow">¶</a></p>
-<p id="section-3.14.2-2">In relaxed mode, the Organizational Domains of the SPF-authenticated
+strict or relaxed.<a href="#section-3.3.2-1" class="pilcrow">¶</a></p>
+<p id="section-3.3.2-2">In relaxed mode, the Organizational Domains of the SPF-authenticated
 domain and RFC5322.From domain must be equal if the identifiers are
 to be considered to be aligned. In strict mode, the two FQDNs must
-match exactly in order from them to be considered to be aligned.<a href="#section-3.14.2-2" class="pilcrow">¶</a></p>
-<p id="section-3.14.2-3">For example, in relaxed mode, if a message passes an SPF check with an
+match exactly in order from them to be considered to be aligned.<a href="#section-3.3.2-2" class="pilcrow">¶</a></p>
+<p id="section-3.3.2-3">For example, in relaxed mode, if a message passes an SPF check with an
 RFC5321.MailFrom domain of "cbg.bounces.example.com", and the address
 portion of the RFC5322.From header field contains
 "payments@example.com", the Authenticated RFC5321.MailFrom domain
 identifier and the RFC5322.From domain are considered to be "in
 alignment" because they have the same Organizational Domain
 ("example.com"). In strict mode, this test would fail because the
-two domains are not identical.<a href="#section-3.14.2-3" class="pilcrow">¶</a></p>
-<p id="section-3.14.2-4">The reader should note that SPF alignment checks in DMARC rely solely
+two domains are not identical.<a href="#section-3.3.2-3" class="pilcrow">¶</a></p>
+<p id="section-3.3.2-4">The reader should note that SPF alignment checks in DMARC rely solely
 on the RFC5321.MailFrom domain. This differs from section 2.3 of
 <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span>, which recommends that SPF checks be done on not only the
-"MAIL FROM" but also on a separate check of the "HELO" identity.<a href="#section-3.14.2-4" class="pilcrow">¶</a></p>
+"MAIL FROM" but also on a separate check of the "HELO" identity.<a href="#section-3.3.2-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="alignment-and-extension-technologies">
-<section id="section-3.14.3">
+<section id="section-3.3.3">
           <h4 id="name-alignment-and-extension-tec">
-<a href="#section-3.14.3" class="section-number selfRef">3.14.3. </a><a href="#name-alignment-and-extension-tec" class="section-name selfRef">Alignment and Extension Technologies</a>
+<a href="#section-3.3.3" class="section-number selfRef">3.3.3. </a><a href="#name-alignment-and-extension-tec" class="section-name selfRef">Alignment and Extension Technologies</a>
           </h4>
-<p id="section-3.14.3-1">If in the future DMARC is extended to include the use of other
+<p id="section-3.3.3-1">If in the future DMARC is extended to include the use of other
 authentication mechanisms, the extensions will need to allow for
 domain identifier extraction so that alignment with the RFC5322.From
-domain can be verified.<a href="#section-3.14.3-1" class="pilcrow">¶</a></p>
+domain can be verified.<a href="#section-3.3.3-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="determining-the-organizational-domain">
-<section id="section-3.15">
+<section id="section-3.4">
         <h3 id="name-determining-the-organizatio">
-<a href="#section-3.15" class="section-number selfRef">3.15. </a><a href="#name-determining-the-organizatio" class="section-name selfRef">Determining The Organizational Domain</a>
+<a href="#section-3.4" class="section-number selfRef">3.4. </a><a href="#name-determining-the-organizatio" class="section-name selfRef">Determining The Organizational Domain</a>
         </h3>
-<p id="section-3.15-1">The Organizational Domain for a subject DNS domain name is defined as
+<p id="section-3.4-1">The Organizational Domain for a subject DNS domain name is defined as
 the domain that is found in the DNS hierarchy one level below the PSD
 in the subject DNS domain name.  The Organizational Domain is determined
-using the following algorithm, similar to the one described in <a href="#policy-discovery" class="xref">Section 6.7.3</a><a href="#section-3.15-1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-3.15-2">
-          <li id="section-3.15-2.1">
-            <p id="section-3.15-2.1.1">Query the DNS for a DMARC TXT record at the DNS domain matching the one
+using the following algorithm, similar to the one described in <a href="#policy-discovery" class="xref">Section 6.7.3</a><a href="#section-3.4-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-3.4-2">
+          <li id="section-3.4-2.1">
+            <p id="section-3.4-2.1.1">Query the DNS for a DMARC TXT record at the DNS domain matching the one
 found in the RFC5322.From domain in the message.  A possibly empty set
-of records is returned.<a href="#section-3.15-2.1.1" class="pilcrow">¶</a></p>
+of records is returned.<a href="#section-3.4-2.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-3.15-2.2">
-            <p id="section-3.15-2.2.1">Records that do not start with a "v=" tag that identifies the
-current version of DMARC are discarded.<a href="#section-3.15-2.2.1" class="pilcrow">¶</a></p>
+<li id="section-3.4-2.2">
+            <p id="section-3.4-2.2.1">Records that do not start with a "v=" tag that identifies the
+current version of DMARC are discarded.<a href="#section-3.4-2.2.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-3.15-2.3">
-            <p id="section-3.15-2.3.1">If the set is now empty, or the set contains one valid DMARC record that
+<li id="section-3.4-2.3">
+            <p id="section-3.4-2.3.1">If the set is now empty, or the set contains one valid DMARC record that
 does not include a psd tag with a value of 'y', then determine the target for
-additional queries, using steps 4 through 8 below.<a href="#section-3.15-2.3.1" class="pilcrow">¶</a></p>
+additional queries, using steps 4 through 8 below.<a href="#section-3.4-2.3.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-3.15-2.4">
-            <p id="section-3.15-2.4.1">Break the subject DNS domain name into a set of "n" ordered
+<li id="section-3.4-2.4">
+            <p id="section-3.4-2.4.1">Break the subject DNS domain name into a set of "n" ordered
 labels.  Number these labels from right to left; e.g., for
 "example.com", "com" would be label 1 and "example" would be
-label 2.<a href="#section-3.15-2.4.1" class="pilcrow">¶</a></p>
+label 2.<a href="#section-3.4-2.4.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-3.15-2.5">
-            <p id="section-3.15-2.5.1">Count the number of labels found in the subject DNS domain. Let that
+<li id="section-3.4-2.5">
+            <p id="section-3.4-2.5.1">Count the number of labels found in the subject DNS domain. Let that
 number be "x". If x &lt; 5, remove the left-most (highest-numbered)
 label from the subject domain. If x &gt;= 5, remove the left-most
 (highest-numbered) labels from the subject domain until 4 labels remain.
-The resulting DNS domain name is the new target for subsequent lookups.<a href="#section-3.15-2.5.1" class="pilcrow">¶</a></p>
+The resulting DNS domain name is the new target for subsequent lookups.<a href="#section-3.4-2.5.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-3.15-2.6">
-            <p id="section-3.15-2.6.1">Query the DNS for a DMARC TXT record at the DNS domain matching this
+<li id="section-3.4-2.6">
+            <p id="section-3.4-2.6.1">Query the DNS for a DMARC TXT record at the DNS domain matching this
 new target in place of the RFC5322.From domain in the message.  A possibly
-empty set of records is returned.<a href="#section-3.15-2.6.1" class="pilcrow">¶</a></p>
+empty set of records is returned.<a href="#section-3.4-2.6.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-3.15-2.7">
-            <p id="section-3.15-2.7.1">Records that do not start with a "v=" tag that identifies the
-current version of DMARC are discarded.<a href="#section-3.15-2.7.1" class="pilcrow">¶</a></p>
+<li id="section-3.4-2.7">
+            <p id="section-3.4-2.7.1">Records that do not start with a "v=" tag that identifies the
+current version of DMARC are discarded.<a href="#section-3.4-2.7.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-3.15-2.8">
-            <p id="section-3.15-2.8.1">If the set is now empty, or the set contains one valid DMARC record that
+<li id="section-3.4-2.8">
+            <p id="section-3.4-2.8.1">If the set is now empty, or the set contains one valid DMARC record that
 does not include a psd tag with the value of 'y', then determine the
 target for additional queries by removing a single label from the target
 domain as described in step 5 and repeating steps 6 and 7 until
 there are no more labels remaining or a record containing a psd tag with
-a value of 'y' is found.<a href="#section-3.15-2.8.1" class="pilcrow">¶</a></p>
+a value of 'y' is found.<a href="#section-3.4-2.8.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-3.15-2.9">
-            <p id="section-3.15-2.9.1">Once a valid DMARC record containing a psd tag with a value of 'y' has
+<li id="section-3.4-2.9">
+            <p id="section-3.4-2.9.1">Once a valid DMARC record containing a psd tag with a value of 'y' has
 been found, the Organizational Domain for the DNS domain matching the
 one found in the RFC5322.From domain can be declared to be the target
 domain queried for in the step prior to the query that found the PSD
-domain.<a href="#section-3.15-2.9.1" class="pilcrow">¶</a></p>
+domain.<a href="#section-3.4-2.9.1" class="pilcrow">¶</a></p>
 </li>
 </ol>
-<p id="section-3.15-3">For example, given the RFC5322.From domain "a.mail.example.com", a series
+<p id="section-3.4-3">For example, given the RFC5322.From domain "a.mail.example.com", a series
 of DNS queries for DMARC records would be executed starting with
 "<em>dmarc.a.mail.example.com" and finishing with "</em>dmarc.com". The "<em>dmarc.com"
 record would contain a psd tag with a value of 'y', and so the Organizational
 Domain for this RFC5322.From domain would be determined to be "example.com",
-the domain of the DMARC query executed prior to the query for "</em>dmarc.com".<a href="#section-3.15-3" class="pilcrow">¶</a></p>
+the domain of the DMARC query executed prior to the query for "</em>dmarc.com".<a href="#section-3.4-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
@@ -2394,11 +2403,11 @@ for details.<a href="#section-5-5" class="pilcrow">¶</a></p>
 used by Mail Receivers to inform their message handling decisions.<a href="#section-6-1" class="pilcrow">¶</a></p>
 <p id="section-6-2">A Domain Owner or PSO advertises DMARC participation of one or more of its
 domains by adding a DNS TXT record (described in <a href="#dmarc-policy-record" class="xref">Section 6.1</a>) to
-those domains.  In doing so, Domain Owners and PSOs indicate their severity of
-concern regarding failed authentication for email messages making use
+those domains.  In doing so, Domain Owners and PSOs indicate their handling
+preference regarding failed authentication for email messages making use
 of their domain in the RFC5322.From header field as well as the provision
 of feedback about those messages. Mail Receivers in turn can take into
-account the Domain Owner's severity of concern when making handling
+account the Domain Owner's stated preference when making handling
 decisions about email messages that fail DMARC authentication checks.<a href="#section-6-2" class="pilcrow">¶</a></p>
 <p id="section-6-3">A Domain Owner or PSO may choose not to participate in DMARC evaluation by
 Mail Receivers.  In this case, the Domain Owner simply declines to
@@ -2476,7 +2485,7 @@ are to be processed; unknown tags MUST be ignored.<a href="#section-6.3-2" class
 <dd id="section-6.3-4.2">
             <p id="section-6.3-4.2.1">(plain-text; OPTIONAL; default is "r".)  Indicates whether
 strict or relaxed DKIM Identifier Alignment mode is required by
-the Domain Owner.  See <a href="#dkim-identifiers" class="xref">Section 3.14.1</a> for details.  Valid values
+the Domain Owner.  See <a href="#dkim-identifiers" class="xref">Section 3.3.1</a> for details.  Valid values
 are as follows:<a href="#section-6.3-4.2.1" class="pilcrow">¶</a></p>
 <dl class="dlParallel" id="section-6.3-4.2.2">
               <dt id="section-6.3-4.2.2.1">r:</dt>
@@ -2494,7 +2503,7 @@ are as follows:<a href="#section-6.3-4.2.1" class="pilcrow">¶</a></p>
 <dd id="section-6.3-4.4">
             <p id="section-6.3-4.4.1">(plain-text; OPTIONAL; default is "r".)  Indicates whether
 strict or relaxed SPF Identifier Alignment mode is required by the
-Domain Owner.  See <a href="#spf-identifiers" class="xref">Section 3.14.2</a> for details.  Valid values are as
+Domain Owner.  See <a href="#spf-identifiers" class="xref">Section 3.3.2</a> for details.  Valid values are as
 follows:<a href="#section-6.3-4.4.1" class="pilcrow">¶</a></p>
 <dl class="dlParallel" id="section-6.3-4.4.2">
               <dt id="section-6.3-4.4.2.1">r:</dt>
@@ -2546,9 +2555,9 @@ s:
 <dl class="dlParallel" id="section-6.3-7">
           <dt id="section-6.3-7.1">np:</dt>
 <dd id="section-6.3-7.2">Domain Owner Assessment Policy for non-existent subdomains
-(plain-text; OPTIONAL).  Indicates the severity of concern the
-Domain Owner or PSO has for mail using non-existent subdomains of the
-domain queried. It applies only to non-existent subdomains of
+(plain-text; OPTIONAL).  Indicates the message handling preference
+that the Domain Owner or PSO has for mail using non-existent subdomains
+of the domain queried. It applies only to non-existent subdomains of
 the domain queried and not to either existing subdomains or
 the domain itself.  Its syntax is identical to that of the "p"
 tag defined below.  If the "np" tag is absent, the policy
@@ -2563,8 +2572,8 @@ mechanism described in <a href="#policy-discovery" class="xref">Section 6.7.3</a
 <dt id="section-6.3-7.3">p:</dt>
 <dd id="section-6.3-7.4">
             <p id="section-6.3-7.4.1">Domain Owner Assessment Policy (plain-text; RECOMMENDED for policy
-records). Indicates the severity of concern the Domain Owner or PSO
-has for mail using its domain but not passing DMARC verification.
+records). Indicates the message handling preference the Domain Owner or
+PSO has for mail using its domain but not passing DMARC verification.
 Policy applies to the domain queried and to subdomains, unless
 subdomain policy is explicitly described using the "sp" or "np" tags.
 This tag is mandatory for policy records only, but not for third-party
@@ -2645,9 +2654,9 @@ additional considerations.<a href="#section-6.3-7.10.1" class="pilcrow">¶</a></
 <dt id="section-6.3-7.11">sp:</dt>
 <dd id="section-6.3-7.12">
             <p id="section-6.3-7.12.1">Domain Owner Assessment Policy for all subdomains (plain-text;
-OPTIONAL). Indicates the severity of concern the Domain Owner or PSO has
-for mail using an existing subdomain of the domain queried but not
-passing DMARC verification.  It applies only to subdomains of
+OPTIONAL). Indicates the message handling preference the Domain Owner
+or PSO has for mail using an existing subdomain of the domain queried
+but not passing DMARC verification.  It applies only to subdomains of
 the domain queried and not to the domain itself.  Its syntax is
 identical to that of the "p" tag defined above.  If both the "sp"
 tag is absent and the "np" tag is either absent or not applicable,
@@ -3113,8 +3122,8 @@ mailstreams making use of its domain in email, to include not only
 illegitimate uses but also, and perhaps more importantly, all
 legitimate uses. Domain Owners can use aggregate reports to ensure
 that all legitimate uses of their domain for sending email are
-properly authenticated, and once they are, increase the severity of
-concern expressed in the p= tag in their DMARC policy records from
+properly authenticated, and once they are, express a stricter message
+handling preference in the p= tag in their DMARC policy records from
 none to quarantine to reject, if appropriate. In turn, DMARC policy
 records with p= tag values of 'quarantine' or 'reject' are higher
 value signals to Mail Receivers, ones that can assist Mail Receivers
@@ -4215,7 +4224,7 @@ labels; this would cause a Mail Receiver to attempt a large number of
 queries in search of a policy record.  Sending many such messages
 constitutes an amplified denial-of-service attack.<a href="#section-a.6-3" class="pilcrow">¶</a></p>
 <p id="section-a.6-4">The Organizational Domain mechanism is a necessary component to the
-goals of DMARC.  The method described in <a href="#determining-the-organizational-domain" class="xref">Section 3.15</a> is far from
+goals of DMARC.  The method described in <a href="#determining-the-organizational-domain" class="xref">Section 3.4</a> is far from
 perfect but serves this purpose reasonably well without adding undue
 burden or semantics to the DNS.  If a method is created to do so that
 is more reliable and secure than the use of a public suffix list,
@@ -4593,7 +4602,7 @@ for the full details of this mechanism.<a href="#section-b.2.3-14" class="pilcro
           </h3>
 <p id="section-b.2.4-1">The Domain Owner has implemented SPF and DKIM in a subdomain used for
 pre-production testing of messaging services.  It now wishes to express
-a severity of concern for messages from this subdomain that fail to
+a handling preference for messages from this subdomain that fail to
 authenticate to indicate to participating receivers that use of this
 domain is not valid.<a href="#section-b.2.4-1" class="pilcrow">¶</a></p>
 <p id="section-b.2.4-2">As a first step, it will express that it considers to be suspicious

--- a/draft-ietf-dmarc-dmarcbis-04.html
+++ b/draft-ietf-dmarc-dmarcbis-04.html
@@ -1109,11 +1109,11 @@ dd.break {
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">DMARCbis</td>
-<td class="right">September 2021</td>
+<td class="right">November 2021</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Herr (ed) &amp; Levine (ed)</td>
-<td class="center">Expires 24 March 2022</td>
+<td class="center">Expires 21 May 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1129,12 +1129,12 @@ dd.break {
 <a href="https://www.rfc-editor.org/rfc/rfc7489" class="eref">7489</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-09-20" class="published">20 September 2021</time>
+<time datetime="2021-11-17" class="published">17 November 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-03-24">24 March 2022</time></dd>
+<dd class="expires"><time datetime="2022-05-21">21 May 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1180,7 +1180,7 @@ handling choices for incoming mail.<a href="#section-abstract-2" class="pilcrow"
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 24 March 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 21 May 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -2148,41 +2148,69 @@ domain can be verified.<a href="#section-3.14.3-1" class="pilcrow">¶</a></p>
         <h3 id="name-determining-the-organizatio">
 <a href="#section-3.15" class="section-number selfRef">3.15. </a><a href="#name-determining-the-organizatio" class="section-name selfRef">Determining The Organizational Domain</a>
         </h3>
-<p id="section-3.15-1">The Organizational Domain is determined using the following
-algorithm:<a href="#section-3.15-1" class="pilcrow">¶</a></p>
+<p id="section-3.15-1">The Organizational Domain for a subject DNS domain name is defined as
+the domain that is found in the DNS hierarchy one level below the PSD
+in the subject DNS domain name.  The Organizational Domain is determined
+using the following algorithm, similar to the one described in <a href="#policy-discovery" class="xref">Section 6.7.3</a><a href="#section-3.15-1" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="section-3.15-2">
           <li id="section-3.15-2.1">
-            <p id="section-3.15-2.1.1">Acquire a "public suffix" list, i.e., a list of DNS domain names
-reserved for registrations.  Some country Top-Level Domains
-(TLDs) make specific registration requirements, e.g., the United
-Kingdom places company registrations under ".co.uk"; other TLDs
-such as ".com" appear in the IANA registry of top-level DNS
-domains.  A public suffix list is the union of all of these.
-<a href="#public-suffix-lists" class="xref">Appendix A.6.1</a> contains some discussion about obtaining a public
-suffix list.<a href="#section-3.15-2.1.1" class="pilcrow">¶</a></p>
+            <p id="section-3.15-2.1.1">Query the DNS for a DMARC TXT record at the DNS domain matching the one
+found in the RFC5322.From domain in the message.  A possibly empty set
+of records is returned.<a href="#section-3.15-2.1.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-3.15-2.2">
-            <p id="section-3.15-2.2.1">Break the subject DNS domain name into a set of "n" ordered
-labels.  Number these labels from right to left; e.g., for
-"example.com", "com" would be label 1 and "example" would be
-label 2.<a href="#section-3.15-2.2.1" class="pilcrow">¶</a></p>
+            <p id="section-3.15-2.2.1">Records that do not start with a "v=" tag that identifies the
+current version of DMARC are discarded.<a href="#section-3.15-2.2.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-3.15-2.3">
-            <p id="section-3.15-2.3.1">Search the public suffix list for the name that matches the
-largest number of labels found in the subject DNS domain.  Let
-that number be "x".<a href="#section-3.15-2.3.1" class="pilcrow">¶</a></p>
+            <p id="section-3.15-2.3.1">If the set is now empty, or the set contains one valid DMARC record that
+does not include a psd tag with a value of 'y', then determine the target for
+additional queries, using steps 4 through 8 below.<a href="#section-3.15-2.3.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-3.15-2.4">
-            <p id="section-3.15-2.4.1">Construct a new DNS domain name using the name that matched from
-the public suffix list and prefixing to it the "x+1"th label from
-the subject domain.  This new name is the Organizational Domain.<a href="#section-3.15-2.4.1" class="pilcrow">¶</a></p>
+            <p id="section-3.15-2.4.1">Break the subject DNS domain name into a set of "n" ordered
+labels.  Number these labels from right to left; e.g., for
+"example.com", "com" would be label 1 and "example" would be
+label 2.<a href="#section-3.15-2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-3.15-2.5">
+            <p id="section-3.15-2.5.1">Count the number of labels found in the subject DNS domain. Let that
+number be "x". If x &lt; 5, remove the left-most (highest-numbered)
+label from the subject domain. If x &gt;= 5, remove the left-most
+(highest-numbered) labels from the subject domain until 4 labels remain.
+The resulting DNS domain name is the new target for subsequent lookups.<a href="#section-3.15-2.5.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-3.15-2.6">
+            <p id="section-3.15-2.6.1">Query the DNS for a DMARC TXT record at the DNS domain matching this
+new target in place of the RFC5322.From domain in the message.  A possibly
+empty set of records is returned.<a href="#section-3.15-2.6.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-3.15-2.7">
+            <p id="section-3.15-2.7.1">Records that do not start with a "v=" tag that identifies the
+current version of DMARC are discarded.<a href="#section-3.15-2.7.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-3.15-2.8">
+            <p id="section-3.15-2.8.1">If the set is now empty, or the set contains one valid DMARC record that
+does not include a psd tag with the value of 'y', then determine the
+target for additional queries by removing a single label from the target
+domain as described in step 5 and repeating steps 6 and 7 until
+there are no more labels remaining or a record containing a psd tag with
+a value of 'y' is found.<a href="#section-3.15-2.8.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-3.15-2.9">
+            <p id="section-3.15-2.9.1">Once a valid DMARC record containing a psd tag with a value of 'y' has
+been found, the Organizational Domain for the DNS domain matching the
+one found in the RFC5322.From domain can be declared to be the target
+domain queried for in the step prior to the query that found the PSD
+domain.<a href="#section-3.15-2.9.1" class="pilcrow">¶</a></p>
 </li>
 </ol>
-<p id="section-3.15-3">Thus, since "com" is an IANA-registered TLD, a subject domain of
-"a.b.c.d.example.com" would have an Organizational Domain of
-"example.com".<a href="#section-3.15-3" class="pilcrow">¶</a></p>
-<p id="section-3.15-4">The process of determining a suffix is currently a heuristic one.  No
-list is guaranteed to be accurate or current.<a href="#section-3.15-4" class="pilcrow">¶</a></p>
+<p id="section-3.15-3">For example, given the RFC5322.From domain "a.mail.example.com", a series
+of DNS queries for DMARC records would be executed starting with
+"<em>dmarc.a.mail.example.com" and finishing with "</em>dmarc.com". The "<em>dmarc.com"
+record would contain a psd tag with a value of 'y', and so the Organizational
+Domain for this RFC5322.From domain would be determined to be "example.com",
+the domain of the DMARC query executed prior to the query for "</em>dmarc.com".<a href="#section-3.15-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
@@ -2563,9 +2591,29 @@ methods and their implications.<a href="#section-6.3-7.4.2.6" class="pilcrow">¶
 </dl>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-7.5">rua:</dt>
+<dt id="section-6.3-7.5">psd:</dt>
 <dd id="section-6.3-7.6">
-            <p id="section-6.3-7.6.1">Addresses to which aggregate feedback is to be sent (comma-
+            <p id="section-6.3-7.6.1">A flag indicating whether the domain is a PSD. (plain-text; OPTIONAL;
+default is 'n'). Possible values are:<a href="#section-6.3-7.6.1" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-6.3-7.6.2">
+              <dt id="section-6.3-7.6.2.1">y:</dt>
+<dd id="section-6.3-7.6.2.2">Domains on the PSL that publish DMARC policy records SHOULD include
+this tag with a value of 'y' to indicate that the domain is a PSD. This
+information will be used during policy discovery to determine how to
+apply any DMARC policy records that are discovered during the tree walk.<a href="#section-6.3-7.6.2.2" class="pilcrow">¶</a>
+</dd>
+<dd class="break"></dd>
+<dt id="section-6.3-7.6.2.3">n:</dt>
+<dd id="section-6.3-7.6.2.4">The default, indicating that the DMARC policy record is published
+for a domain that is not a PSD.<a href="#section-6.3-7.6.2.4" class="pilcrow">¶</a>
+</dd>
+<dd class="break"></dd>
+</dl>
+</dd>
+<dd class="break"></dd>
+<dt id="section-6.3-7.7">rua:</dt>
+<dd id="section-6.3-7.8">
+            <p id="section-6.3-7.8.1">Addresses to which aggregate feedback is to be sent (comma-
 separated plain-text list of DMARC URIs; OPTIONAL).  Section 3 of <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span>
 discusses considerations that apply when the domain name of a URI differs
 from that of the domain advertising the policy.  See <a href="#external-report-addresses" class="xref">Section 10.5</a>
@@ -2574,12 +2622,12 @@ A Mail Receiver MUST implement support for a "mailto:" URI, i.e., the
 ability to send a DMARC report via electronic mail.  If not provided,
 Mail Receivers MUST NOT generate aggregate feedback reports.  URIs
 not supported by Mail Receivers MUST be ignored.  The aggregate
-feedback report format is described in <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-6.3-7.6.1" class="pilcrow">¶</a></p>
+feedback report format is described in <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-6.3-7.8.1" class="pilcrow">¶</a></p>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-7.7">ruf:</dt>
-<dd id="section-6.3-7.8">
-            <p id="section-6.3-7.8.1">Addresses to which message-specific failure information is to
+<dt id="section-6.3-7.9">ruf:</dt>
+<dd id="section-6.3-7.10">
+            <p id="section-6.3-7.10.1">Addresses to which message-specific failure information is to
 be reported (comma-separated plain-text list of DMARC URIs;
 OPTIONAL).  If present, the Domain Owner or PSO is requesting Mail
 Receivers to send detailed failure reports about messages that
@@ -2591,12 +2639,12 @@ from that of the domain advertising the policy.  A Mail Receiver
 MUST implement support for a "mailto:" URI, i.e., the ability to
 send a DMARC report via electronic mail.  If not provided, Mail
 Receivers MUST NOT generate failure reports.  See <a href="#external-report-addresses" class="xref">Section 10.5</a> for
-additional considerations.<a href="#section-6.3-7.8.1" class="pilcrow">¶</a></p>
+additional considerations.<a href="#section-6.3-7.10.1" class="pilcrow">¶</a></p>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-7.9">sp:</dt>
-<dd id="section-6.3-7.10">
-            <p id="section-6.3-7.10.1">Domain Owner Assessment Policy for all subdomains (plain-text;
+<dt id="section-6.3-7.11">sp:</dt>
+<dd id="section-6.3-7.12">
+            <p id="section-6.3-7.12.1">Domain Owner Assessment Policy for all subdomains (plain-text;
 OPTIONAL). Indicates the severity of concern the Domain Owner or PSO has
 for mail using an existing subdomain of the domain queried but not
 passing DMARC verification.  It applies only to subdomains of
@@ -2606,41 +2654,41 @@ tag is absent and the "np" tag is either absent or not applicable,
 the policy specified by the "p" tag MUST be applied for subdomains.
 Note that "sp" will be ignored for DMARC records published on
 subdomains of Organizational Domains due to the effect of the
-DMARC policy discovery mechanism described in <a href="#policy-discovery" class="xref">Section 6.7.3</a>.<a href="#section-6.3-7.10.1" class="pilcrow">¶</a></p>
+DMARC policy discovery mechanism described in <a href="#policy-discovery" class="xref">Section 6.7.3</a>.<a href="#section-6.3-7.12.1" class="pilcrow">¶</a></p>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-7.11">t:</dt>
-<dd id="section-6.3-7.12">
-            <p id="section-6.3-7.12.1">DMARC policy test mode (plain-text; OPTIONAL; default is 'n'). For
+<dt id="section-6.3-7.13">t:</dt>
+<dd id="section-6.3-7.14">
+            <p id="section-6.3-7.14.1">DMARC policy test mode (plain-text; OPTIONAL; default is 'n'). For
 the RFC5322.From domain to which the DMARC record applies, the "t"
 tag serves as a signal to the actor performing DMARC verification checks
 as to whether or not the domain owner wishes the assessment policy
 declared in the "p=", "sp=", and/or "np=" tags to actually be applied. This
 parameter does not affect the generation of DMARC reports.  Possible values
-are as follows:<a href="#section-6.3-7.12.1" class="pilcrow">¶</a></p>
-<dl class="dlParallel" id="section-6.3-7.12.2">
-              <dt id="section-6.3-7.12.2.1">y:</dt>
-<dd id="section-6.3-7.12.2.2">A request that the actor performing the DMARC verification check not
+are as follows:<a href="#section-6.3-7.14.1" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-6.3-7.14.2">
+              <dt id="section-6.3-7.14.2.1">y:</dt>
+<dd id="section-6.3-7.14.2.2">A request that the actor performing the DMARC verification check not
 apply the policy, but instead apply any special handling rules it might have
 in place, such as rewriting the RFC5322.From header.  The domain owner is
-currently testing its specified DMARC assessment policy.<a href="#section-6.3-7.12.2.2" class="pilcrow">¶</a>
+currently testing its specified DMARC assessment policy.<a href="#section-6.3-7.14.2.2" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-7.12.2.3">n:</dt>
-<dd id="section-6.3-7.12.2.4">The default, a request to apply the policy as specified to any
-message that produces a DMARC "fail" result.<a href="#section-6.3-7.12.2.4" class="pilcrow">¶</a>
+<dt id="section-6.3-7.14.2.3">n:</dt>
+<dd id="section-6.3-7.14.2.4">The default, a request to apply the policy as specified to any
+message that produces a DMARC "fail" result.<a href="#section-6.3-7.14.2.4" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
 </dl>
 </dd>
 <dd class="break"></dd>
-<dt id="section-6.3-7.13">v:</dt>
-<dd id="section-6.3-7.14">
-            <p id="section-6.3-7.14.1">Version (plain-text; REQUIRED).  Identifies the record retrieved
+<dt id="section-6.3-7.15">v:</dt>
+<dd id="section-6.3-7.16">
+            <p id="section-6.3-7.16.1">Version (plain-text; REQUIRED).  Identifies the record retrieved
 as a DMARC record.  It MUST have the value of "DMARC1".  The value
 of this tag MUST match precisely; if it does not or it is absent,
 the entire retrieved record MUST be ignored.  It MUST be the first
-tag in the list.<a href="#section-6.3-7.14.1" class="pilcrow">¶</a></p>
+tag in the list.<a href="#section-6.3-7.16.1" class="pilcrow">¶</a></p>
 </dd>
 <dd class="break"></dd>
 </dl>
@@ -2944,9 +2992,9 @@ advertise policy.  Policy discovery is accomplished via a method
 similar to the method used for SPF records.  This method, and the
 important differences between DMARC and SPF mechanisms, are discussed
 below.<a href="#section-6.7.3-1" class="pilcrow">¶</a></p>
-<p id="section-6.7.3-2">To balance the conflicting requirements of supporting wildcarding,
-allowing subdomain policy overrides, and limiting DNS query load, the
-following DNS lookup scheme is employed:<a href="#section-6.7.3-2" class="pilcrow">¶</a></p>
+<p id="section-6.7.3-2">To balance the conflicting requirements of supporting wildcarding and
+allowing subdomain policy overrides, the following DNS lookup scheme
+is employed:<a href="#section-6.7.3-2" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="section-6.7.3-3">
             <li id="section-6.7.3-3.1">
               <p id="section-6.7.3-3.1.1">Mail Receivers MUST query the DNS for a DMARC TXT record at the
@@ -2958,49 +3006,56 @@ the message.  A possibly empty set of records is returned.<a href="#section-6.7.
 current version of DMARC are discarded.<a href="#section-6.7.3-3.2.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-6.7.3-3.3">
-              <p id="section-6.7.3-3.3.1">If the set is now empty, the Mail Receiver MUST query the DNS for
-a DMARC TXT record at the DNS domain matching the Organizational
-Domain in place of the RFC5322.From domain in the message (if
-different).  This record can contain policy to be asserted for
-subdomains of the Organizational Domain.  A possibly empty set of
-records is returned.<a href="#section-6.7.3-3.3.1" class="pilcrow">¶</a></p>
+              <p id="section-6.7.3-3.3.1">If the set is now empty, the Mail Receiver determines the target
+for additional queries, using steps 4 through 8 below.<a href="#section-6.7.3-3.3.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-6.7.3-3.4">
-              <p id="section-6.7.3-3.4.1">Records that do not start with a "v=" tag that identifies the
-current version of DMARC are discarded.<a href="#section-6.7.3-3.4.1" class="pilcrow">¶</a></p>
+              <p id="section-6.7.3-3.4.1">Break the subject DNS domain name into a set of "n" ordered labels.
+Number these lables from right to left; e.g., for "example.com",
+"com" would be label 1 and "example" would be label 2.<a href="#section-6.7.3-3.4.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-6.7.3-3.5">
-              <p id="section-6.7.3-3.5.1">If the set is now empty and the longest PSD <a href="#longest-psd" class="xref">Section 3.6</a> of the
-Organizational Domain is one that the receiver has determined is
-acceptable for PSD DMARC (based on the data in one of the DMARC
-PSD Registry Examples decribed in Appendix B of <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>)
-the Mail Receiver MUST query the DNS for a DMARC TXT record at
-the DNS domain matching the longest PSD in place of the RFC5322.From
-domain in the message (if different).  A possibly empty set of records
-is returned.<a href="#section-6.7.3-3.5.1" class="pilcrow">¶</a></p>
+              <p id="section-6.7.3-3.5.1">Count the number of labels found in the subject DNS domain. Let that
+number be "x". If x &lt; 5, remove the left-most (highest-numbered)
+label from the subject domain. If x &gt;= 5, remove the left-most
+(highest-numbered) labels from the subject domain until 4 labels remain.
+The resulting DNS domain name is the new target for subsequent lookups.<a href="#section-6.7.3-3.5.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-6.7.3-3.6">
-              <p id="section-6.7.3-3.6.1">Records that do not start with a "v=" tag that identifies the
-current version of DMARC are discarded.<a href="#section-6.7.3-3.6.1" class="pilcrow">¶</a></p>
+              <p id="section-6.7.3-3.6.1">The Mail Receiver MUST query the DNS for a DMARC TXT record at
+the DNS domain matching this new target in place of the RFC5322.From
+domain in the message. This record can contain policy to be asserted
+for subdomains of the target. A possibly empty set of records is
+returned.<a href="#section-6.7.3-3.6.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-6.7.3-3.7">
-              <p id="section-6.7.3-3.7.1">If the remaining set contains multiple records or no records,
-policy discovery terminates and DMARC processing is not applied
-to this message.<a href="#section-6.7.3-3.7.1" class="pilcrow">¶</a></p>
+              <p id="section-6.7.3-3.7.1">Records that do not start with a "v=" tag that identifies the
+current version of DMARC are discarded.<a href="#section-6.7.3-3.7.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-6.7.3-3.8">
-              <p id="section-6.7.3-3.8.1">If a retrieved policy record does not contain a valid "p" tag, or
-contains an "sp" tag that is not valid, then:<a href="#section-6.7.3-3.8.1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-6.7.3-3.8.2">
-                <li id="section-6.7.3-3.8.2.1">
-                  <p id="section-6.7.3-3.8.2.1.1">if a "rua" tag is present and contains at least one
+              <p id="section-6.7.3-3.8.1">If the set is now empty, the Mail Receiver determines the target
+for additional queries by removing a single label from the target
+domain as described in step 5 and repeating steps 6 and 7 until
+there are no more labels remaining.<a href="#section-6.7.3-3.8.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-6.7.3-3.9">
+              <p id="section-6.7.3-3.9.1">If the remaining set contains multiple records or no records,
+policy discovery terminates and DMARC processing is not applied
+to this message.<a href="#section-6.7.3-3.9.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-6.7.3-3.10">
+              <p id="section-6.7.3-3.10.1">If a retrieved policy record does not contain a valid "p" tag, or
+contains an "sp" tag that is not valid, then:<a href="#section-6.7.3-3.10.1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-6.7.3-3.10.2">
+                <li id="section-6.7.3-3.10.2.1">
+                  <p id="section-6.7.3-3.10.2.1.1">if a "rua" tag is present and contains at least one
 syntactically valid reporting URI, the Mail Receiver SHOULD
 act as if a record containing a valid "v" tag and "p=none"
-was retrieved, and continue processing;<a href="#section-6.7.3-3.8.2.1.1" class="pilcrow">¶</a></p>
+was retrieved, and continue processing;<a href="#section-6.7.3-3.10.2.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-6.7.3-3.8.2.2">
-                  <p id="section-6.7.3-3.8.2.2.1">otherwise, the Mail Receiver applies no DMARC processing to
-this message.<a href="#section-6.7.3-3.8.2.2.1" class="pilcrow">¶</a></p>
+<li id="section-6.7.3-3.10.2.2">
+                  <p id="section-6.7.3-3.10.2.2.1">otherwise, the Mail Receiver applies no DMARC processing to
+this message.<a href="#section-6.7.3-3.10.2.2.1" class="pilcrow">¶</a></p>
 </li>
 </ol>
 </li>

--- a/draft-ietf-dmarc-dmarcbis-04.html
+++ b/draft-ietf-dmarc-dmarcbis-04.html
@@ -1113,7 +1113,7 @@ dd.break {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Herr (ed) &amp; Levine (ed)</td>
-<td class="center">Expires 27 May 2022</td>
+<td class="center">Expires 3 June 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1129,12 +1129,12 @@ dd.break {
 <a href="https://www.rfc-editor.org/rfc/rfc7489" class="eref">7489</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-11-23" class="published">23 November 2021</time>
+<time datetime="2021-11-30" class="published">30 November 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-05-27">27 May 2022</time></dd>
+<dd class="expires"><time datetime="2022-06-03">3 June 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1180,7 +1180,7 @@ handling choices for incoming mail.<a href="#section-abstract-2" class="pilcrow"
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 27 May 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 3 June 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1219,13 +1219,13 @@ handling choices for incoming mail.<a href="#section-abstract-2" class="pilcrow"
                 <p id="section-toc.1-1.2.2.1.1" class="keepWithNext"><a href="#section-2.1" class="xref">2.1</a>.  <a href="#name-high-level-goals" class="xref">High-Level Goals</a><a href="#section-toc.1-1.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.2">
-                <p id="section-toc.1-1.2.2.2.1" class="keepWithNext"><a href="#section-2.2" class="xref">2.2</a>.  <a href="#name-out-of-scope" class="xref">Out of Scope</a><a href="#section-toc.1-1.2.2.2.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.2.2.2.1" class="keepWithNext"><a href="#section-2.2" class="xref">2.2</a>.  <a href="#name-anti-phishing" class="xref">Anti-Phishing</a><a href="#section-toc.1-1.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.3">
                 <p id="section-toc.1-1.2.2.3.1"><a href="#section-2.3" class="xref">2.3</a>.  <a href="#name-scalability" class="xref">Scalability</a><a href="#section-toc.1-1.2.2.3.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.4">
-                <p id="section-toc.1-1.2.2.4.1"><a href="#section-2.4" class="xref">2.4</a>.  <a href="#name-anti-phishing" class="xref">Anti-Phishing</a><a href="#section-toc.1-1.2.2.4.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.2.2.4.1"><a href="#section-2.4" class="xref">2.4</a>.  <a href="#name-out-of-scope" class="xref">Out of Scope</a><a href="#section-toc.1-1.2.2.4.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
@@ -1251,28 +1251,25 @@ handling choices for incoming mail.<a href="#section-abstract-2" class="pilcrow"
                     <p id="section-toc.1-1.3.2.2.2.4.1"><a href="#section-3.2.4" class="xref">3.2.4</a>.  <a href="#name-identifier-alignment" class="xref">Identifier Alignment</a><a href="#section-toc.1-1.3.2.2.2.4.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.5">
-                    <p id="section-toc.1-1.3.2.2.2.5.1"><a href="#section-3.2.5" class="xref">3.2.5</a>.  <a href="#name-longest-psd" class="xref">Longest PSD</a><a href="#section-toc.1-1.3.2.2.2.5.1" class="pilcrow">¶</a></p>
+                    <p id="section-toc.1-1.3.2.2.2.5.1"><a href="#section-3.2.5" class="xref">3.2.5</a>.  <a href="#name-mail-receiver" class="xref">Mail Receiver</a><a href="#section-toc.1-1.3.2.2.2.5.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.6">
-                    <p id="section-toc.1-1.3.2.2.2.6.1"><a href="#section-3.2.6" class="xref">3.2.6</a>.  <a href="#name-mail-receiver" class="xref">Mail Receiver</a><a href="#section-toc.1-1.3.2.2.2.6.1" class="pilcrow">¶</a></p>
+                    <p id="section-toc.1-1.3.2.2.2.6.1"><a href="#section-3.2.6" class="xref">3.2.6</a>.  <a href="#name-non-existent-domains" class="xref">Non-existent Domains</a><a href="#section-toc.1-1.3.2.2.2.6.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.7">
-                    <p id="section-toc.1-1.3.2.2.2.7.1"><a href="#section-3.2.7" class="xref">3.2.7</a>.  <a href="#name-non-existent-domains" class="xref">Non-existent Domains</a><a href="#section-toc.1-1.3.2.2.2.7.1" class="pilcrow">¶</a></p>
+                    <p id="section-toc.1-1.3.2.2.2.7.1"><a href="#section-3.2.7" class="xref">3.2.7</a>.  <a href="#name-organizational-domain" class="xref">Organizational Domain</a><a href="#section-toc.1-1.3.2.2.2.7.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.8">
-                    <p id="section-toc.1-1.3.2.2.2.8.1"><a href="#section-3.2.8" class="xref">3.2.8</a>.  <a href="#name-organizational-domain" class="xref">Organizational Domain</a><a href="#section-toc.1-1.3.2.2.2.8.1" class="pilcrow">¶</a></p>
+                    <p id="section-toc.1-1.3.2.2.2.8.1"><a href="#section-3.2.8" class="xref">3.2.8</a>.  <a href="#name-public-suffix-domain-psd" class="xref">Public Suffix Domain (PSD)</a><a href="#section-toc.1-1.3.2.2.2.8.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.9">
-                    <p id="section-toc.1-1.3.2.2.2.9.1"><a href="#section-3.2.9" class="xref">3.2.9</a>.  <a href="#name-public-suffix-domain-psd" class="xref">Public Suffix Domain (PSD)</a><a href="#section-toc.1-1.3.2.2.2.9.1" class="pilcrow">¶</a></p>
+                    <p id="section-toc.1-1.3.2.2.2.9.1"><a href="#section-3.2.9" class="xref">3.2.9</a>.  <a href="#name-public-suffix-operator-pso" class="xref">Public Suffix Operator (PSO)</a><a href="#section-toc.1-1.3.2.2.2.9.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.10">
-                    <p id="section-toc.1-1.3.2.2.2.10.1"><a href="#section-3.2.10" class="xref">3.2.10</a>. <a href="#name-public-suffix-operator-pso" class="xref">Public Suffix Operator (PSO)</a><a href="#section-toc.1-1.3.2.2.2.10.1" class="pilcrow">¶</a></p>
+                    <p id="section-toc.1-1.3.2.2.2.10.1"><a href="#section-3.2.10" class="xref">3.2.10</a>. <a href="#name-pso-controlled-domain-names" class="xref">PSO Controlled Domain Names</a><a href="#section-toc.1-1.3.2.2.2.10.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.11">
-                    <p id="section-toc.1-1.3.2.2.2.11.1"><a href="#section-3.2.11" class="xref">3.2.11</a>. <a href="#name-pso-controlled-domain-names" class="xref">PSO Controlled Domain Names</a><a href="#section-toc.1-1.3.2.2.2.11.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.2.2.12">
-                    <p id="section-toc.1-1.3.2.2.2.12.1"><a href="#section-3.2.12" class="xref">3.2.12</a>. <a href="#name-report-receiver" class="xref">Report Receiver</a><a href="#section-toc.1-1.3.2.2.2.12.1" class="pilcrow">¶</a></p>
+                    <p id="section-toc.1-1.3.2.2.2.11.1"><a href="#section-3.2.11" class="xref">3.2.11</a>. <a href="#name-report-receiver" class="xref">Report Receiver</a><a href="#section-toc.1-1.3.2.2.2.11.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
@@ -1473,11 +1470,6 @@ handling choices for incoming mail.<a href="#section-abstract-2" class="pilcrow"
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.12.2.6">
                 <p id="section-toc.1-1.12.2.6.1"><a href="#section-a.6" class="xref">A.6</a>.  <a href="#name-organizational-domain-disco" class="xref">Organizational Domain Discovery Issues</a><a href="#section-toc.1-1.12.2.6.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.12.2.6.2.1">
-                    <p id="section-toc.1-1.12.2.6.2.1.1"><a href="#section-a.6.1" class="xref">A.6.1</a>.  <a href="#name-public-suffix-lists" class="xref">Public Suffix Lists</a><a href="#section-toc.1-1.12.2.6.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.12.2.7">
                 <p id="section-toc.1-1.12.2.7.1"><a href="#section-a.7" class="xref">A.7</a>.  <a href="#name-removal-of-the-pct-tag" class="xref">Removal of the "pct" Tag</a><a href="#section-toc.1-1.12.2.7.1" class="pilcrow">¶</a></p>
@@ -1517,197 +1509,22 @@ handling choices for incoming mail.<a href="#section-abstract-2" class="pilcrow"
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.13.2.3">
                 <p id="section-toc.1-1.13.2.3.1"><a href="#section-b.3" class="xref">B.3</a>.  <a href="#name-mail-receiver-example" class="xref">Mail Receiver Example</a><a href="#section-toc.1-1.13.2.3.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.13.2.3.2.1">
+                    <p id="section-toc.1-1.13.2.3.2.1.1"><a href="#section-b.3.1" class="xref">B.3.1</a>.  <a href="#name-smtp-session-example" class="xref">SMTP Session Example</a><a href="#section-toc.1-1.13.2.3.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.13.2.4">
-                <p id="section-toc.1-1.13.2.4.1"><a href="#section-b.4" class="xref">B.4</a>.  <a href="#name-processing-of-smtp-time" class="xref">Processing of SMTP Time</a><a href="#section-toc.1-1.13.2.4.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.13.2.5">
-                <p id="section-toc.1-1.13.2.5.1"><a href="#section-b.5" class="xref">B.5</a>.  <a href="#name-utilization-of-aggregate-fe" class="xref">Utilization of Aggregate Feedback: Example</a><a href="#section-toc.1-1.13.2.5.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.13.2.4.1"><a href="#section-b.4" class="xref">B.4</a>.  <a href="#name-utilization-of-aggregate-fe" class="xref">Utilization of Aggregate Feedback: Example</a><a href="#section-toc.1-1.13.2.4.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.14">
-            <p id="section-toc.1-1.14.1"><a href="#section-appendix.c" class="xref">Appendix C</a>.  <a href="#name-change-log" class="xref">Change Log</a><a href="#section-toc.1-1.14.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.1">
-                <p id="section-toc.1-1.14.2.1.1"><a href="#section-c.1" class="xref">C.1</a>.  <a href="#name-january-5-2021" class="xref">January 5, 2021</a><a href="#section-toc.1-1.14.2.1.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.1.2.1">
-                    <p id="section-toc.1-1.14.2.1.2.1.1"><a href="#section-c.1.1" class="xref">C.1.1</a>.  <a href="#name-ticket-80-dmarcbis-should-h" class="xref">Ticket 80 - DMARCbis SHould Have Clear and Concise Defintion of DMARC</a><a href="#section-toc.1-1.14.2.1.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.2">
-                <p id="section-toc.1-1.14.2.2.1"><a href="#section-c.2" class="xref">C.2</a>.  <a href="#name-february-4-2021" class="xref">February 4, 2021</a><a href="#section-toc.1-1.14.2.2.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.2.2.1">
-                    <p id="section-toc.1-1.14.2.2.2.1.1"><a href="#section-c.2.1" class="xref">C.2.1</a>.  <a href="#name-ticket-1-spf-rfc-4408-vs-72" class="xref">Ticket 1 - SPF RFC 4408 vs 7208</a><a href="#section-toc.1-1.14.2.2.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.3">
-                <p id="section-toc.1-1.14.2.3.1"><a href="#section-c.3" class="xref">C.3</a>.  <a href="#name-february-10-2021" class="xref">February 10, 2021</a><a href="#section-toc.1-1.14.2.3.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.3.2.1">
-                    <p id="section-toc.1-1.14.2.3.2.1.1"><a href="#section-c.3.1" class="xref">C.3.1</a>.  <a href="#name-ticket-84-remove-erroneous-" class="xref">Ticket 84 - Remove Erroneous References to RFC3986</a><a href="#section-toc.1-1.14.2.3.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.4">
-                <p id="section-toc.1-1.14.2.4.1"><a href="#section-c.4" class="xref">C.4</a>.  <a href="#name-march-1-2021" class="xref">March 1, 2021</a><a href="#section-toc.1-1.14.2.4.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.4.2.1">
-                    <p id="section-toc.1-1.14.2.4.2.1.1"><a href="#section-c.4.1" class="xref">C.4.1</a>.  <a href="#name-design-team-work-begins" class="xref">Design Team Work Begins</a><a href="#section-toc.1-1.14.2.4.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.5">
-                <p id="section-toc.1-1.14.2.5.1"><a href="#section-c.5" class="xref">C.5</a>.  <a href="#name-march-8-2021" class="xref">March 8, 2021</a><a href="#section-toc.1-1.14.2.5.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.5.2.1">
-                    <p id="section-toc.1-1.14.2.5.2.1.1"><a href="#section-c.5.1" class="xref">C.5.1</a>.  <a href="#name-removed-e-gustafsson-as-edi" class="xref">Removed E. Gustafsson as editor</a><a href="#section-toc.1-1.14.2.5.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.5.2.2">
-                    <p id="section-toc.1-1.14.2.5.2.2.1"><a href="#section-c.5.2" class="xref">C.5.2</a>.  <a href="#name-ticket-3-two-tiny-nits" class="xref">Ticket 3 - Two tiny nits</a><a href="#section-toc.1-1.14.2.5.2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.5.2.3">
-                    <p id="section-toc.1-1.14.2.5.2.3.1"><a href="#section-c.5.3" class="xref">C.5.3</a>.  <a href="#name-ticket-4-definition-of-fo-p" class="xref">Ticket 4 - Definition of "fo" parameter</a><a href="#section-toc.1-1.14.2.5.2.3.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.6">
-                <p id="section-toc.1-1.14.2.6.1"><a href="#section-c.6" class="xref">C.6</a>.  <a href="#name-march-16-2021" class="xref">March 16, 2021</a><a href="#section-toc.1-1.14.2.6.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.6.2.1">
-                    <p id="section-toc.1-1.14.2.6.2.1.1"><a href="#section-c.6.1" class="xref">C.6.1</a>.  <a href="#name-ticket-7-abnf-for-dmarc-rec" class="xref">Ticket 7 - ABNF for dmarc-record is slightly wrong</a><a href="#section-toc.1-1.14.2.6.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.6.2.2">
-                    <p id="section-toc.1-1.14.2.6.2.2.1"><a href="#section-c.6.2" class="xref">C.6.2</a>.  <a href="#name-ticket-26-abnf-for-pct-allo" class="xref">Ticket 26 - ABNF for pct allows "999"</a><a href="#section-toc.1-1.14.2.6.2.2.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.7">
-                <p id="section-toc.1-1.14.2.7.1"><a href="#section-c.7" class="xref">C.7</a>.  <a href="#name-march-23-2021" class="xref">March 23, 2021</a><a href="#section-toc.1-1.14.2.7.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.7.2.1">
-                    <p id="section-toc.1-1.14.2.7.2.1.1"><a href="#section-c.7.1" class="xref">C.7.1</a>.  <a href="#name-ticket-75-using-wording-alt" class="xref">Ticket 75 - Using wording alternatives to 'disposition', 'dispose', and the like</a><a href="#section-toc.1-1.14.2.7.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.7.2.2">
-                    <p id="section-toc.1-1.14.2.7.2.2.1"><a href="#section-c.7.2" class="xref">C.7.2</a>.  <a href="#name-ticket-72-remove-absolute-r" class="xref">Ticket 72 - Remove absolute requirement for p= tag in DMARC record</a><a href="#section-toc.1-1.14.2.7.2.2.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.8">
-                <p id="section-toc.1-1.14.2.8.1"><a href="#section-c.8" class="xref">C.8</a>.  <a href="#name-march-29-2021" class="xref">March 29, 2021</a><a href="#section-toc.1-1.14.2.8.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.8.2.1">
-                    <p id="section-toc.1-1.14.2.8.2.1.1"><a href="#section-c.8.1" class="xref">C.8.1</a>.  <a href="#name-ticket-54-remove-or-expand-" class="xref">Ticket 54 - Remove or expand limits on number of recipients per report</a><a href="#section-toc.1-1.14.2.8.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.9">
-                <p id="section-toc.1-1.14.2.9.1"><a href="#section-c.9" class="xref">C.9</a>.  <a href="#name-april-12-2021" class="xref">April 12, 2021</a><a href="#section-toc.1-1.14.2.9.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.9.2.1">
-                    <p id="section-toc.1-1.14.2.9.2.1.1"><a href="#section-c.9.1" class="xref">C.9.1</a>.  <a href="#name-ticket-50-remove-ri-tag" class="xref">Ticket 50 - Remove ri= tag</a><a href="#section-toc.1-1.14.2.9.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.9.2.2">
-                    <p id="section-toc.1-1.14.2.9.2.2.1"><a href="#section-c.9.2" class="xref">C.9.2</a>.  <a href="#name-ticket-66-define-what-it-me" class="xref">Ticket 66 - Define what it means to have implemented DMARC</a><a href="#section-toc.1-1.14.2.9.2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.9.2.3">
-                    <p id="section-toc.1-1.14.2.9.2.3.1"><a href="#section-c.9.3" class="xref">C.9.3</a>.  <a href="#name-ticket-96-tweaks-to-abstrac" class="xref">Ticket 96 - Tweaks to Abstract and Introduction</a><a href="#section-toc.1-1.14.2.9.2.3.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.10">
-                <p id="section-toc.1-1.14.2.10.1"><a href="#section-c.10" class="xref">C.10</a>. <a href="#name-april-13-2021" class="xref">April 13, 2021</a><a href="#section-toc.1-1.14.2.10.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.10.2.1">
-                    <p id="section-toc.1-1.14.2.10.2.1.1"><a href="#section-c.10.1" class="xref">C.10.1</a>.  <a href="#name-ticket-53-remove-reporting-" class="xref">Ticket 53 - Remove reporting message size chunking</a><a href="#section-toc.1-1.14.2.10.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.10.2.2">
-                    <p id="section-toc.1-1.14.2.10.2.2.1"><a href="#section-c.10.2" class="xref">C.10.2</a>.  <a href="#name-ticket-52-remove-strict-ali" class="xref">Ticket 52 - Remove strict alignment (and adkim and aspf tags)</a><a href="#section-toc.1-1.14.2.10.2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.10.2.3">
-                    <p id="section-toc.1-1.14.2.10.2.3.1"><a href="#section-c.10.3" class="xref">C.10.3</a>.  <a href="#name-ticket-47-remove-pct-tag" class="xref">Ticket 47 - Remove pct= tag</a><a href="#section-toc.1-1.14.2.10.2.3.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.10.2.4">
-                    <p id="section-toc.1-1.14.2.10.2.4.1"><a href="#section-c.10.4" class="xref">C.10.4</a>.  <a href="#name-ticket-2-flow-of-operations" class="xref">Ticket 2 - Flow of operations text in dmarc-base</a><a href="#section-toc.1-1.14.2.10.2.4.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.11">
-                <p id="section-toc.1-1.14.2.11.1"><a href="#section-c.11" class="xref">C.11</a>. <a href="#name-april-14-2021" class="xref">April 14, 2021</a><a href="#section-toc.1-1.14.2.11.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.11.2.1">
-                    <p id="section-toc.1-1.14.2.11.2.1.1"><a href="#section-c.11.1" class="xref">C.11.1</a>.  <a href="#name-ticket-107-dmarcbis-should-" class="xref">Ticket 107 - DMARCbis should take a stand on multi-valued From fields</a><a href="#section-toc.1-1.14.2.11.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.11.2.2">
-                    <p id="section-toc.1-1.14.2.11.2.2.1"><a href="#section-c.11.2" class="xref">C.11.2</a>.  <a href="#name-ticket-82-deprecate-rf-and-" class="xref">Ticket 82 - Deprecate rf= and maybe fo= tag</a><a href="#section-toc.1-1.14.2.11.2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.11.2.3">
-                    <p id="section-toc.1-1.14.2.11.2.3.1"><a href="#section-c.11.3" class="xref">C.11.3</a>.  <a href="#name-ticket-85-proposed-change-t" class="xref">Ticket 85 - Proposed change to wording describing 'p' tag and values</a><a href="#section-toc.1-1.14.2.11.2.3.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.12">
-                <p id="section-toc.1-1.14.2.12.1"><a href="#section-c.12" class="xref">C.12</a>. <a href="#name-april-15-2021" class="xref">April 15, 2021</a><a href="#section-toc.1-1.14.2.12.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.12.2.1">
-                    <p id="section-toc.1-1.14.2.12.2.1.1"><a href="#section-c.12.1" class="xref">C.12.1</a>.  <a href="#name-ticket-86-a-r-results-for-d" class="xref">Ticket 86 - A-R results for DMARC</a><a href="#section-toc.1-1.14.2.12.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.12.2.2">
-                    <p id="section-toc.1-1.14.2.12.2.2.1"><a href="#section-c.12.2" class="xref">C.12.2</a>.  <a href="#name-ticket-62-make-aggregate-re" class="xref">Ticket 62 - Make aggregate reporting a normative MUST</a><a href="#section-toc.1-1.14.2.12.2.2.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.13">
-                <p id="section-toc.1-1.14.2.13.1"><a href="#section-c.13" class="xref">C.13</a>. <a href="#name-april-19-2021" class="xref">April 19, 2021</a><a href="#section-toc.1-1.14.2.13.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.13.2.1">
-                    <p id="section-toc.1-1.14.2.13.2.1.1"><a href="#section-c.13.1" class="xref">C.13.1</a>.  <a href="#name-ticket-109-sanity-check-dma" class="xref">Ticket 109 - Sanity Check DMARCbis Document</a><a href="#section-toc.1-1.14.2.13.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.14">
-                <p id="section-toc.1-1.14.2.14.1"><a href="#section-c.14" class="xref">C.14</a>. <a href="#name-april-20-2021" class="xref">April 20, 2021</a><a href="#section-toc.1-1.14.2.14.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.14.2.1">
-                    <p id="section-toc.1-1.14.2.14.2.1.1"><a href="#section-c.14.1" class="xref">C.14.1</a>.  <a href="#name-ticket-108-changes-to-dmarc" class="xref">Ticket 108 - Changes to DMARCbis for PSD</a><a href="#section-toc.1-1.14.2.14.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.15">
-                <p id="section-toc.1-1.14.2.15.1"><a href="#section-c.15" class="xref">C.15</a>. <a href="#name-april-22-2021" class="xref">April 22, 2021</a><a href="#section-toc.1-1.14.2.15.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.15.2.1">
-                    <p id="section-toc.1-1.14.2.15.2.1.1"><a href="#section-c.15.1" class="xref">C.15.1</a>.  <a href="#name-ticket-104-update-the-secur" class="xref">Ticket 104 - Update the Security Considerations section 11.3 on DNS</a><a href="#section-toc.1-1.14.2.15.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.16">
-                <p id="section-toc.1-1.14.2.16.1"><a href="#section-c.16" class="xref">C.16</a>. <a href="#name-june-16-2021" class="xref">June 16, 2021</a><a href="#section-toc.1-1.14.2.16.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.16.2.1">
-                    <p id="section-toc.1-1.14.2.16.2.1.1"><a href="#section-c.16.1" class="xref">C.16.1</a>.  <a href="#name-publication-of-draft-ietf-d" class="xref">Publication of draft-ietf-dmarc-dmarcbis-02</a><a href="#section-toc.1-1.14.2.16.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.17">
-                <p id="section-toc.1-1.14.2.17.1"><a href="#section-c.17" class="xref">C.17</a>. <a href="#name-august-12-2021" class="xref">August 12, 2021</a><a href="#section-toc.1-1.14.2.17.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.14.2.17.2.1">
-                    <p id="section-toc.1-1.14.2.17.2.1.1"><a href="#section-c.17.1" class="xref">C.17.1</a>.  <a href="#name-publication-of-draft-ietf-dm" class="xref">Publication of draft-ietf-dmarc-dmarcbis-03</a><a href="#section-toc.1-1.14.2.17.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-</ul>
+            <p id="section-toc.1-1.14.1"><a href="#section-appendix.c" class="xref"></a><a href="#name-acknowledgements" class="xref">Acknowledgements</a><a href="#section-toc.1-1.14.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.15">
-            <p id="section-toc.1-1.15.1"><a href="#section-appendix.d" class="xref"></a><a href="#name-acknowledgements" class="xref">Acknowledgements</a><a href="#section-toc.1-1.15.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.16">
-            <p id="section-toc.1-1.16.1"><a href="#section-appendix.e" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a><a href="#section-toc.1-1.16.1" class="pilcrow">¶</a></p>
+            <p id="section-toc.1-1.15.1"><a href="#section-appendix.d" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a><a href="#section-toc.1-1.15.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </nav>
@@ -1727,9 +1544,9 @@ belongs to an organization expected to be known to - and presumably
 trusted by - the recipient. The Sender Policy Framework (SPF) <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span>
 and DomainKeys Identified Mail (DKIM) <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span> protocols provide
 domain-level authentication but are not directly associated with the
-RFC5322.From domain. DMARC leverages them, and provides a method for
-Domain Owners to publish a DNS record describing the email authentication
-policies for the RFC5322.From domain and to request a specific handling
+RFC5322.From domain. DMARC leverages these two protocols, providing a method
+for Domain Owners to publish a DNS record describing the email authentication
+policies for the RFC5322.From domain and to request specific handling
 for messages using that domain that fail authentication checks.<a href="#section-1-2" class="pilcrow">¶</a></p>
 <p id="section-1-3">As with SPF and DKIM, DMARC classes results as "pass" or "fail". In order
 to get a DMARC result of "pass", a pass from either SPF or DKIM is required.
@@ -1767,7 +1584,8 @@ Owners can use these reports, especially the aggregate reports, to identify
 not only sources of mail attempting to fraudulently use their domain, but also
 (and perhaps more importantly) gaps in their own authentication practices. However,
 as with honoring the Domain Owner's stated mail handling preference, a mail-receiving
-organization supporting DMARC is under no obligation to send requested reports.<a href="#section-1-7" class="pilcrow">¶</a></p>
+organization supporting DMARC is under no obligation to send requested reports,
+although it is recommended that they do send aggregate reports.<a href="#section-1-7" class="pilcrow">¶</a></p>
 <p id="section-1-8">Use of DMARC creates some interoperability challenges that require due
 consideration before deployment, particularly with configurations that
 can cause mail to be rejected.  These are discussed in <a href="#other-topics" class="xref">Section 7</a>.<a href="#section-1-8" class="pilcrow">¶</a></p>
@@ -1810,43 +1628,26 @@ messages.<a href="#section-2.1-2.3.1" class="pilcrow">¶</a></p>
 </ul>
 </section>
 </div>
-<div id="out-of-scope">
+<div id="anti-phishing">
 <section id="section-2.2">
-        <h3 id="name-out-of-scope">
-<a href="#section-2.2" class="section-number selfRef">2.2. </a><a href="#name-out-of-scope" class="section-name selfRef">Out of Scope</a>
+        <h3 id="name-anti-phishing">
+<a href="#section-2.2" class="section-number selfRef">2.2. </a><a href="#name-anti-phishing" class="section-name selfRef">Anti-Phishing</a>
         </h3>
-<p id="section-2.2-1">Several topics and issues are specifically out of scope for this
-work.  These include the following:<a href="#section-2.2-1" class="pilcrow">¶</a></p>
-<ul>
-<li id="section-2.2-2.1">
-            <p id="section-2.2-2.1.1">Different treatment of messages that are not authenticated versus
-those that fail authentication;<a href="#section-2.2-2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2.2-2.2">
-            <p id="section-2.2-2.2.1">Evaluation of anything other than RFC5322.From header field;<a href="#section-2.2-2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2.2-2.3">
-            <p id="section-2.2-2.3.1">Multiple reporting formats;<a href="#section-2.2-2.3.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2.2-2.4">
-            <p id="section-2.2-2.4.1">Publishing policy other than via the DNS;<a href="#section-2.2-2.4.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2.2-2.5">
-            <p id="section-2.2-2.5.1">Reporting or otherwise evaluating other than the last-hop IP
-address;<a href="#section-2.2-2.5.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2.2-2.6">
-            <p id="section-2.2-2.6.1">Attacks in the From: header field, also known as "display name"
-attacks;<a href="#section-2.2-2.6.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2.2-2.7">
-            <p id="section-2.2-2.7.1">Authentication of entities other than domains, since DMARC is
-built upon SPF and DKIM, which authenticate domains; and<a href="#section-2.2-2.7.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2.2-2.8">
-            <p id="section-2.2-2.8.1">Content analysis.<a href="#section-2.2-2.8.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
+<p id="section-2.2-1">DMARC is designed to prevent bad actors from sending mail that claims
+to come from legitimate senders, particularly senders of transactional
+email (official mail that is about business transactions).  One of the
+primary uses of this kind of spoofed mail is phishing (enticing users
+to provide information by pretending to be the legitimate service
+requesting the information).  Thus, DMARC is significantly informed
+by ongoing efforts to enact large-scale, Internet-wide anti-phishing
+measures.<a href="#section-2.2-1" class="pilcrow">¶</a></p>
+<p id="section-2.2-2">Although DMARC can only be used to combat specific forms of
+exact-domain spoofing directly, the DMARC mechanism has been found
+to be useful in the creation of reliable and defensible message streams.<a href="#section-2.2-2" class="pilcrow">¶</a></p>
+<p id="section-2.2-3">DMARC does not attempt to solve all problems with spoofed or
+otherwise fraudulent email.  In particular, it does not address the
+use of visually similar domain names ("cousin domains") or abuse of
+the RFC5322.From human-readable &lt;display-name&gt;.<a href="#section-2.2-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="scalability">
@@ -1865,26 +1666,43 @@ email-handling flow, it also does not preclude them.  Such third
 parties are free to provide services in conjunction with DMARC.<a href="#section-2.3-2" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="anti-phishing">
+<div id="out-of-scope">
 <section id="section-2.4">
-        <h3 id="name-anti-phishing">
-<a href="#section-2.4" class="section-number selfRef">2.4. </a><a href="#name-anti-phishing" class="section-name selfRef">Anti-Phishing</a>
+        <h3 id="name-out-of-scope">
+<a href="#section-2.4" class="section-number selfRef">2.4. </a><a href="#name-out-of-scope" class="section-name selfRef">Out of Scope</a>
         </h3>
-<p id="section-2.4-1">DMARC is designed to prevent bad actors from sending mail that claims
-to come from legitimate senders, particularly senders of
-transactional email (official mail that is about business
-transactions).  One of the primary uses of this kind of spoofed mail
-is phishing (enticing users to provide information by pretending to
-be the legitimate service requesting the information).  Thus, DMARC
-is significantly informed by ongoing efforts to enact large-scale,
-Internet-wide anti-phishing measures.<a href="#section-2.4-1" class="pilcrow">¶</a></p>
-<p id="section-2.4-2">Although DMARC can only be used to combat specific forms of exact-
-domain spoofing directly, the DMARC mechanism has been found to be
-useful in the creation of reliable and defensible message streams.<a href="#section-2.4-2" class="pilcrow">¶</a></p>
-<p id="section-2.4-3">DMARC does not attempt to solve all problems with spoofed or
-otherwise fraudulent email.  In particular, it does not address the
-use of visually similar domain names ("cousin domains") or abuse of
-the RFC5322.From human-readable &lt;display-name&gt;.<a href="#section-2.4-3" class="pilcrow">¶</a></p>
+<p id="section-2.4-1">Several topics and issues are specifically out of scope for this
+work.  These include the following:<a href="#section-2.4-1" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-2.4-2.1">
+            <p id="section-2.4-2.1.1">Different treatment of messages that are not authenticated versus
+those that fail authentication;<a href="#section-2.4-2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.4-2.2">
+            <p id="section-2.4-2.2.1">Evaluation of anything other than RFC5322.From header field;<a href="#section-2.4-2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.4-2.3">
+            <p id="section-2.4-2.3.1">Multiple reporting formats;<a href="#section-2.4-2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.4-2.4">
+            <p id="section-2.4-2.4.1">Publishing policy other than via the DNS;<a href="#section-2.4-2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.4-2.5">
+            <p id="section-2.4-2.5.1">Reporting or otherwise evaluating other than the last-hop IP
+address;<a href="#section-2.4-2.5.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.4-2.6">
+            <p id="section-2.4-2.6.1">Attacks in the RFC5322.From header field, also known as "display name"
+attacks;<a href="#section-2.4-2.6.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.4-2.7">
+            <p id="section-2.4-2.7.1">Authentication of entities other than domains, since DMARC is
+built upon SPF and DKIM, which authenticate domains; and<a href="#section-2.4-2.7.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.4-2.8">
+            <p id="section-2.4-2.8.1">Content analysis.<a href="#section-2.4-2.8.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
 </section>
 </div>
 </section>
@@ -1936,7 +1754,7 @@ for details about the supported mechanisms.<a href="#section-3.2.1-1" class="pil
           <h4 id="name-author-domain">
 <a href="#section-3.2.2" class="section-number selfRef">3.2.2. </a><a href="#name-author-domain" class="section-name selfRef">Author Domain</a>
           </h4>
-<p id="section-3.2.2-1">The domain name of the apparent author, as extracted from the From: header field.<a href="#section-3.2.2-1" class="pilcrow">¶</a></p>
+<p id="section-3.2.2-1">The domain name of the apparent author, as extracted from the RFC5322.From header field.<a href="#section-3.2.2-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="domain-owner">
@@ -1961,88 +1779,79 @@ their immediate management domain.<a href="#section-3.2.3-1" class="pilcrow">¶<
           <h4 id="name-identifier-alignment">
 <a href="#section-3.2.4" class="section-number selfRef">3.2.4. </a><a href="#name-identifier-alignment" class="section-name selfRef">Identifier Alignment</a>
           </h4>
-<p id="section-3.2.4-1">When the domain in the address in the From: header field has the
+<p id="section-3.2.4-1">When the domain in the address in the RFC5322.From header field has the
 same Organizational Domain as a domain verified by an authenticated
-identifier, it has Identifier Alignment. (see below)<a href="#section-3.2.4-1" class="pilcrow">¶</a></p>
-</section>
-</div>
-<div id="longest-psd">
-<section id="section-3.2.5">
-          <h4 id="name-longest-psd">
-<a href="#section-3.2.5" class="section-number selfRef">3.2.5. </a><a href="#name-longest-psd" class="section-name selfRef">Longest PSD</a>
-          </h4>
-<p id="section-3.2.5-1">The term Longest PSD is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.2.5-1" class="pilcrow">¶</a></p>
+identifier, it has Identifier Alignment. (see <a href="#organizational-domain" class="xref">Section 3.2.7</a>)<a href="#section-3.2.4-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="mail-receiver">
-<section id="section-3.2.6">
+<section id="section-3.2.5">
           <h4 id="name-mail-receiver">
-<a href="#section-3.2.6" class="section-number selfRef">3.2.6. </a><a href="#name-mail-receiver" class="section-name selfRef">Mail Receiver</a>
+<a href="#section-3.2.5" class="section-number selfRef">3.2.5. </a><a href="#name-mail-receiver" class="section-name selfRef">Mail Receiver</a>
           </h4>
-<p id="section-3.2.6-1">The entity or organization that receives and processes email.<br>
-Mail Receivers operate one or more Internet-facing Mail Transport
-Agents (MTAs).<a href="#section-3.2.6-1" class="pilcrow">¶</a></p>
+<p id="section-3.2.5-1">The entity or organization that receives and processes email. Mail
+Receivers operate one or more Internet-facing Mail Transport Agents (MTAs).<a href="#section-3.2.5-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="non-existent-domains">
-<section id="section-3.2.7">
+<section id="section-3.2.6">
           <h4 id="name-non-existent-domains">
-<a href="#section-3.2.7" class="section-number selfRef">3.2.7. </a><a href="#name-non-existent-domains" class="section-name selfRef">Non-existent Domains</a>
+<a href="#section-3.2.6" class="section-number selfRef">3.2.6. </a><a href="#name-non-existent-domains" class="section-name selfRef">Non-existent Domains</a>
           </h4>
-<p id="section-3.2.7-1">For DMARC purposes, a non-existent domain is a domain for which there
+<p id="section-3.2.6-1">For DMARC purposes, a non-existent domain is a domain for which there
 is an NXDOMAIN or NODATA response for A, AAAA, and MX records.  This
-is a broader definition than that in <span>[<a href="#RFC8020" class="xref">RFC8020</a>]</span>.<a href="#section-3.2.7-1" class="pilcrow">¶</a></p>
+is a broader definition than that in <span>[<a href="#RFC8020" class="xref">RFC8020</a>]</span>.<a href="#section-3.2.6-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="organizational-domain">
-<section id="section-3.2.8">
+<section id="section-3.2.7">
           <h4 id="name-organizational-domain">
-<a href="#section-3.2.8" class="section-number selfRef">3.2.8. </a><a href="#name-organizational-domain" class="section-name selfRef">Organizational Domain</a>
+<a href="#section-3.2.7" class="section-number selfRef">3.2.7. </a><a href="#name-organizational-domain" class="section-name selfRef">Organizational Domain</a>
           </h4>
-<p id="section-3.2.8-1">The Organizational Domain is typically a domain that was registered with
+<p id="section-3.2.7-1">The Organizational Domain is typically a domain that was registered with
 a domain name registrar.  More formally, it is any Public Suffix Domain
 plus one label. The Organizational Domain for the domain in the
 RFC5322.From domain is determined by applying the algorithm found in
-<a href="#determining-the-organizational-domain" class="xref">Section 4.6</a>.<a href="#section-3.2.8-1" class="pilcrow">¶</a></p>
+<a href="#determining-the-organizational-domain" class="xref">Section 4.6</a>.<a href="#section-3.2.7-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="public-suffix-domain">
-<section id="section-3.2.9">
+<section id="section-3.2.8">
           <h4 id="name-public-suffix-domain-psd">
-<a href="#section-3.2.9" class="section-number selfRef">3.2.9. </a><a href="#name-public-suffix-domain-psd" class="section-name selfRef">Public Suffix Domain (PSD)</a>
+<a href="#section-3.2.8" class="section-number selfRef">3.2.8. </a><a href="#name-public-suffix-domain-psd" class="section-name selfRef">Public Suffix Domain (PSD)</a>
           </h4>
-<p id="section-3.2.9-1">The term Public Suffix Domain is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.2.9-1" class="pilcrow">¶</a></p>
+<p id="section-3.2.8-1">The term Public Suffix Domain is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.2.8-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="public-suffix-operator">
-<section id="section-3.2.10">
+<section id="section-3.2.9">
           <h4 id="name-public-suffix-operator-pso">
-<a href="#section-3.2.10" class="section-number selfRef">3.2.10. </a><a href="#name-public-suffix-operator-pso" class="section-name selfRef">Public Suffix Operator (PSO)</a>
+<a href="#section-3.2.9" class="section-number selfRef">3.2.9. </a><a href="#name-public-suffix-operator-pso" class="section-name selfRef">Public Suffix Operator (PSO)</a>
           </h4>
-<p id="section-3.2.10-1">The term Public Suffix Operator is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.2.10-1" class="pilcrow">¶</a></p>
+<p id="section-3.2.9-1">The term Public Suffix Operator is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.2.9-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="pso-controlled-domain-names">
-<section id="section-3.2.11">
+<section id="section-3.2.10">
           <h4 id="name-pso-controlled-domain-names">
-<a href="#section-3.2.11" class="section-number selfRef">3.2.11. </a><a href="#name-pso-controlled-domain-names" class="section-name selfRef">PSO Controlled Domain Names</a>
+<a href="#section-3.2.10" class="section-number selfRef">3.2.10. </a><a href="#name-pso-controlled-domain-names" class="section-name selfRef">PSO Controlled Domain Names</a>
           </h4>
-<p id="section-3.2.11-1">The term PSO Controlled Domain Names is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.2.11-1" class="pilcrow">¶</a></p>
+<p id="section-3.2.10-1">The term PSO Controlled Domain Names is defined in <span>[<a href="#RFC9091" class="xref">RFC9091</a>]</span>.<a href="#section-3.2.10-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="report-receiver">
-<section id="section-3.2.12">
+<section id="section-3.2.11">
           <h4 id="name-report-receiver">
-<a href="#section-3.2.12" class="section-number selfRef">3.2.12. </a><a href="#name-report-receiver" class="section-name selfRef">Report Receiver</a>
+<a href="#section-3.2.11" class="section-number selfRef">3.2.11. </a><a href="#name-report-receiver" class="section-name selfRef">Report Receiver</a>
           </h4>
-<p id="section-3.2.12-1">An operator that receives reports from another operator implementing the
+<p id="section-3.2.11-1">An operator that receives reports from another operator implementing the
 reporting mechanisms described in this document and/or the documents
 <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> and <span>[<a href="#DMARC-Failure-Reporting" class="xref">DMARC-Failure-Reporting</a>]</span>. Such an
 operator might be receiving reports about messages related to a domain
 for which it is the Domain Owner or PSO, or reports about messages related
 to another operator's domain.  This term applies collectively to the
 system components that receive and process these reports and the organizations
-that operate them.<a href="#section-3.2.12-1" class="pilcrow">¶</a></p>
+that operate them.<a href="#section-3.2.11-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
@@ -2068,8 +1877,8 @@ about use of the domain name.  All information about a Domain Owner's or
 PSO's DMARC policy is published and retrieved via the DNS.<a href="#section-4.1-1" class="pilcrow">¶</a></p>
 <p id="section-4.1-2">DMARC's verification function is based on whether the RFC5322.From
 domain is aligned with a domain name used in a supported authentication
-mechanism. <a href="#authentication-mechanisms" class="xref">Section 4.3</a> When a DMARC policy exists
-for the domain name found in the RFC5322.From header field, and that
+mechanism, as described in <a href="#authentication-mechanisms" class="xref">Section 4.3</a>. When a DMARC policy
+exists for the domain name found in the RFC5322.From header field, and that
 domain name is not verified through an aligned supported authentication
 mechanism, the handling of that message can be affected based on the
 DMARC policy when delivered to a participating receiver.<a href="#section-4.1-2" class="pilcrow">¶</a></p>
@@ -2136,15 +1945,17 @@ evidence that the message was indeed originated by the agent they
 associate with that mailbox, if the end user knows that these
 various protections have been provided.<a href="#section-4.2-3.3.1" class="pilcrow">¶</a></p>
 </li>
+<li id="section-4.2-3.4">
+            <p id="section-4.2-3.4.1">The absence of a single, properly formed RFC5322.From header field
+renders the message invalid. Handling of such a message is outside
+of the scope of this specification.<a href="#section-4.2-3.4.1" class="pilcrow">¶</a></p>
+</li>
 </ul>
-<p id="section-4.2-4">The absence of a single, properly formed RFC5322.From header field renders
-the message invalid.  Handling of such a message is outside of the
-scope of this specification.<a href="#section-4.2-4" class="pilcrow">¶</a></p>
-<p id="section-4.2-5">Since the sorts of mail typically protected by DMARC participants
+<p id="section-4.2-4">Since the sorts of mail typically protected by DMARC participants
 tend to only have single Authors, DMARC participants generally
 operate under a slightly restricted profile of RFC5322 with respect
 to the expected syntax of this field.  See <a href="#mail-receiver-actions" class="xref">Section 5.7</a>
-for details.<a href="#section-4.2-5" class="pilcrow">¶</a></p>
+for details.<a href="#section-4.2-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="authentication-mechanisms">
@@ -2161,7 +1972,7 @@ the "d=" tag of a verified DKIM-Signature header field.<a href="#section-4.3-2.1
 </li>
 <li id="section-4.3-2.2">
             <p id="section-4.3-2.2.1">SPF, <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span>, which can authenticate both the domain found in
-an <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span> HELO/EHLO command (the HELO identity) and the domain
+an SMTP <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span> HELO/EHLO command (the HELO identity) and the domain
 found in an SMTP MAIL command (the MAIL FROM identity). As noted earlier,
 however, DMARC relies solely on SPF authentication of the domain found in
 SMTP MAIL FROM command. Section 2.4 of <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span> describes MAIL FROM
@@ -2229,7 +2040,7 @@ found in <a href="#domain-owner-actions" class="xref">Section 5.5</a> and <a hre
 <a href="#section-4.5" class="section-number selfRef">4.5. </a><a href="#name-dns-tree-walk" class="section-name selfRef">DNS Tree Walk</a>
         </h3>
 <p id="section-4.5-1">While the DMARC protocol defines a method for communicating information
-through publishing records in DNS, it is not necessarily true that a
+through the publishing of records in DNS, it is not necessarily true that a
 DMARC policy record for a given domain will be found in DNS at the same
 level as the name label for the domain in question. Instead, some domains
 will inherit their DNS policy records from parent domains one level or more
@@ -2345,8 +2156,8 @@ are typically not visible to the end user.<a href="#section-4.7-1" class="pilcro
 that it have the same Organizational Domain as an Authenticated Identifier
 (a condition known as "relaxed alignment") or that it be identical to the
 domain of the Authenticated Identifier (a condition known as "strict
-alignment"). The choice of relaxed or strict alignment is left to the domain
-owner and is expressed in the domain's DMARC policy record.  Domain names
+alignment"). The choice of relaxed or strict alignment is left to the Domain
+Owner and is expressed in the domain's DMARC policy record.  Domain names
 in this context are to be compared in a case-insensitive manner, per <span>[<a href="#RFC4343" class="xref">RFC4343</a>]</span>.<a href="#section-4.7-2" class="pilcrow">¶</a></p>
 <p id="section-4.7-3">It is important to note that Identifier Alignment cannot occur with a
 message that is not valid per <span>[<a href="#RFC5322" class="xref">RFC5322</a>]</span>, particularly one with a
@@ -2439,24 +2250,24 @@ domain can be verified.<a href="#section-4.7.3-1" class="pilcrow">¶</a></p>
       <h2 id="name-policy">
 <a href="#section-5" class="section-number selfRef">5. </a><a href="#name-policy" class="section-name selfRef">Policy</a>
       </h2>
-<p id="section-5-1">DMARC policies are published by Domain Owners and PSOs and can be
-used by Mail Receivers to inform their message handling decisions.<a href="#section-5-1" class="pilcrow">¶</a></p>
-<p id="section-5-2">A Domain Owner or PSO advertises DMARC participation of one or more of its
+<p id="section-5-1">A Domain Owner or PSO advertises DMARC participation of one or more of its
 domains by adding a DNS TXT record (described in <a href="#dmarc-policy-record" class="xref">Section 5.1</a>) to
 those domains.  In doing so, Domain Owners and PSOs indicate their handling
 preference regarding failed authentication for email messages making use
-of their domain in the RFC5322.From header field as well as the provision
-of feedback about those messages. Mail Receivers in turn can take into
+of their domain in the RFC5322.From header field as well as their desire
+for feedback about those messages. Mail Receivers in turn can take into
 account the Domain Owner's stated preference when making handling
-decisions about email messages that fail DMARC authentication checks.<a href="#section-5-2" class="pilcrow">¶</a></p>
-<p id="section-5-3">A Domain Owner or PSO may choose not to participate in DMARC evaluation by
-Mail Receivers.  In this case, the Domain Owner simply declines to
-advertise participation in those schemes.  For example, if the
-results of path authorization checks ought not be considered as part
-of the overall DMARC result for a given Author Domain, then the
-Domain Owner does not publish an SPF policy record that can produce
-an SPF pass result.<a href="#section-5-3" class="pilcrow">¶</a></p>
-<p id="section-5-4">A Mail Receiver implementing the DMARC mechanism SHOULD make a best-effort
+decisions about email messages that fail DMARC authentication checks.<a href="#section-5-1" class="pilcrow">¶</a></p>
+<p id="section-5-2">A Domain Owner or PSO may choose not to participate in DMARC evaluation by
+Mail Receivers simply by not publishing an appropriate DNS TXT record for
+its domain(s).  A Domain Owner can also choose to not have some underlying
+authentication technologies apply to DMARC evaluation of its domain(s). In
+this case, the Domain Owner simply declines to advertise participation in
+those schemes.  For example, if the results of path authorization checks
+ought not be considered as part of the overall DMARC result for a given
+Author Domain, then the Domain Owner does not publish an SPF policy record
+that can produce an SPF pass result.<a href="#section-5-2" class="pilcrow">¶</a></p>
+<p id="section-5-3">A Mail Receiver implementing the DMARC mechanism SHOULD make a best-effort
 attempt to adhere to the Domain Owner's or PSO's published DMARC Domain
 Owner Assessment Policy when a message fails the DMARC test. Since email
 streams can be complicated (due to forwarding, existing RFC5322.From
@@ -2464,7 +2275,7 @@ domain-spoofing services, etc.), Mail Receivers MAY deviate from a published
 Domain Owner Assessment Policy during message processing and SHOULD
 make available the fact of and reason for the deviation to the Domain
 Owner via feedback reporting, specifically using the "PolicyOverride"
-feature of the aggregate report defined in <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-5-4" class="pilcrow">¶</a></p>
+feature of the aggregate report defined in <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-5-3" class="pilcrow">¶</a></p>
 <div id="dmarc-policy-record">
 <section id="section-5.1">
         <h3 id="name-dmarc-policy-record">
@@ -2565,36 +2376,37 @@ Report generators MAY choose to adhere to the requested options.
 This tag's content MUST be ignored if a "ruf" tag (below) is not
 also specified.  Failure reporting options are shown below. The value
 of this tag is either "0", "1", or a colon-separated list of the
-options represented by alphabetic characters.<a href="#section-5.3-4.6.1" class="pilcrow">¶</a></p>
+options represented by alphabetic characters. The valid values and
+their meanings are:<a href="#section-5.3-4.6.1" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-5.3-4.6.2">
+              <dt id="section-5.3-4.6.2.1">0:</dt>
+<dd id="section-5.3-4.6.2.2">Generate a DMARC failure report if all underlying authentication
+mechanisms fail to produce an aligned "pass" result.<a href="#section-5.3-4.6.2.2" class="pilcrow">¶</a>
+</dd>
+<dd class="break"></dd>
+<dt id="section-5.3-4.6.2.3">1:</dt>
+<dd id="section-5.3-4.6.2.4">Generate a DMARC failure report if any underlying authentication
+mechanism produced something other than an aligned "pass" result.<a href="#section-5.3-4.6.2.4" class="pilcrow">¶</a>
+</dd>
+<dd class="break"></dd>
+<dt id="section-5.3-4.6.2.5">d:</dt>
+<dd id="section-5.3-4.6.2.6">Generate a DKIM failure report if the message had a signature
+that failed evaluation, regardless of its alignment. DKIM-specific
+reporting is described in <span>[<a href="#RFC6651" class="xref">RFC6651</a>]</span>.<a href="#section-5.3-4.6.2.6" class="pilcrow">¶</a>
+</dd>
+<dd class="break"></dd>
+<dt id="section-5.3-4.6.2.7">s:</dt>
+<dd id="section-5.3-4.6.2.8">Generate an SPF failure report if the message failed SPF
+evaluation, regardless of its alignment. SPF-specific
+reporting is described in <span>[<a href="#RFC6652" class="xref">RFC6652</a>]</span>.<a href="#section-5.3-4.6.2.8" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
 </dl>
-<p id="section-5.3-5">The valid values and their meanings are:<a href="#section-5.3-5" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-5.3-6">
-<pre>0:
-:  Generate a DMARC failure report if all underlying
-   authentication mechanisms fail to produce an aligned "pass"
-   result.
-
-1:
-:  Generate a DMARC failure report if any underlying
-   authentication mechanism produced something other than an
-   aligned "pass" result.
-
-d:
-:  Generate a DKIM failure report if the message had a signature
-   that failed evaluation, regardless of its alignment.  DKIM-
-   specific reporting is described in [@!RFC6651].
-
-s:
-:  Generate an SPF failure report if the message failed SPF
-   evaluation, regardless of its alignment.  SPF-specific
-   reporting is described in [@!RFC6652].
-</pre><a href="#section-5.3-6" class="pilcrow">¶</a>
-</div>
-<dl class="dlParallel" id="section-5.3-7">
-          <dt id="section-5.3-7.1">np:</dt>
-<dd id="section-5.3-7.2">Domain Owner Assessment Policy for non-existent subdomains
+</dd>
+<dd class="break"></dd>
+<dt id="section-5.3-4.7">np:</dt>
+<dd id="section-5.3-4.8">
+            <p id="section-5.3-4.8.1">Domain Owner Assessment Policy for non-existent subdomains
 (plain-text; OPTIONAL).  Indicates the message handling preference
 that the Domain Owner or PSO has for mail using non-existent subdomains
 of the domain queried. It applies only to non-existent subdomains of
@@ -2606,94 +2418,89 @@ policy specified by the "p" tag, if the "sp" tag is not present,
 MUST be applied for non-existent subdomains.  Note that "np" will
 be ignored for DMARC records published on subdomains of Organizational
 Domains and PSDs due to the effect of the DMARC policy discovery
-mechanism described in <a href="#dmarc-policy-discovery" class="xref">Section 5.7.2.1</a>.<a href="#section-5.3-7.2" class="pilcrow">¶</a>
+mechanism described in <a href="#dmarc-policy-discovery" class="xref">Section 5.7.2.1</a>.<a href="#section-5.3-4.8.1" class="pilcrow">¶</a></p>
 </dd>
 <dd class="break"></dd>
-<dt id="section-5.3-7.3">p:</dt>
-<dd id="section-5.3-7.4">
-            <p id="section-5.3-7.4.1">Domain Owner Assessment Policy (plain-text; RECOMMENDED for policy
+<dt id="section-5.3-4.9">p:</dt>
+<dd id="section-5.3-4.10">
+            <p id="section-5.3-4.10.1">Domain Owner Assessment Policy (plain-text; RECOMMENDED for policy
 records). Indicates the message handling preference the Domain Owner or
 PSO has for mail using its domain but not passing DMARC verification.
 Policy applies to the domain queried and to subdomains, unless
 subdomain policy is explicitly described using the "sp" or "np" tags.
 This tag is mandatory for policy records only, but not for third-party
 reporting records (see <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> and <span>[<a href="#DMARC-Failure-Reporting" class="xref">DMARC-Failure-Reporting</a>]</span>)
-Possible values are as follows:<a href="#section-5.3-7.4.1" class="pilcrow">¶</a></p>
-<dl class="dlParallel" id="section-5.3-7.4.2">
-              <dt id="section-5.3-7.4.2.1">none:</dt>
-<dd id="section-5.3-7.4.2.2">The Domain Owner offers no expression of preference.<a href="#section-5.3-7.4.2.2" class="pilcrow">¶</a>
+Possible values are as follows:<a href="#section-5.3-4.10.1" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-5.3-4.10.2">
+              <dt id="section-5.3-4.10.2.1">none:</dt>
+<dd id="section-5.3-4.10.2.2">The Domain Owner offers no expression of preference.<a href="#section-5.3-4.10.2.2" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
-<dt id="section-5.3-7.4.2.3">quarantine:</dt>
-<dd id="section-5.3-7.4.2.4">The Domain Owner considers such mail to be suspicious. It
-is possible the mail is valid, although the failure creates
-a significant concern.<a href="#section-5.3-7.4.2.4" class="pilcrow">¶</a>
+<dt id="section-5.3-4.10.2.3">quarantine:</dt>
+<dd id="section-5.3-4.10.2.4">The Domain Owner considers such mail to be suspicious. It is possible
+the mail is valid, although the failure creates a significant concern.<a href="#section-5.3-4.10.2.4" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
-<dt id="section-5.3-7.4.2.5">reject:</dt>
-<dd id="section-5.3-7.4.2.6">The Domain Owner considers all such failures to be a clear
-indication that the use of the domain name is not valid. See
-<a href="#rejecting-messages" class="xref">Section 7.3</a> for some discussion of SMTP rejection
-methods and their implications.<a href="#section-5.3-7.4.2.6" class="pilcrow">¶</a>
+<dt id="section-5.3-4.10.2.5">reject:</dt>
+<dd id="section-5.3-4.10.2.6">The Domain Owner considers all such failures to be a clear indication
+that the use of the domain name is not valid. See <a href="#rejecting-messages" class="xref">Section 7.3</a>
+for some discussion of SMTP rejection methods and their implications.<a href="#section-5.3-4.10.2.6" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
 </dl>
 </dd>
 <dd class="break"></dd>
-<dt id="section-5.3-7.5">psd:</dt>
-<dd id="section-5.3-7.6">
-            <p id="section-5.3-7.6.1">A flag indicating whether the domain is a PSD. (plain-text; OPTIONAL;
-default is 'n'). Possible values are:<a href="#section-5.3-7.6.1" class="pilcrow">¶</a></p>
-<dl class="dlParallel" id="section-5.3-7.6.2">
-              <dt id="section-5.3-7.6.2.1">y:</dt>
-<dd id="section-5.3-7.6.2.2">Domains on the PSL that publish DMARC policy records SHOULD include
+<dt id="section-5.3-4.11">psd:</dt>
+<dd id="section-5.3-4.12">
+            <p id="section-5.3-4.12.1">A flag indicating whether the domain is a PSD. (plain-text; OPTIONAL;
+default is 'n'). Possible values are:<a href="#section-5.3-4.12.1" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-5.3-4.12.2">
+              <dt id="section-5.3-4.12.2.1">y:</dt>
+<dd id="section-5.3-4.12.2.2">Domains on the PSL that publish DMARC policy records SHOULD include
 this tag with a value of 'y' to indicate that the domain is a PSD. This
 information will be used during policy discovery to determine how to
-apply any DMARC policy records that are discovered during the tree walk.<a href="#section-5.3-7.6.2.2" class="pilcrow">¶</a>
+apply any DMARC policy records that are discovered during the tree walk.<a href="#section-5.3-4.12.2.2" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
-<dt id="section-5.3-7.6.2.3">n:</dt>
-<dd id="section-5.3-7.6.2.4">The default, indicating that the DMARC policy record is published
-for a domain that is not a PSD.<a href="#section-5.3-7.6.2.4" class="pilcrow">¶</a>
+<dt id="section-5.3-4.12.2.3">n:</dt>
+<dd id="section-5.3-4.12.2.4">The default, indicating that the DMARC policy record is published for a
+domain that is not a PSD.<a href="#section-5.3-4.12.2.4" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
 </dl>
 </dd>
 <dd class="break"></dd>
-<dt id="section-5.3-7.7">rua:</dt>
-<dd id="section-5.3-7.8">
-            <p id="section-5.3-7.8.1">Addresses to which aggregate feedback is to be sent (comma-
-separated plain-text list of DMARC URIs; OPTIONAL).  <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span>
-discusses considerations that apply when the domain name of a URI differs
-from that of the domain advertising the policy.  See <a href="#external-report-addresses" class="xref">Section 9.5</a>
-for additional considerations.  Any valid URI can be specified.<br>
-A Mail Receiver MUST implement support for a "mailto:" URI, i.e., the
-ability to send a DMARC report via electronic mail.  If not provided,
-Mail Receivers MUST NOT generate aggregate feedback reports.  URIs
-not supported by Mail Receivers MUST be ignored.  The aggregate
-feedback report format is described in <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-5.3-7.8.1" class="pilcrow">¶</a></p>
+<dt id="section-5.3-4.13">rua:</dt>
+<dd id="section-5.3-4.14">
+            <p id="section-5.3-4.14.1">Addresses to which aggregate feedback is to be sent (comma-separated plain-text
+list of DMARC URIs; OPTIONAL).  <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> discusses considerations
+that apply when the domain name of a URI differs from that of the domain advertising
+the policy.  See <a href="#external-report-addresses" class="xref">Section 9.5</a> for additional considerations. Any
+valid URI can be specified.  A Mail Receiver MUST implement support for a "mailto:"
+URI, i.e., the ability to send a DMARC report via electronic mail.  If the tag is not
+provided, Mail Receivers MUST NOT generate aggregate feedback reports for the domain.
+URIs not supported by Mail Receivers MUST be ignored. The aggregate feedback report
+format is described in <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-5.3-4.14.1" class="pilcrow">¶</a></p>
 </dd>
 <dd class="break"></dd>
-<dt id="section-5.3-7.9">ruf:</dt>
-<dd id="section-5.3-7.10">
-            <p id="section-5.3-7.10.1">Addresses to which message-specific failure information is to
-be reported (comma-separated plain-text list of DMARC URIs;
-OPTIONAL).  If present, the Domain Owner or PSO is requesting Mail
-Receivers to send detailed failure reports about messages that
-fail the DMARC evaluation in specific ways (see the "fo" tag
-above).  The format of the message to be generated MUST follow the
-format specified for the "rf" tag. <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> discusses
-considerations that apply when the domain name of a URI differs
-from that of the domain advertising the policy.  A Mail Receiver
-MUST implement support for a "mailto:" URI, i.e., the ability to
-send a DMARC report via electronic mail.  If not provided, Mail
-Receivers MUST NOT generate failure reports.  See <a href="#external-report-addresses" class="xref">Section 9.5</a> for
-additional considerations.<a href="#section-5.3-7.10.1" class="pilcrow">¶</a></p>
+<dt id="section-5.3-4.15">ruf:</dt>
+<dd id="section-5.3-4.16">
+            <p id="section-5.3-4.16.1">Addresses to which message-specific failure information is to be reported
+(comma-separated plain-text list of DMARC URIs; OPTIONAL).  If present, the Domain
+Owner or PSO is requesting Mail Receivers to send detailed failure reports about
+messages that fail the DMARC evaluation in specific ways (see the "fo" tag above).
+The format of the message to be generated MUST follow the format specified for the
+"rf" tag. <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> discusses considerations that apply when
+the domain name of a URI differs from that of the domain advertising the policy.
+A Mail Receiver MUST implement support for a "mailto:" URI, i.e., the ability to
+send a DMARC report via electronic mail.  If the tag is not provided, Mail Receivers
+MUST NOT generate failure reports for the domain. See <a href="#external-report-addresses" class="xref">Section 9.5</a>
+for additional considerations.<a href="#section-5.3-4.16.1" class="pilcrow">¶</a></p>
 </dd>
 <dd class="break"></dd>
-<dt id="section-5.3-7.11">sp:</dt>
-<dd id="section-5.3-7.12">
-            <p id="section-5.3-7.12.1">Domain Owner Assessment Policy for all subdomains (plain-text;
+<dt id="section-5.3-4.17">sp:</dt>
+<dd id="section-5.3-4.18">
+            <p id="section-5.3-4.18.1">Domain Owner Assessment Policy for all subdomains (plain-text;
 OPTIONAL). Indicates the message handling preference the Domain Owner
 or PSO has for mail using an existing subdomain of the domain queried
 but not passing DMARC verification.  It applies only to subdomains of
@@ -2703,54 +2510,54 @@ tag is absent and the "np" tag is either absent or not applicable,
 the policy specified by the "p" tag MUST be applied for subdomains.
 Note that "sp" will be ignored for DMARC records published on
 subdomains of Organizational Domains due to the effect of the
-DMARC policy discovery mechanism described in <a href="#dmarc-policy-discovery" class="xref">Section 5.7.2.1</a>.<a href="#section-5.3-7.12.1" class="pilcrow">¶</a></p>
+DMARC policy discovery mechanism described in <a href="#dmarc-policy-discovery" class="xref">Section 5.7.2.1</a>.<a href="#section-5.3-4.18.1" class="pilcrow">¶</a></p>
 </dd>
 <dd class="break"></dd>
-<dt id="section-5.3-7.13">t:</dt>
-<dd id="section-5.3-7.14">
-            <p id="section-5.3-7.14.1">DMARC policy test mode (plain-text; OPTIONAL; default is 'n'). For
+<dt id="section-5.3-4.19">t:</dt>
+<dd id="section-5.3-4.20">
+            <p id="section-5.3-4.20.1">DMARC policy test mode (plain-text; OPTIONAL; default is 'n'). For
 the RFC5322.From domain to which the DMARC record applies, the "t"
 tag serves as a signal to the actor performing DMARC verification checks
 as to whether or not the domain owner wishes the assessment policy
 declared in the "p=", "sp=", and/or "np=" tags to actually be applied. This
 parameter does not affect the generation of DMARC reports.  Possible values
-are as follows:<a href="#section-5.3-7.14.1" class="pilcrow">¶</a></p>
-<dl class="dlParallel" id="section-5.3-7.14.2">
-              <dt id="section-5.3-7.14.2.1">y:</dt>
-<dd id="section-5.3-7.14.2.2">A request that the actor performing the DMARC verification check not
+are as follows:<a href="#section-5.3-4.20.1" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-5.3-4.20.2">
+              <dt id="section-5.3-4.20.2.1">y:</dt>
+<dd id="section-5.3-4.20.2.2">A request that the actor performing the DMARC verification check not
 apply the policy, but instead apply any special handling rules it might have
 in place, such as rewriting the RFC5322.From header.  The domain owner is
-currently testing its specified DMARC assessment policy.<a href="#section-5.3-7.14.2.2" class="pilcrow">¶</a>
+currently testing its specified DMARC assessment policy.<a href="#section-5.3-4.20.2.2" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
-<dt id="section-5.3-7.14.2.3">n:</dt>
-<dd id="section-5.3-7.14.2.4">The default, a request to apply the policy as specified to any
-message that produces a DMARC "fail" result.<a href="#section-5.3-7.14.2.4" class="pilcrow">¶</a>
+<dt id="section-5.3-4.20.2.3">n:</dt>
+<dd id="section-5.3-4.20.2.4">The default, a request to apply the policy as specified to any
+message that produces a DMARC "fail" result.<a href="#section-5.3-4.20.2.4" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
 </dl>
 </dd>
 <dd class="break"></dd>
-<dt id="section-5.3-7.15">v:</dt>
-<dd id="section-5.3-7.16">
-            <p id="section-5.3-7.16.1">Version (plain-text; REQUIRED).  Identifies the record retrieved
+<dt id="section-5.3-4.21">v:</dt>
+<dd id="section-5.3-4.22">
+            <p id="section-5.3-4.22.1">Version (plain-text; REQUIRED).  Identifies the record retrieved
 as a DMARC record.  It MUST have the value of "DMARC1".  The value
 of this tag MUST match precisely; if it does not or it is absent,
 the entire retrieved record MUST be ignored.  It MUST be the first
-tag in the list.<a href="#section-5.3-7.16.1" class="pilcrow">¶</a></p>
+tag in the list.<a href="#section-5.3-4.22.1" class="pilcrow">¶</a></p>
 </dd>
 <dd class="break"></dd>
 </dl>
-<p id="section-5.3-8">A DMARC policy record MUST comply with the formal specification found
+<p id="section-5.3-5">A DMARC policy record MUST comply with the formal specification found
 in <a href="#formal-definition" class="xref">Section 5.4</a> in that the "v" tag MUST be present and MUST
 appear first.  Unknown tags MUST be ignored.  Syntax errors
 in the remainder of the record SHOULD be discarded in favor of
-default values (if any) or ignored outright.<a href="#section-5.3-8" class="pilcrow">¶</a></p>
-<p id="section-5.3-9">Note that given the rules of the previous paragraph, addition of a
+default values (if any) or ignored outright.<a href="#section-5.3-5" class="pilcrow">¶</a></p>
+<p id="section-5.3-6">Note that given the rules of the previous paragraph, addition of a
 new tag into the registered list of tags does not itself require a
 new version of DMARC to be generated (with a corresponding change to
 the "v" tag's value), but a change to any existing tags does require
-a new version of DMARC.<a href="#section-5.3-9" class="pilcrow">¶</a></p>
+a new version of DMARC.<a href="#section-5.3-6" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="formal-definition">
@@ -2771,7 +2578,7 @@ follows:<a href="#section-5.4-1" class="pilcrow">¶</a></p>
   dmarc-tag       = dmarc-request /
                     dmarc-test /
                     dmarc-psd /
-                    dmarc-srequest /
+                    dmarc-sprequest /
                     dmarc-nprequest /
                     dmarc-adkim /
                     dmarc-aspf /
@@ -2793,7 +2600,7 @@ follows:<a href="#section-5.4-1" class="pilcrow">¶</a></p>
 
   dmarc-psd       = "psd" *WSP "=" ( "y" / "n" )
 
-  dmarc-srequest  = "sp" *WSP "=" *WSP
+  dmarc-sprequest = "sp" *WSP "=" *WSP
                     ( "none" / "quarantine" / "reject" )
 
   dmarc-nprequest  = "np" *WSP "=" *WSP
@@ -2835,10 +2642,12 @@ DMARC mechanism.<a href="#section-5.5-1" class="pilcrow">¶</a></p>
 <p id="section-5.5.1-1">Because DMARC relies on SPF <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span> and DKIM <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>, in
 order to take full advantage of DMARC, a Domain Owner SHOULD first
 ensure that SPF and DKIM authentication are properly configured.
-The easiest first step here is to choose a domain to use as the
-RFC5321.From domain (i.e., the Return-Path domain) for its mail,
+As a first step the Domain Owner SHOULD choose a domain to use as the
+RFC5321.MailFrom domain (i.e., the Return-Path domain) for its mail,
 one that aligns with the Author Domain, and then publish an SPF
-policy in DNS for that domain.<a href="#section-5.5.1-1" class="pilcrow">¶</a></p>
+policy in DNS for that domain. The SPF record SHOULD be constructed
+at a minimum to ensure an SPF pass verdict for all known sources of
+mail for the RFC5321.MailFrom domain.<a href="#section-5.5.1-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="configure-sending-system-for-dkim-signing-using-an-aligned-domain">
@@ -2852,7 +2661,8 @@ both authentication mechanisms are in place in order to guard
 against failure of just one of them. The Domain Owner SHOULD choose
 a DKIM-Signing domain (i.e., the d= domain in the DKIM-Signature
 header) that aligns with the Author Domain and configure its system
-to sign using that domain.<a href="#section-5.5.2-1" class="pilcrow">¶</a></p>
+to sign using that domain, to include publishing a corresponding DKIM
+public key in DNS.<a href="#section-5.5.2-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="setup-a-mailbox-to-receive-aggregate-reports">
@@ -2868,11 +2678,11 @@ Owner, showing sources of mail using the Author Domain. Depending
 on how mature the Domain Owner's DMARC rollout is, some of these
 sources could be legitimate ones that were overlooked during the
 intial deployment of SPF and/or DKIM.<a href="#section-5.5.3-1" class="pilcrow">¶</a></p>
-<p id="section-5.5.3-2">Because the aggregate reports are XML documents, it is strongly
-advised that they be machine-parsed, so setting up a mailbox
-involves more than just the physical creation of the mailbox. Many
-third-party services exist that will process DMARC aggregate reports,
-or the Domain Owner can create its own set of tools. No matter which
+<p id="section-5.5.3-2">Because the aggregate reports are XML documents, it is recommended
+that they be machine-parsed, so setting up a mailbox involves more
+than just the physical creation of that mailbox. Many third-party
+services exist that will process DMARC aggregate reports, or the
+Domain Owner can create its own set of tools. No matter which
 method is chosen, the ability to parse these reports and consume
 the data contained in them will go a long way to ensuring a
 successful deployment.<a href="#section-5.5.3-2" class="pilcrow">¶</a></p>
@@ -2885,8 +2695,8 @@ successful deployment.<a href="#section-5.5.3-2" class="pilcrow">¶</a></p>
           </h4>
 <p id="section-5.5.4-1">Once SPF, DKIM, and the aggregate reports mailbox are all in place,
 it's time to publish a DMARC record. For best results, Domain Owners
-SHOULD start with "p=none", with the rua tag containg the mailbox
-created in the previous step.<a href="#section-5.5.4-1" class="pilcrow">¶</a></p>
+SHOULD start with "p=none", with the rua tag containg a URI that
+references the mailbox created in the previous step.<a href="#section-5.5.4-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="collect-and-analyze-reports-and-adjust-authentication">
@@ -3004,11 +2814,11 @@ to complete the SPF check.<a href="#section-5.7.2-3.4.1" class="pilcrow">¶</a><
               <p id="section-5.7.2-3.5.1">Conduct Identifier Alignment checks.  With authentication checks
 and policy discovery performed, the Mail Receiver checks to see
 if Authenticated Identifiers fall into alignment as described in
-<a href="#terminology" class="xref">Section 3</a>.  If one or more of the Authenticated Identifiers align
-with the RFC5322.From domain, the message is considered to pass
-the DMARC mechanism check.  All other conditions (authentication
-failures, identifier mismatches) are considered to be DMARC
-mechanism check failures.<a href="#section-5.7.2-3.5.1" class="pilcrow">¶</a></p>
+<a href="#identifier-alignment-explained" class="xref">Section 4.7</a>.  If one or more of the Authenticated
+Identifiers align with the RFC5322.From domain, the message is
+considered to pass the DMARC mechanism check.  All other conditions
+(authentication failures, identifier mismatches) are considered to be
+DMARC mechanism check failures.<a href="#section-5.7.2-3.5.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-5.7.2-3.6">
               <p id="section-5.7.2-3.6.1">Apply policy, if appropriate.  Emails that fail the DMARC mechanism
@@ -3078,7 +2888,7 @@ closed").<a href="#section-5.7.2.1-4" class="pilcrow">¶</a></p>
 <p id="section-5.7.2.1-5">Note: Because the PSD policy query comes after the Organizational
 Domain policy query, PSD policy is not used for Organizational
 domains that have published a DMARC policy.  Specifically, this is
-not a mechanism to provide feedback addresses (RUA/RUF) when an
+not a mechanism to provide feedback addresses (rua/ruf) when an
 Organizational Domain has declined to do so.<a href="#section-5.7.2.1-5" class="pilcrow">¶</a></p>
 </section>
 </div>
@@ -3112,8 +2922,8 @@ records with p= tag values of 'quarantine' or 'reject' are higher
 value signals to Mail Receivers, ones that can assist Mail Receivers
 with handling decisions for a message in ways that p= tag values of
 'none' cannot.<a href="#section-5.7.4-1" class="pilcrow">¶</a></p>
-<p id="section-5.7.4-2">In order to ensure maximum usefulness for DMARC across the email
-ecosystem, then, Mail Receivers SHOULD generate and send aggregate
+<p id="section-5.7.4-2">Given the above, in order to ensure maximum usefulness for DMARC across
+the email ecosystem, Mail Receivers SHOULD generate and send aggregate
 reports with a frequency of at least once every 24 hours.<a href="#section-5.7.4-2" class="pilcrow">¶</a></p>
 </section>
 </div>
@@ -3246,7 +3056,7 @@ benefits of DNS caching.<a href="#section-7.2-2" class="pilcrow">¶</a></p>
         </h3>
 <p id="section-7.3-1">This protocol calls for rejection of a message during the SMTP
 session under certain circumstances.  This is preferable to
-generation of a Delivery Status Notification (<span>[<a href="#RFC3464" class="xref">RFC3464</a>]</span>), since
+generation of a Delivery Status Notification <span>[<a href="#RFC3464" class="xref">RFC3464</a>]</span>, since
 fraudulent messages caught and rejected using DMARC would then result
 in annoying generation of such failure reports that go back to the
 RFC5321.MailFrom address.<a href="#section-7.3-1" class="pilcrow">¶</a></p>
@@ -3752,18 +3562,20 @@ false data from compromised but known Mail Receivers.<a href="#section-9.2-3.3.1
         </h3>
 <p id="section-9.3-1">The DMARC mechanism and its underlying technologies (SPF, DKIM)
 depend on the security of the DNS. Examples of how hostile parties can
-have an adverse impact on DNS traffic include:
-*  If they can snoop on DNS traffic, they can get an idea of who is
-   sending mail.<a href="#section-9.3-1" class="pilcrow">¶</a></p>
+have an adverse impact on DNS traffic include:<a href="#section-9.3-1" class="pilcrow">¶</a></p>
 <ul>
 <li id="section-9.3-2.1">
-            <p id="section-9.3-2.1.1">If they can block outgoing or reply DNS messages, they can prevent
-systems from discovering senders' DMARC policies, causing recipients
-to assume p=none by default.<a href="#section-9.3-2.1.1" class="pilcrow">¶</a></p>
+            <p id="section-9.3-2.1.1">If they can snoop on DNS traffic, they can get an idea of who is
+sending mail.<a href="#section-9.3-2.1.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-9.3-2.2">
-            <p id="section-9.3-2.2.1">If they can send forged response packets, they can make aligned mail
-appear unaligned or vice-versa.<a href="#section-9.3-2.2.1" class="pilcrow">¶</a></p>
+            <p id="section-9.3-2.2.1">If they can block outgoing or reply DNS messages, they can prevent
+systems from discovering senders' DMARC policies, causing recipients
+to assume p=none by default.<a href="#section-9.3-2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-9.3-2.3">
+            <p id="section-9.3-2.3.1">If they can send forged response packets, they can make aligned mail
+appear unaligned or vice-versa.<a href="#section-9.3-2.3.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 <p id="section-9.3-3">None of these threats are unique to DMARC, and they can be addressed using
@@ -4012,10 +3824,9 @@ could reveal private information.<a href="#section-9.6-2" class="pilcrow">¶</a>
 <a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-technology-considerations" class="section-name selfRef">Technology Considerations</a>
       </h2>
 <p id="section-appendix.a-1">This section documents some design decisions that were made in the
-development of DMARC.  Specifically, addressed here are some
-suggestions that were considered but not included in the design.
-This text is included to explain why they were considered and not
-included in this version.<a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
+development of DMARC.  Specifically addressed here are some
+suggestions that were considered but not included in the design,
+with explanatory text regarding the decision.<a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
 <div id="s-mime">
 <section id="section-a.1">
         <h2 id="name-s-mime">
@@ -4194,50 +4005,61 @@ tight for ADSP; they must match exactly.<a href="#section-a.5-3.7.1" class="pilc
         <h2 id="name-organizational-domain-disco">
 <a href="#section-a.6" class="section-number selfRef">A.6. </a><a href="#name-organizational-domain-disco" class="section-name selfRef">Organizational Domain Discovery Issues</a>
         </h2>
-<p id="section-a.6-1">Although protocols like ADSP are useful for "protecting" a specific
-domain name, they are not helpful at protecting subdomains.  If one
-wished to protect "example.com" by requiring via ADSP that all mail
-bearing an RFC5322.From domain of "example.com" be signed, this would
-"protect" that domain; however, one could then craft an email whose
-RFC5322.From domain is "security.example.com", and ADSP would not
-provide any protection.  One could use a DNS wildcard, but this can
-undesirably interfere with other DNS activity; one could add ADSP
-records as fraudulent domains are discovered, but this solution does
-not scale and is a purely reactive measure against abuse.<a href="#section-a.6-1" class="pilcrow">¶</a></p>
-<p id="section-a.6-2">The DNS does not provide a method by which the "domain of record", or
-the domain that was actually registered with a domain registrar, can
-be determined given an arbitrary domain name.  Suggestions have been
-made that attempt to glean such information from SOA or NS resource
-records, but these too are not fully reliable, as the partitioning of
-the DNS is not always done at administrative boundaries.<a href="#section-a.6-2" class="pilcrow">¶</a></p>
-<p id="section-a.6-3">When seeking domain-specific policy based on an arbitrary domain
-name, one could "climb the tree", dropping labels off the left end of
-the name until the root is reached or a policy is discovered, but
-then one could craft a name that has a large number of nonsense
-labels; this would cause a Mail Receiver to attempt a large number of
-queries in search of a policy record.  Sending many such messages
-constitutes an amplified denial-of-service attack.<a href="#section-a.6-3" class="pilcrow">¶</a></p>
-<p id="section-a.6-4">The Organizational Domain mechanism is a necessary component to the
-goals of DMARC.  The method described in <a href="#determining-the-organizational-domain" class="xref">Section 4.6</a> is far from
-perfect but serves this purpose reasonably well without adding undue
-burden or semantics to the DNS.  If a method is created to do so that
-is more reliable and secure than the use of a public suffix list,
-DMARC should be amended to use that method as soon as it is generally
-available.<a href="#section-a.6-4" class="pilcrow">¶</a></p>
-<div id="public-suffix-lists">
-<section id="section-a.6.1">
-          <h3 id="name-public-suffix-lists">
-<a href="#section-a.6.1" class="section-number selfRef">A.6.1. </a><a href="#name-public-suffix-lists" class="section-name selfRef">Public Suffix Lists</a>
-          </h3>
-<p id="section-a.6.1-1">A public suffix list for the purposes of determining the
-Organizational Domain can be obtained from various sources.  The most
-common one is maintained by the Mozilla Foundation and made public at
-<a href="http://publicsuffix.org">http://publicsuffix.org</a>.  License terms governing the use of that
-list are available at that URI.<a href="#section-a.6.1-1" class="pilcrow">¶</a></p>
-<p id="section-a.6.1-2">Note that if operators use a variety of public suffix lists,
-interoperability will be difficult or impossible to guarantee.<a href="#section-a.6.1-2" class="pilcrow">¶</a></p>
-</section>
-</div>
+<p id="section-a.6-1">An earlier informational version of the DMARC protocol <span>[<a href="#RFC7489" class="xref">RFC7489</a>]</span>
+noted that the DNS does not provide a method by which the "domain of record",
+or the domain that was actually registered with a domain registrar, can
+be determined given an arbitrary domain name. That version further mentioned
+suggestions that have been made that attempt to glean such information from
+SOA or NS resource records, but these too are not fully reliable, as the
+partitioning of the DNS is not always done at administrative boundaries.<a href="#section-a.6-1" class="pilcrow">¶</a></p>
+<p id="section-a.6-2">That previous version posited that one could "climb the tree" to find the
+Organizational Domain, but expressed concern that an attacker could exploit
+this for a denial-of-service attack through sending a high number of messages
+each with a relatively large number of nonsense labels, causing a Mail Receiver
+to perform a large number of DNS queries in search of a policy record. This
+version defines a method for performing a DNS Tree Walk, described in <a href="#dns-tree-walk" class="xref">Section 4.5</a>,
+and further mitigates the risk of the denial-of-service attack by expressly limiting
+the number of DNS queries to execute regardless of the number of labels in the domain
+name.<a href="#section-a.6-2" class="pilcrow">¶</a></p>
+<p id="section-a.6-3">As a matter of historical record, the method for finding the Organizational
+Domain described in <span>[<a href="#RFC7489" class="xref">RFC7489</a>]</span> is preserved here:<a href="#section-a.6-3" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-a.6-4">
+          <li id="section-a.6-4.1">
+            <p id="section-a.6-4.1.1">Acquire a "public suffix" list (PSL), i.e., a list of DNS domain
+   names reserved for registrations.  Some country Top-Level Domains
+   (TLDs) make specific registration requirements, e.g., the United
+   Kingdom places company registrations under ".co.uk"; other TLDs
+   such as ".com" appear in the IANA registry of top-level DNS
+   domains.  A PSL is the union of all of these.<a href="#section-a.6-4.1.1" class="pilcrow">¶</a></p>
+<p id="section-a.6-4.1.2">A PSL can be obtained from various sources. The most common one
+   is maintained by the Mozilla Foundation and made public at
+   <a href="http://publicsuffix.org">http://publicsuffix.org</a>.  License terms governing the use of that
+   list are available at that URI.<a href="#section-a.6-4.1.2" class="pilcrow">¶</a></p>
+<p id="section-a.6-4.1.3">Note that if operators use a variety of public suffix lists,
+   interoperability will be difficult or impossible to guarantee.<a href="#section-a.6-4.1.3" class="pilcrow">¶</a></p>
+</li>
+<li id="section-a.6-4.2">
+            <p id="section-a.6-4.2.1">Break the subject DNS domain name into a set of "n" ordered
+   labels.  Number these labels from right to left; e.g., for
+   "example.com", "com" would be label 1 and "example" would be
+   label 2.<a href="#section-a.6-4.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-a.6-4.3">
+            <p id="section-a.6-4.3.1">Search the public suffix list for the name that matches the
+   largest number of labels found in the subject DNS domain.  Let
+   that number be "x".<a href="#section-a.6-4.3.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-a.6-4.4">
+            <p id="section-a.6-4.4.1">Construct a new DNS domain name using the name that matched from
+   the public suffix list and prefixing to it the "x+1"th label from
+   the subject domain.  This new name is the Organizational Domain.<a href="#section-a.6-4.4.1" class="pilcrow">¶</a></p>
+</li>
+</ol>
+<p id="section-a.6-5">Thus, since "com" is an IANA-registered TLD, a subject domain of
+   "a.b.c.d.example.com" would have an Organizational Domain of
+   "example.com".<a href="#section-a.6-5" class="pilcrow">¶</a></p>
+<p id="section-a.6-6">The process of determining a suffix is currently a heuristic one.  No
+   list is guaranteed to be accurate or current.<a href="#section-a.6-6" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="removal-of-the-pct-tag">
@@ -4252,16 +4074,15 @@ owners with a method to gradually change their preferred assessment policy
 (the p= tag) from 'none' to 'quarantine' or from 'quarantine' to 'reject'
 by requesting the stricter treatment for just a percentage of messages
 that produced DMARC results of "fail".<a href="#section-a.7-1" class="pilcrow">¶</a></p>
-<p id="section-a.7-2">Operational experience and mathematics (specifically the Probability Mass
-Function as applied to Binomial Distributions) showed that the pct tag
-was usually not accurately applied, unless the value specified was either "0"
-or "100" (the default), and the inaccuracies with other values varied widely
-from implementation to implementation. The default value was easily implemented,
-as it required no special processing on the part of the message receiver, while
-the value of "0" took on unintended significance as a value used by some
-intermediaries and mailbox providers as an indicator to deviate from
-standard handling of the message, usually by rewriting the RFC5322.From
-header in an effort to avoid DMARC failures downstream.<a href="#section-a.7-2" class="pilcrow">¶</a></p>
+<p id="section-a.7-2">Operational experience showed that the pct tag was usually not accurately
+applied, unless the value specified was either "0" or "100" (the default),
+and the inaccuracies with other values varied widely from implementation to
+implementation. The default value was easily implemented, as it required no
+special processing on the part of the message receiver, while the value
+of "0" took on unintended significance as a value used by some intermediaries
+and mailbox providers as an indicator to deviate from standard handling of
+the message, usually by rewriting the RFC5322.From header in an effort to
+avoid DMARC failures downstream.<a href="#section-a.7-2" class="pilcrow">¶</a></p>
 <p id="section-a.7-3">These custom actions when the pct= tag was set to "0" proved valuable to the
 email community. In particular, header rewriting by an intermediary meant
 that a Domain Owner's aggregate reports could reveal to the Domain Owner
@@ -4480,12 +4301,12 @@ implemented DKIM correctly, but they are still seeing periodic
 authentication failures.  In order to diagnose these intermittent
 problems, they wish to request per-message failure reports when
 authentication failures occur.<a href="#section-b.2.2-1" class="pilcrow">¶</a></p>
-<p id="section-b.2.2-2">Not all Receivers will honor such a request, but the Domain Owner
+<p id="section-b.2.2-2">Not all Mail Receivers will honor such a request, but the Domain Owner
 feels that any reports it does receive will be helpful enough to
 justify publishing this record.  The default per-message report
 format (<span>[<a href="#RFC6591" class="xref">RFC6591</a>]</span>) meets the Domain Owner's needs in this scenario.<a href="#section-b.2.2-2" class="pilcrow">¶</a></p>
 <p id="section-b.2.2-3">The Domain Owner accomplishes this by adding the following to its
-policy record from <a href="#domain-owner-example" class="xref">Appendix B.2</a>:<a href="#section-b.2.2-3" class="pilcrow">¶</a></p>
+policy record from <a href="#entire-domain-monitoring-only" class="xref">Appendix B.2.1</a>:<a href="#section-b.2.2-3" class="pilcrow">¶</a></p>
 <ul>
 <li id="section-b.2.2-4.1">Per-message failure reports should be sent via email to the
 address "auth-reports@example.com"
@@ -4521,7 +4342,7 @@ might create an entry like the following in the appropriate zone file
           </h3>
 <p id="section-b.2.3-1">The Domain Owner from the previous example is maintaining the same
 policy but now wishes to have a third party receive and process the
-per-message failure reports.  Again, not all Receivers will honor
+per-message failure reports.  Again, not all Mail Receivers will honor
 this request, but those that do may implement additional checks to
 verify that the third party wishes to receive the failure reports
 for this domain.<a href="#section-b.2.3-1" class="pilcrow">¶</a></p>
@@ -4555,7 +4376,7 @@ might create an entry like the following in the appropriate zone file
 </div>
 <p id="section-b.2.3-8">Because the address used in the "ruf" tag is outside the
 Organizational Domain in which this record is published, conforming
-Receivers will implement additional checks as described in Section 3 of
+Mail Receivers will implement additional checks as described in Section 3 of
 <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span>.  In order to pass these additional
 checks, the third party will need to publish an additional DNS record
 as follows:<a href="#section-b.2.3-8" class="pilcrow">¶</a></p>
@@ -4641,7 +4462,7 @@ line but is wrapped here for publication):<a href="#section-b.2.4-5" class="pilc
 <div class="artwork art-text alignLeft" id="section-b.2.4-6">
 <pre>  % dig +short TXT _dmarc.test.example.com
   "v=DMARC1; p=quarantine; rua=mailto:dmarc-feedback@example.com,
-   mailto:tld-test@thirdparty.example.net t=y"
+   mailto:tld-test@thirdparty.example.net; t=y"
 </pre><a href="#section-b.2.4-6" class="pilcrow">¶</a>
 </div>
 <p id="section-b.2.4-7">To publish such a record, the DNS administrator for the Domain Owner
@@ -4662,7 +4483,8 @@ the subdomain is properly authenticating and passing DMARC checks, then
 the Domain Owner can update the policy record to indicate that it considers
 authentication failures to be a clear indication that use of the subdomain
 is not valid. It would do this by altering the DNS record to advise
-receivers of its position on such messages ("p=reject").<a href="#section-b.2.4-9" class="pilcrow">¶</a></p>
+receivers of its position on such messages ("p=reject") and removing the
+testing flag ("t=y").<a href="#section-b.2.4-9" class="pilcrow">¶</a></p>
 <p id="section-b.2.4-10">After alteration, the DMARC policy record might look like this when retrieved
 using a common command-line tool (the output shown would appear on a single
 line but is wrapped here for publication):<a href="#section-b.2.4-10" class="pilcrow">¶</a></p>
@@ -4696,61 +4518,59 @@ file:<a href="#section-b.2.4-12" class="pilcrow">¶</a></p>
 SPF and DKIM, and possess the ability to collect relevant information
 from various email-processing stages to provide feedback to Domain
 Owners (possibly via Report Receivers).<a href="#section-b.3-1" class="pilcrow">¶</a></p>
-</section>
-</div>
-<div id="processing-of-smtp-time">
-<section id="section-b.4">
-        <h2 id="name-processing-of-smtp-time">
-<a href="#section-b.4" class="section-number selfRef">B.4. </a><a href="#name-processing-of-smtp-time" class="section-name selfRef">Processing of SMTP Time</a>
-        </h2>
-<p id="section-b.4-1">An optimal DMARC-enabled Mail Receiver performs authentication and
-Identifier Alignment checking during the SMTP <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span> conversation.<a href="#section-b.4-1" class="pilcrow">¶</a></p>
-<p id="section-b.4-2">Prior to returning a final reply to the DATA command, the Mail
-Receiver's MTA has performed:<a href="#section-b.4-2" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-b.4-3">
-          <li id="section-b.4-3.1">
-            <p id="section-b.4-3.1.1">An SPF check to determine an SPF-authenticated Identifier.<a href="#section-b.4-3.1.1" class="pilcrow">¶</a></p>
+<div id="smtp-session-example">
+<section id="section-b.3.1">
+          <h3 id="name-smtp-session-example">
+<a href="#section-b.3.1" class="section-number selfRef">B.3.1. </a><a href="#name-smtp-session-example" class="section-name selfRef">SMTP Session Example</a>
+          </h3>
+<p id="section-b.3.1-1">An optimal DMARC-enabled Mail Receiver performs authentication and
+Identifier Alignment checking during the SMTP <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span> conversation.<a href="#section-b.3.1-1" class="pilcrow">¶</a></p>
+<p id="section-b.3.1-2">Prior to returning a final reply to the DATA command, the Mail
+Receiver's MTA has performed:<a href="#section-b.3.1-2" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-b.3.1-3">
+            <li id="section-b.3.1-3.1">
+              <p id="section-b.3.1-3.1.1">An SPF check to determine an SPF-authenticated Identifier.<a href="#section-b.3.1-3.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-b.4-3.2">
-            <p id="section-b.4-3.2.1">DKIM checks that yield one or more DKIM-authenticated
-Identifiers.<a href="#section-b.4-3.2.1" class="pilcrow">¶</a></p>
+<li id="section-b.3.1-3.2">
+              <p id="section-b.3.1-3.2.1">DKIM checks that yield one or more DKIM-authenticated
+Identifiers.<a href="#section-b.3.1-3.2.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-b.4-3.3">
-            <p id="section-b.4-3.3.1">A DMARC policy lookup.<a href="#section-b.4-3.3.1" class="pilcrow">¶</a></p>
+<li id="section-b.3.1-3.3">
+              <p id="section-b.3.1-3.3.1">A DMARC policy lookup.<a href="#section-b.3.1-3.3.1" class="pilcrow">¶</a></p>
 </li>
 </ol>
-<p id="section-b.4-4">The presence of an Author Domain DMARC record indicates that the Mail
+<p id="section-b.3.1-4">The presence of an Author Domain DMARC record indicates that the Mail
 Receiver should continue with DMARC-specific processing before
-returning a reply to the DATA command.<a href="#section-b.4-4" class="pilcrow">¶</a></p>
-<p id="section-b.4-5">Given a DMARC record and the set of Authenticated Identifiers, the
+returning a reply to the DATA command.<a href="#section-b.3.1-4" class="pilcrow">¶</a></p>
+<p id="section-b.3.1-5">Given a DMARC record and the set of Authenticated Identifiers, the
 Mail Receiver checks to see if the Authenticated Identifiers align
 with the Author Domain (taking into consideration any strict versus
-relaxed options found in the DMARC record).<a href="#section-b.4-5" class="pilcrow">¶</a></p>
-<p id="section-b.4-6">For example, the following sample data is considered to be from a
-piece of email originating from the Domain Owner of "example.com":<a href="#section-b.4-6" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-b.4-7">
+relaxed options found in the DMARC record).<a href="#section-b.3.1-5" class="pilcrow">¶</a></p>
+<p id="section-b.3.1-6">For example, the following sample data is considered to be from a
+piece of email originating from the Domain Owner of "example.com":<a href="#section-b.3.1-6" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-b.3.1-7">
 <pre>  Author Domain: example.com
   SPF-authenticated Identifier: mail.example.com
   DKIM-authenticated Identifier: example.com
   DMARC record:
     "v=DMARC1; p=reject; aspf=r;
      rua=mailto:dmarc-feedback@example.com"
-</pre><a href="#section-b.4-7" class="pilcrow">¶</a>
+</pre><a href="#section-b.3.1-7" class="pilcrow">¶</a>
 </div>
-<p id="section-b.4-8">In the above sample, both the SPF-authenticated Identifier and the
+<p id="section-b.3.1-8">In the above sample, both the SPF-authenticated Identifier and the
 DKIM-authenticated Identifier align with the Author Domain.  The Mail
 Receiver considers the above email to pass the DMARC check, avoiding
 the "reject" policy that is requested to be applied to email that fails
-to pass the DMARC check.<a href="#section-b.4-8" class="pilcrow">¶</a></p>
-<p id="section-b.4-9">If no Authenticated Identifiers align with the Author Domain, then
-the Mail Receiver applies the DMARC-record-specified policy.
-However, before this action is taken, the Mail Receiver can consult
-external information to override the Domain Owner's Assessment Policy.<br>
-For example, if the Mail Receiver knows that this particular email
-came from a known and trusted forwarder (that happens to break both
-SPF and DKIM), then the Mail Receiver may choose to ignore the Domain
-Owner's policy.<a href="#section-b.4-9" class="pilcrow">¶</a></p>
-<p id="section-b.4-10">The Mail Receiver is now ready to reply to the DATA command.  If the
+to pass the DMARC check.<a href="#section-b.3.1-8" class="pilcrow">¶</a></p>
+<p id="section-b.3.1-9">If no Authenticated Identifiers align with the Author Domain, then
+the Mail Receiver applies the DMARC-record-specified policy. However,
+before this action is taken, the Mail Receiver can consult external
+information to override the Domain Owner's Assessment Policy. For
+example, if the Mail Receiver knows that this particular email came
+from a known and trusted forwarder (that happens to break both SPF
+and DKIM), then the Mail Receiver may choose to ignore the Domain
+Owner's policy.<a href="#section-b.3.1-9" class="pilcrow">¶</a></p>
+<p id="section-b.3.1-10">The Mail Receiver is now ready to reply to the DATA command.  If the
 DMARC check yields that the message is to be rejected, then the Mail
 Receiver replies with a 5xy code to inform the sender of failure.  If
 the DMARC check cannot be resolved due to transient network errors,
@@ -4759,33 +4579,35 @@ as to the need to reattempt delivery later.  If the DMARC check
 yields a passing message, then the Mail Receiver continues on with
 email processing, perhaps using the result of the DMARC check as an
 input to additional processing modules such as a domain reputation
-query.<a href="#section-b.4-10" class="pilcrow">¶</a></p>
-<p id="section-b.4-11">Before exiting DMARC-specific processing, the Mail Receiver checks to
+query.<a href="#section-b.3.1-10" class="pilcrow">¶</a></p>
+<p id="section-b.3.1-11">Before exiting DMARC-specific processing, the Mail Receiver checks to
 see if the Author Domain DMARC record requests AFRF-based reporting.
 If so, then the Mail Receiver can emit an AFRF to the reporting
-address supplied in the DMARC record.<a href="#section-b.4-11" class="pilcrow">¶</a></p>
-<p id="section-b.4-12">At the exit of DMARC-specific processing, the Mail Receiver captures
+address supplied in the DMARC record.<a href="#section-b.3.1-11" class="pilcrow">¶</a></p>
+<p id="section-b.3.1-12">At the exit of DMARC-specific processing, the Mail Receiver captures
 (through logging or direct insertion into a data store) the result of
 DMARC processing.  Captured information is used to build feedback for
 Domain Owner consumption.  This is not necessary if the Domain Owner
 has not requested aggregate reports, i.e., no "rua" tag was found in
-the policy record.<a href="#section-b.4-12" class="pilcrow">¶</a></p>
+the policy record.<a href="#section-b.3.1-12" class="pilcrow">¶</a></p>
+</section>
+</div>
 </section>
 </div>
 <div id="utilization-of-aggregate-feedback-example">
-<section id="section-b.5">
+<section id="section-b.4">
         <h2 id="name-utilization-of-aggregate-fe">
-<a href="#section-b.5" class="section-number selfRef">B.5. </a><a href="#name-utilization-of-aggregate-fe" class="section-name selfRef">Utilization of Aggregate Feedback: Example</a>
+<a href="#section-b.4" class="section-number selfRef">B.4. </a><a href="#name-utilization-of-aggregate-fe" class="section-name selfRef">Utilization of Aggregate Feedback: Example</a>
         </h2>
-<p id="section-b.5-1">Aggregate feedback is consumed by Domain Owners to verify their
+<p id="section-b.4-1">Aggregate feedback is consumed by Domain Owners to verify their
 understanding of how a given domain is being processed by the Mail
 Receiver.  Aggregate reporting data on emails that pass all
 DMARC-supporting authentication checks is used by Domain Owners to
 verify that their authentication practices remain accurate.  For
 example, if a third party is sending on behalf of a Domain Owner,
 the Domain Owner can use aggregate report data to verify ongoing
-authentication practices of the third party.<a href="#section-b.5-1" class="pilcrow">¶</a></p>
-<p id="section-b.5-2">Data on email that only partially passes underlying authentication
+authentication practices of the third party.<a href="#section-b.4-1" class="pilcrow">¶</a></p>
+<p id="section-b.4-2">Data on email that only partially passes underlying authentication
 checks provides visibility into problems that need to be addressed by
 the Domain Owner.  For example, if either SPF or DKIM fails to pass,
 the Domain Owner is provided with enough information to either
@@ -4794,534 +4616,25 @@ breaking changes are being introduced in the email transmission path.
 If authentication-breaking changes due to email transmission path
 cannot be directly corrected, then the Domain Owner at least
 maintains an understanding of the effect of DMARC-based policies upon
-the Domain Owner's email.<a href="#section-b.5-2" class="pilcrow">¶</a></p>
-<p id="section-b.5-3">Data on email that fails all underlying authentication checks
+the Domain Owner's email.<a href="#section-b.4-2" class="pilcrow">¶</a></p>
+<p id="section-b.4-3">Data on email that fails all underlying authentication checks
 provides baseline visibility on how the Domain Owner's domain is
 being received at the Mail Receiver.  Based on this visibility, the
 Domain Owner can begin deployment of authentication technologies
 across uncovered email sources, if the mail that is failing the checks
 was generated by or on behalf of the Domain Owner.  Data regarding
 failing authentication checks can also allow the Domain Owner to
-come to an understanding of how its domain is being misused.<a href="#section-b.5-3" class="pilcrow">¶</a></p>
-<p id="section-b.5-4">(Aggregate report example should be moved to <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span>)<a href="#section-b.5-4" class="pilcrow">¶</a></p>
-</section>
-</div>
-</section>
-</div>
-<div id="change-log">
-<section id="section-appendix.c">
-      <h2 id="name-change-log">
-<a href="#section-appendix.c" class="section-number selfRef">Appendix C. </a><a href="#name-change-log" class="section-name selfRef">Change Log</a>
-      </h2>
-<div id="january-5-2021">
-<section id="section-c.1">
-        <h2 id="name-january-5-2021">
-<a href="#section-c.1" class="section-number selfRef">C.1. </a><a href="#name-january-5-2021" class="section-name selfRef">January 5, 2021</a>
-        </h2>
-<div id="ticket-80-dmarcbis-should-have-clear-and-concise-defintion-of-dmarc">
-<section id="section-c.1.1">
-          <h3 id="name-ticket-80-dmarcbis-should-h">
-<a href="#section-c.1.1" class="section-number selfRef">C.1.1. </a><a href="#name-ticket-80-dmarcbis-should-h" class="section-name selfRef">Ticket 80 - DMARCbis SHould Have Clear and Concise Defintion of DMARC</a>
-          </h3>
-<ul>
-<li id="section-c.1.1-1.1">Updated text for Abstract and Introduction sections.<a href="#section-c.1.1-1.1" class="pilcrow">¶</a>
-</li>
-<li id="section-c.1.1-1.2">Diffs are recorded here - <a href="https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/1/files">https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/1/files</a><a href="#section-c.1.1-1.2" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-</section>
-</div>
-<div id="february-4-2021">
-<section id="section-c.2">
-        <h2 id="name-february-4-2021">
-<a href="#section-c.2" class="section-number selfRef">C.2. </a><a href="#name-february-4-2021" class="section-name selfRef">February 4, 2021</a>
-        </h2>
-<div id="ticket-1-spf-rfc-4408-vs-7208">
-<section id="section-c.2.1">
-          <h3 id="name-ticket-1-spf-rfc-4408-vs-72">
-<a href="#section-c.2.1" class="section-number selfRef">C.2.1. </a><a href="#name-ticket-1-spf-rfc-4408-vs-72" class="section-name selfRef">Ticket 1 - SPF RFC 4408 vs 7208</a>
-          </h3>
-<ul>
-<li id="section-c.2.1-1.1">Some rearranging of text in the "SPF-Authenticated Identifiers" section<a href="#section-c.2.1-1.1" class="pilcrow">¶</a>
-</li>
-<li id="section-c.2.1-1.2">Clarification of the term "in alignment" in that same section<a href="#section-c.2.1-1.2" class="pilcrow">¶</a>
-</li>
-<li id="section-c.2.1-1.3">Diffs are here - <a href="https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/3/files">https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/3/files</a><a href="#section-c.2.1-1.3" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-</section>
-</div>
-<div id="february-10-2021">
-<section id="section-c.3">
-        <h2 id="name-february-10-2021">
-<a href="#section-c.3" class="section-number selfRef">C.3. </a><a href="#name-february-10-2021" class="section-name selfRef">February 10, 2021</a>
-        </h2>
-<div id="ticket-84-remove-erroneous-references-to-rfc3986">
-<section id="section-c.3.1">
-          <h3 id="name-ticket-84-remove-erroneous-">
-<a href="#section-c.3.1" class="section-number selfRef">C.3.1. </a><a href="#name-ticket-84-remove-erroneous-" class="section-name selfRef">Ticket 84 - Remove Erroneous References to RFC3986</a>
-          </h3>
-<ul>
-<li id="section-c.3.1-1.1">Several references to RFC3986 changed to RFC7208<a href="#section-c.3.1-1.1" class="pilcrow">¶</a>
-</li>
-<li id="section-c.3.1-1.2">Diffs are here - <a href="https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/4/files">https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/4/files</a><a href="#section-c.3.1-1.2" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-</section>
-</div>
-<div id="march-1-2021">
-<section id="section-c.4">
-        <h2 id="name-march-1-2021">
-<a href="#section-c.4" class="section-number selfRef">C.4. </a><a href="#name-march-1-2021" class="section-name selfRef">March 1, 2021</a>
-        </h2>
-<div id="design-team-work-begins">
-<section id="section-c.4.1">
-          <h3 id="name-design-team-work-begins">
-<a href="#section-c.4.1" class="section-number selfRef">C.4.1. </a><a href="#name-design-team-work-begins" class="section-name selfRef">Design Team Work Begins</a>
-          </h3>
-<ul>
-<li id="section-c.4.1-1.1">Added change log section to document<a href="#section-c.4.1-1.1" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-</section>
-</div>
-<div id="march-8-2021">
-<section id="section-c.5">
-        <h2 id="name-march-8-2021">
-<a href="#section-c.5" class="section-number selfRef">C.5. </a><a href="#name-march-8-2021" class="section-name selfRef">March 8, 2021</a>
-        </h2>
-<div id="removed-e-gustafsson-as-editor">
-<section id="section-c.5.1">
-          <h3 id="name-removed-e-gustafsson-as-edi">
-<a href="#section-c.5.1" class="section-number selfRef">C.5.1. </a><a href="#name-removed-e-gustafsson-as-edi" class="section-name selfRef">Removed E. Gustafsson as editor</a>
-          </h3>
-<ul>
-<li id="section-c.5.1-1.1">He withdrew as editor after a job change.<a href="#section-c.5.1-1.1" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-<div id="ticket-3-two-tiny-nits">
-<section id="section-c.5.2">
-          <h3 id="name-ticket-3-two-tiny-nits">
-<a href="#section-c.5.2" class="section-number selfRef">C.5.2. </a><a href="#name-ticket-3-two-tiny-nits" class="section-name selfRef">Ticket 3 - Two tiny nits</a>
-          </h3>
-<ul>
-<li id="section-c.5.2-1.1">Changes to wording in section 6.6.2, Determine Handling Policy, steps
-3 and 4.<a href="#section-c.5.2-1.1" class="pilcrow">¶</a>
-</li>
-<li id="section-c.5.2-1.2">New text documented here - <a href="https://trac.ietf.org/trac/dmarc/ticket/3#comment:6">https://trac.ietf.org/trac/dmarc/ticket/3#comment:6</a><a href="#section-c.5.2-1.2" class="pilcrow">¶</a>
-</li>
-<li id="section-c.5.2-1.3">No change to section 6.6.3, Policy Discovery; ticket seems to pre-date
-current text, which appears to have answered the concern raised.<a href="#section-c.5.2-1.3" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-<div id="ticket-4-definition-of-fo-parameter">
-<section id="section-c.5.3">
-          <h3 id="name-ticket-4-definition-of-fo-p">
-<a href="#section-c.5.3" class="section-number selfRef">C.5.3. </a><a href="#name-ticket-4-definition-of-fo-p" class="section-name selfRef">Ticket 4 - Definition of "fo" parameter</a>
-          </h3>
-<ul>
-<li id="section-c.5.3-1.1">Changes to wording in section 6.3, to bring clarity to use of colon-separated
-list as possible value to "fo"<a href="#section-c.5.3-1.1" class="pilcrow">¶</a>
-</li>
-<li id="section-c.5.3-1.2">New text documented here - <a href="https://trac.ietf.org/trac/dmarc/ticket/4#comment:4">https://trac.ietf.org/trac/dmarc/ticket/4#comment:4</a><a href="#section-c.5.3-1.2" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-</section>
-</div>
-<div id="march-16-2021">
-<section id="section-c.6">
-        <h2 id="name-march-16-2021">
-<a href="#section-c.6" class="section-number selfRef">C.6. </a><a href="#name-march-16-2021" class="section-name selfRef">March 16, 2021</a>
-        </h2>
-<div id="ticket-7-abnf-for-dmarc-record-is-slightly-wrong">
-<section id="section-c.6.1">
-          <h3 id="name-ticket-7-abnf-for-dmarc-rec">
-<a href="#section-c.6.1" class="section-number selfRef">C.6.1. </a><a href="#name-ticket-7-abnf-for-dmarc-rec" class="section-name selfRef">Ticket 7 - ABNF for dmarc-record is slightly wrong</a>
-          </h3>
-<ul>
-<li id="section-c.6.1-1.1">New text documented here - <a href="https://trac.ietf.org/trac/dmarc/ticket/7">https://trac.ietf.org/trac/dmarc/ticket/7</a><a href="#section-c.6.1-1.1" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-<div id="ticket-26-abnf-for-pct-allows-999">
-<section id="section-c.6.2">
-          <h3 id="name-ticket-26-abnf-for-pct-allo">
-<a href="#section-c.6.2" class="section-number selfRef">C.6.2. </a><a href="#name-ticket-26-abnf-for-pct-allo" class="section-name selfRef">Ticket 26 - ABNF for pct allows "999"</a>
-          </h3>
-<ul>
-<li id="section-c.6.2-1.1">Updated ABNF for dmarc-percent<a href="#section-c.6.2-1.1" class="pilcrow">¶</a>
-</li>
-<li id="section-c.6.2-1.2">New text documented here - <a href="https://trac.ietf.org/trac/dmarc/ticket/26#comment:6">https://trac.ietf.org/trac/dmarc/ticket/26#comment:6</a><a href="#section-c.6.2-1.2" class="pilcrow">¶</a>
-</li>
-<li id="section-c.6.2-1.3">Ticket 47, Remove pct= tag, rendered change obsolete<a href="#section-c.6.2-1.3" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-</section>
-</div>
-<div id="march-23-2021">
-<section id="section-c.7">
-        <h2 id="name-march-23-2021">
-<a href="#section-c.7" class="section-number selfRef">C.7. </a><a href="#name-march-23-2021" class="section-name selfRef">March 23, 2021</a>
-        </h2>
-<div id="ticket-75-using-wording-alternatives-to-disposition-dispose-and-the-like">
-<section id="section-c.7.1">
-          <h3 id="name-ticket-75-using-wording-alt">
-<a href="#section-c.7.1" class="section-number selfRef">C.7.1. </a><a href="#name-ticket-75-using-wording-alt" class="section-name selfRef">Ticket 75 - Using wording alternatives to 'disposition', 'dispose', and the like</a>
-          </h3>
-<ul>
-<li id="section-c.7.1-1.1">Changed disposition/dispose to "handling"<a href="#section-c.7.1-1.1" class="pilcrow">¶</a>
-</li>
-<li id="section-c.7.1-1.2">Diffs documented here - <a href="https://trac.ietf.org/trac/dmarc/ticket/75#comment:3">https://trac.ietf.org/trac/dmarc/ticket/75#comment:3</a><a href="#section-c.7.1-1.2" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-<div id="ticket-72-remove-absolute-requirement-for-p-tag-in-dmarc-record">
-<section id="section-c.7.2">
-          <h3 id="name-ticket-72-remove-absolute-r">
-<a href="#section-c.7.2" class="section-number selfRef">C.7.2. </a><a href="#name-ticket-72-remove-absolute-r" class="section-name selfRef">Ticket 72 - Remove absolute requirement for p= tag in DMARC record</a>
-          </h3>
-<ul>
-<li id="section-c.7.2-1.1">Changed from REQUIRED to RECOMMENDED, noted default with forward reference to discussion<a href="#section-c.7.2-1.1" class="pilcrow">¶</a>
-</li>
-<li id="section-c.7.2-1.2">Diffs documented here - <a href="https://trac.ietf.org/trac/dmarc/ticket/72#comment:3">https://trac.ietf.org/trac/dmarc/ticket/72#comment:3</a><a href="#section-c.7.2-1.2" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-</section>
-</div>
-<div id="march-29-2021">
-<section id="section-c.8">
-        <h2 id="name-march-29-2021">
-<a href="#section-c.8" class="section-number selfRef">C.8. </a><a href="#name-march-29-2021" class="section-name selfRef">March 29, 2021</a>
-        </h2>
-<div id="ticket-54-remove-or-expand-limits-on-number-of-recipients-per-report">
-<section id="section-c.8.1">
-          <h3 id="name-ticket-54-remove-or-expand-">
-<a href="#section-c.8.1" class="section-number selfRef">C.8.1. </a><a href="#name-ticket-54-remove-or-expand-" class="section-name selfRef">Ticket 54 - Remove or expand limits on number of recipients per report</a>
-          </h3>
-<ul>
-<li id="section-c.8.1-1.1">Removed limit<a href="#section-c.8.1-1.1" class="pilcrow">¶</a>
-</li>
-<li id="section-c.8.1-1.2">Diffs documented here - <a href="https://trac.ietf.org/trac/dmarc/ticket/54#comment:5">https://trac.ietf.org/trac/dmarc/ticket/54#comment:5</a><a href="#section-c.8.1-1.2" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-</section>
-</div>
-<div id="april-12-2021">
-<section id="section-c.9">
-        <h2 id="name-april-12-2021">
-<a href="#section-c.9" class="section-number selfRef">C.9. </a><a href="#name-april-12-2021" class="section-name selfRef">April 12, 2021</a>
-        </h2>
-<div id="ticket-50-remove-ri-tag">
-<section id="section-c.9.1">
-          <h3 id="name-ticket-50-remove-ri-tag">
-<a href="#section-c.9.1" class="section-number selfRef">C.9.1. </a><a href="#name-ticket-50-remove-ri-tag" class="section-name selfRef">Ticket 50 - Remove ri= tag</a>
-          </h3>
-<ul>
-<li id="section-c.9.1-1.1">Updated text to recommend against its usage, a la the ptr mechanism in RFC 7208<a href="#section-c.9.1-1.1" class="pilcrow">¶</a>
-</li>
-<li id="section-c.9.1-1.2">Diffs documented here - <a href="https://trac.ietf.org/trac/dmarc/ticket/50#comment:5">https://trac.ietf.org/trac/dmarc/ticket/50#comment:5</a><a href="#section-c.9.1-1.2" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-<div id="ticket-66-define-what-it-means-to-have-implemented-dmarc">
-<section id="section-c.9.2">
-          <h3 id="name-ticket-66-define-what-it-me">
-<a href="#section-c.9.2" class="section-number selfRef">C.9.2. </a><a href="#name-ticket-66-define-what-it-me" class="section-name selfRef">Ticket 66 - Define what it means to have implemented DMARC</a>
-          </h3>
-<ul>
-<li id="section-c.9.2-1.1">Proposed new text (taken straight from <a href="https://trac.ietf.org/trac/dmarc/ticket/66">https://trac.ietf.org/trac/dmarc/ticket/66</a>
-as replacement for current text in "Minimum Implemenatations"<a href="#section-c.9.2-1.1" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-<div id="ticket-96-tweaks-to-abstract-and-introduction">
-<section id="section-c.9.3">
-          <h3 id="name-ticket-96-tweaks-to-abstrac">
-<a href="#section-c.9.3" class="section-number selfRef">C.9.3. </a><a href="#name-ticket-96-tweaks-to-abstrac" class="section-name selfRef">Ticket 96 - Tweaks to Abstract and Introduction</a>
-          </h3>
-<ul>
-<li id="section-c.9.3-1.1">Changed phrase in Abstract to "an email author's domain name"<a href="#section-c.9.3-1.1" class="pilcrow">¶</a>
-</li>
-<li id="section-c.9.3-1.2">Changed phrase in Introduction to "reports about email use of the domain name"<a href="#section-c.9.3-1.2" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-</section>
-</div>
-<div id="april-13-2021">
-<section id="section-c.10">
-        <h2 id="name-april-13-2021">
-<a href="#section-c.10" class="section-number selfRef">C.10. </a><a href="#name-april-13-2021" class="section-name selfRef">April 13, 2021</a>
-        </h2>
-<div id="ticket-53-remove-reporting-message-size-chunking">
-<section id="section-c.10.1">
-          <h3 id="name-ticket-53-remove-reporting-">
-<a href="#section-c.10.1" class="section-number selfRef">C.10.1. </a><a href="#name-ticket-53-remove-reporting-" class="section-name selfRef">Ticket 53 - Remove reporting message size chunking</a>
-          </h3>
-<ul>
-<li id="section-c.10.1-1.1">Proposed text to remove all references to message size chunking<a href="#section-c.10.1-1.1" class="pilcrow">¶</a>
-</li>
-<li id="section-c.10.1-1.2">Data demonstrating lack of use of feature entered into ticket -
-<a href="https://trac.ietf.org/trac/dmarc/ticket/53#comment:4">https://trac.ietf.org/trac/dmarc/ticket/53#comment:4</a><a href="#section-c.10.1-1.2" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-<div id="ticket-52-remove-strict-alignment-and-adkim-and-aspf-tags">
-<section id="section-c.10.2">
-          <h3 id="name-ticket-52-remove-strict-ali">
-<a href="#section-c.10.2" class="section-number selfRef">C.10.2. </a><a href="#name-ticket-52-remove-strict-ali" class="section-name selfRef">Ticket 52 - Remove strict alignment (and adkim and aspf tags)</a>
-          </h3>
-<ul>
-<li id="section-c.10.2-1.1">Proposed text to remove all references to strict alignment<a href="#section-c.10.2-1.1" class="pilcrow">¶</a>
-</li>
-<li id="section-c.10.2-1.2">Data demonstrating lack of use of feature entered into ticket -
-<a href="https://trac.ietf.org/trac/dmarc/ticket/52#comment:2">https://trac.ietf.org/trac/dmarc/ticket/52#comment:2</a><a href="#section-c.10.2-1.2" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-<div id="ticket-47-remove-pct-tag">
-<section id="section-c.10.3">
-          <h3 id="name-ticket-47-remove-pct-tag">
-<a href="#section-c.10.3" class="section-number selfRef">C.10.3. </a><a href="#name-ticket-47-remove-pct-tag" class="section-name selfRef">Ticket 47 - Remove pct= tag</a>
-          </h3>
-<ul>
-<li id="section-c.10.3-1.1">Proposed text to remove all references to pct and message sampling<a href="#section-c.10.3-1.1" class="pilcrow">¶</a>
-</li>
-<li id="section-c.10.3-1.2">Data demonstrating lack of use of feature entered into ticket -
-<a href="https://trac.ietf.org/trac/dmarc/ticket/47#comment:4">https://trac.ietf.org/trac/dmarc/ticket/47#comment:4</a><a href="#section-c.10.3-1.2" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-<div id="ticket-2-flow-of-operations-text-in-dmarc-base">
-<section id="section-c.10.4">
-          <h3 id="name-ticket-2-flow-of-operations">
-<a href="#section-c.10.4" class="section-number selfRef">C.10.4. </a><a href="#name-ticket-2-flow-of-operations" class="section-name selfRef">Ticket 2 - Flow of operations text in dmarc-base</a>
-          </h3>
-<ul>
-<li id="section-c.10.4-1.1">Update ASCII Art<a href="#section-c.10.4-1.1" class="pilcrow">¶</a>
-</li>
-<li id="section-c.10.4-1.2">Proposed text to replace description of ASCII Art<a href="#section-c.10.4-1.2" class="pilcrow">¶</a>
-</li>
-<li id="section-c.10.4-1.3">Proposed text to update Domain Owner Actions section<a href="#section-c.10.4-1.3" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-</section>
-</div>
-<div id="april-14-2021">
-<section id="section-c.11">
-        <h2 id="name-april-14-2021">
-<a href="#section-c.11" class="section-number selfRef">C.11. </a><a href="#name-april-14-2021" class="section-name selfRef">April 14, 2021</a>
-        </h2>
-<div id="ticket-107-dmarcbis-should-take-a-stand-on-multi-valued-from-fields">
-<section id="section-c.11.1">
-          <h3 id="name-ticket-107-dmarcbis-should-">
-<a href="#section-c.11.1" class="section-number selfRef">C.11.1. </a><a href="#name-ticket-107-dmarcbis-should-" class="section-name selfRef">Ticket 107 - DMARCbis should take a stand on multi-valued From fields</a>
-          </h3>
-<ul>
-<li id="section-c.11.1-1.1">Proposed text that limits processing to only those times when all domains
-are the same.<a href="#section-c.11.1-1.1" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-<div id="ticket-82-deprecate-rf-and-maybe-fo-tag">
-<section id="section-c.11.2">
-          <h3 id="name-ticket-82-deprecate-rf-and-">
-<a href="#section-c.11.2" class="section-number selfRef">C.11.2. </a><a href="#name-ticket-82-deprecate-rf-and-" class="section-name selfRef">Ticket 82 - Deprecate rf= and maybe fo= tag</a>
-          </h3>
-<ul>
-<li id="section-c.11.2-1.1">Proposed text to deprecate rf= tag, while leaving fo= tag as is<a href="#section-c.11.2-1.1" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-<div id="ticket-85-proposed-change-to-wording-describing-p-tag-and-values">
-<section id="section-c.11.3">
-          <h3 id="name-ticket-85-proposed-change-t">
-<a href="#section-c.11.3" class="section-number selfRef">C.11.3. </a><a href="#name-ticket-85-proposed-change-t" class="section-name selfRef">Ticket 85 - Proposed change to wording describing 'p' tag and values</a>
-          </h3>
-<ul>
-<li id="section-c.11.3-1.1">The language expressing the semantics is proposed to be changed to be,
-in a sense, egocentric. How do I, the domain owner feel about (assess)
-the meaning of a DMARC failure?<a href="#section-c.11.3-1.1" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-</section>
-</div>
-<div id="april-15-2021">
-<section id="section-c.12">
-        <h2 id="name-april-15-2021">
-<a href="#section-c.12" class="section-number selfRef">C.12. </a><a href="#name-april-15-2021" class="section-name selfRef">April 15, 2021</a>
-        </h2>
-<div id="ticket-86-a-r-results-for-dmarc">
-<section id="section-c.12.1">
-          <h3 id="name-ticket-86-a-r-results-for-d">
-<a href="#section-c.12.1" class="section-number selfRef">C.12.1. </a><a href="#name-ticket-86-a-r-results-for-d" class="section-name selfRef">Ticket 86 - A-R results for DMARC</a>
-          </h3>
-<ul>
-<li id="section-c.12.1-1.1">Proposed text to add for polrec.p and polrec.domain methods for registry
-update.<a href="#section-c.12.1-1.1" class="pilcrow">¶</a>
-</li>
-<li id="section-c.12.1-1.2">Did not include polrec.pct due to proposal to remove pct tag (Ticket 47)<a href="#section-c.12.1-1.2" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-<div id="ticket-62-make-aggregate-reporting-a-normative-must">
-<section id="section-c.12.2">
-          <h3 id="name-ticket-62-make-aggregate-re">
-<a href="#section-c.12.2" class="section-number selfRef">C.12.2. </a><a href="#name-ticket-62-make-aggregate-re" class="section-name selfRef">Ticket 62 - Make aggregate reporting a normative MUST</a>
-          </h3>
-<ul>
-<li id="section-c.12.2-1.1">Proposed text to do just that in Mail Receiver Actions, section
-titled "Send Aggregate Reports"<a href="#section-c.12.2-1.1" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-</section>
-</div>
-<div id="april-19-2021">
-<section id="section-c.13">
-        <h2 id="name-april-19-2021">
-<a href="#section-c.13" class="section-number selfRef">C.13. </a><a href="#name-april-19-2021" class="section-name selfRef">April 19, 2021</a>
-        </h2>
-<div id="ticket-109-sanity-check-dmarcbis-document">
-<section id="section-c.13.1">
-          <h3 id="name-ticket-109-sanity-check-dma">
-<a href="#section-c.13.1" class="section-number selfRef">C.13.1. </a><a href="#name-ticket-109-sanity-check-dma" class="section-name selfRef">Ticket 109 - Sanity Check DMARCbis Document</a>
-          </h3>
-<ul>
-<li id="section-c.13.1-1.1">Updated document to remove all "original text"/"proposed text" couplets
-in favor of one (hopefully coherent) document full of proposed text
-changes.<a href="#section-c.13.1-1.1" class="pilcrow">¶</a>
-</li>
-<li id="section-c.13.1-1.2">Noted which tickets were the cause of whatever rfcdiff output will show
-in tracker<a href="#section-c.13.1-1.2" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-</section>
-</div>
-<div id="april-20-2021">
-<section id="section-c.14">
-        <h2 id="name-april-20-2021">
-<a href="#section-c.14" class="section-number selfRef">C.14. </a><a href="#name-april-20-2021" class="section-name selfRef">April 20, 2021</a>
-        </h2>
-<div id="ticket-108-changes-to-dmarcbis-for-psd">
-<section id="section-c.14.1">
-          <h3 id="name-ticket-108-changes-to-dmarc">
-<a href="#section-c.14.1" class="section-number selfRef">C.14.1. </a><a href="#name-ticket-108-changes-to-dmarc" class="section-name selfRef">Ticket 108 - Changes to DMARCbis for PSD</a>
-          </h3>
-<ul>
-<li id="section-c.14.1-1.1">Incorporating requests for changes to DMARCbis made in text of
-"Experimental DMARC Extension for Public Suffix Domains"
-(<a href="https://datatracker.ietf.org/doc/draft-ietf-dmarc-psd/">https://datatracker.ietf.org/doc/draft-ietf-dmarc-psd/</a>)<a href="#section-c.14.1-1.1" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-</section>
-</div>
-<div id="april-22-2021">
-<section id="section-c.15">
-        <h2 id="name-april-22-2021">
-<a href="#section-c.15" class="section-number selfRef">C.15. </a><a href="#name-april-22-2021" class="section-name selfRef">April 22, 2021</a>
-        </h2>
-<div id="ticket-104-update-the-security-considerations-section-11-3-on-dns">
-<section id="section-c.15.1">
-          <h3 id="name-ticket-104-update-the-secur">
-<a href="#section-c.15.1" class="section-number selfRef">C.15.1. </a><a href="#name-ticket-104-update-the-secur" class="section-name selfRef">Ticket 104 - Update the Security Considerations section 11.3 on DNS</a>
-          </h3>
-<ul>
-<li id="section-c.15.1-1.1">Updated text. Diffs are here - <a href="https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/31/files">https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/31/files</a><a href="#section-c.15.1-1.1" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-</section>
-</div>
-<div id="june-16-2021">
-<section id="section-c.16">
-        <h2 id="name-june-16-2021">
-<a href="#section-c.16" class="section-number selfRef">C.16. </a><a href="#name-june-16-2021" class="section-name selfRef">June 16, 2021</a>
-        </h2>
-<div id="publication-of-draft-ietf-dmarc-dmarcbis-02">
-<section id="section-c.16.1">
-          <h3 id="name-publication-of-draft-ietf-d">
-<a href="#section-c.16.1" class="section-number selfRef">C.16.1. </a><a href="#name-publication-of-draft-ietf-d" class="section-name selfRef">Publication of draft-ietf-dmarc-dmarcbis-02</a>
-          </h3>
-<ul>
-<li id="section-c.16.1-1.1">Includes final resolution for tickets 4, 47, 50, 52, 53, 54, and 82<a href="#section-c.16.1-1.1" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
-</section>
-</div>
-<div id="august-12-2021">
-<section id="section-c.17">
-        <h2 id="name-august-12-2021">
-<a href="#section-c.17" class="section-number selfRef">C.17. </a><a href="#name-august-12-2021" class="section-name selfRef">August 12, 2021</a>
-        </h2>
-<div id="publication-of-draft-ietf-dmarc-dmarcbis-03">
-<section id="section-c.17.1">
-          <h3 id="name-publication-of-draft-ietf-dm">
-<a href="#section-c.17.1" class="section-number selfRef">C.17.1. </a><a href="#name-publication-of-draft-ietf-dm" class="section-name selfRef">Publication of draft-ietf-dmarc-dmarcbis-03</a>
-          </h3>
-<ul>
-<li id="section-c.17.1-1.1">Removal of "pct" tag<a href="#section-c.17.1-1.1" class="pilcrow">¶</a>
-</li>
-<li id="section-c.17.1-1.2">Addition of "t" tag<a href="#section-c.17.1-1.2" class="pilcrow">¶</a>
-</li>
-<li id="section-c.17.1-1.3">Rearranging of some text and formatting for better readability and consistency.<a href="#section-c.17.1-1.3" class="pilcrow">¶</a>
-</li>
-</ul>
-</section>
-</div>
+come to an understanding of how its domain is being misused.<a href="#section-b.4-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="acknowledgements">
-<section id="section-appendix.d">
+<section id="section-appendix.c">
       <h2 id="name-acknowledgements">
 <a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
       </h2>
-<p id="section-appendix.d-1">DMARC and the draft version of this document submitted to the
+<p id="section-appendix.c-1">DMARC and the draft version of this document submitted to the
 Independent Submission Editor were the result of lengthy efforts by
 an informal industry consortium: DMARC.org (see <a href="http://dmarc.org">http://dmarc.org</a>).
 Participating companies included Agari, American Greetings, AOL, Bank
@@ -5333,15 +4646,15 @@ individual contributions were made by J. Trent Adams, Michael Adkins,
 Monica Chew, Dave Crocker, Tim Draegen, Steve Jones, Franck Martin,
 Brett McDowell, and Paul Midgen.  The contributors would also like to
 recognize the invaluable input and guidance that was provided early
-on by J.D. Falk.<a href="#section-appendix.d-1" class="pilcrow">¶</a></p>
-<p id="section-appendix.d-2">Additional contributions within the IETF context were made by Kurt
+on by J.D. Falk.<a href="#section-appendix.c-1" class="pilcrow">¶</a></p>
+<p id="section-appendix.c-2">Additional contributions within the IETF context were made by Kurt
 Anderson, Michael Jack Assels, Les Barstow, Anne Bennett, Jim Fenton,
 J. Gomez, Mike Jones, Scott Kitterman, Eliot Lear, John Levine,
-S. Moonesamy, Rolf Sonneveld, Henry Timmes, and Stephen J. Turnbull.<a href="#section-appendix.d-2" class="pilcrow">¶</a></p>
+S. Moonesamy, Rolf Sonneveld, Henry Timmes, and Stephen J. Turnbull.<a href="#section-appendix.c-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="authors-addresses">
-<section id="section-appendix.e">
+<section id="section-appendix.d">
       <h2 id="name-authors-addresses">
 <a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/draft-ietf-dmarc-dmarcbis-04.html
+++ b/draft-ietf-dmarc-dmarcbis-04.html
@@ -1113,7 +1113,7 @@ dd.break {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Herr (ed) &amp; Levine (ed)</td>
-<td class="center">Expires 26 May 2022</td>
+<td class="center">Expires 27 May 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1129,12 +1129,12 @@ dd.break {
 <a href="https://www.rfc-editor.org/rfc/rfc7489" class="eref">7489</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-11-22" class="published">22 November 2021</time>
+<time datetime="2021-11-23" class="published">23 November 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-05-26">26 May 2022</time></dd>
+<dd class="expires"><time datetime="2022-05-27">27 May 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1180,7 +1180,7 @@ handling choices for incoming mail.<a href="#section-abstract-2" class="pilcrow"
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 26 May 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 27 May 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1282,30 +1282,36 @@ handling choices for incoming mail.<a href="#section-abstract-2" class="pilcrow"
             <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-overview-and-key-concepts" class="xref">Overview and Key Concepts</a><a href="#section-toc.1-1.4.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
 <li class="toc ulEmpty" id="section-toc.1-1.4.2.1">
-                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="xref">4.1</a>.  <a href="#name-use-of-rfc5322from" class="xref">Use of RFC5322.From</a><a href="#section-toc.1-1.4.2.1.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="xref">4.1</a>.  <a href="#name-dmarc-basics" class="xref">DMARC Basics</a><a href="#section-toc.1-1.4.2.1.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.4.2.2">
-                <p id="section-toc.1-1.4.2.2.1"><a href="#section-4.2" class="xref">4.2</a>.  <a href="#name-authentication-mechanisms" class="xref">Authentication Mechanisms</a><a href="#section-toc.1-1.4.2.2.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.4.2.2.1"><a href="#section-4.2" class="xref">4.2</a>.  <a href="#name-use-of-rfc5322from" class="xref">Use of RFC5322.From</a><a href="#section-toc.1-1.4.2.2.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.4.2.3">
-                <p id="section-toc.1-1.4.2.3.1"><a href="#section-4.3" class="xref">4.3</a>.  <a href="#name-flow-diagram" class="xref">Flow Diagram</a><a href="#section-toc.1-1.4.2.3.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.4.2.3.1"><a href="#section-4.3" class="xref">4.3</a>.  <a href="#name-authentication-mechanisms" class="xref">Authentication Mechanisms</a><a href="#section-toc.1-1.4.2.3.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.4.2.4">
-                <p id="section-toc.1-1.4.2.4.1"><a href="#section-4.4" class="xref">4.4</a>.  <a href="#name-identifier-alignment-explai" class="xref">Identifier Alignment Explained</a><a href="#section-toc.1-1.4.2.4.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.4.2.4.2.1">
-                    <p id="section-toc.1-1.4.2.4.2.1.1"><a href="#section-4.4.1" class="xref">4.4.1</a>.  <a href="#name-dkim-authenticated-identifi" class="xref">DKIM-Authenticated Identifiers</a><a href="#section-toc.1-1.4.2.4.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.4.2.4.2.2">
-                    <p id="section-toc.1-1.4.2.4.2.2.1"><a href="#section-4.4.2" class="xref">4.4.2</a>.  <a href="#name-spf-authenticated-identifie" class="xref">SPF-Authenticated Identifiers</a><a href="#section-toc.1-1.4.2.4.2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.4.2.4.2.3">
-                    <p id="section-toc.1-1.4.2.4.2.3.1"><a href="#section-4.4.3" class="xref">4.4.3</a>.  <a href="#name-alignment-and-extension-tec" class="xref">Alignment and Extension Technologies</a><a href="#section-toc.1-1.4.2.4.2.3.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
+                <p id="section-toc.1-1.4.2.4.1"><a href="#section-4.4" class="xref">4.4</a>.  <a href="#name-flow-diagram" class="xref">Flow Diagram</a><a href="#section-toc.1-1.4.2.4.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.4.2.5">
-                <p id="section-toc.1-1.4.2.5.1"><a href="#section-4.5" class="xref">4.5</a>.  <a href="#name-determining-the-organizatio" class="xref">Determining The Organizational Domain</a><a href="#section-toc.1-1.4.2.5.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.4.2.5.1"><a href="#section-4.5" class="xref">4.5</a>.  <a href="#name-dns-tree-walk" class="xref">DNS Tree Walk</a><a href="#section-toc.1-1.4.2.5.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.4.2.6">
+                <p id="section-toc.1-1.4.2.6.1"><a href="#section-4.6" class="xref">4.6</a>.  <a href="#name-determining-the-organizatio" class="xref">Determining the Organizational Domain</a><a href="#section-toc.1-1.4.2.6.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.4.2.7">
+                <p id="section-toc.1-1.4.2.7.1"><a href="#section-4.7" class="xref">4.7</a>.  <a href="#name-identifier-alignment-explai" class="xref">Identifier Alignment Explained</a><a href="#section-toc.1-1.4.2.7.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.4.2.7.2.1">
+                    <p id="section-toc.1-1.4.2.7.2.1.1"><a href="#section-4.7.1" class="xref">4.7.1</a>.  <a href="#name-dkim-authenticated-identifi" class="xref">DKIM-Authenticated Identifiers</a><a href="#section-toc.1-1.4.2.7.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.4.2.7.2.2">
+                    <p id="section-toc.1-1.4.2.7.2.2.1"><a href="#section-4.7.2" class="xref">4.7.2</a>.  <a href="#name-spf-authenticated-identifie" class="xref">SPF-Authenticated Identifiers</a><a href="#section-toc.1-1.4.2.7.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.4.2.7.2.3">
+                    <p id="section-toc.1-1.4.2.7.2.3.1"><a href="#section-4.7.3" class="xref">4.7.3</a>.  <a href="#name-alignment-and-extension-tec" class="xref">Alignment and Extension Technologies</a><a href="#section-toc.1-1.4.2.7.2.3.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
 </li>
 </ul>
 </li>
@@ -1360,13 +1366,10 @@ handling choices for incoming mail.<a href="#section-abstract-2" class="pilcrow"
                     <p id="section-toc.1-1.5.2.7.2.2.1"><a href="#section-5.7.2" class="xref">5.7.2</a>.  <a href="#name-determine-handling-policy" class="xref">Determine Handling Policy</a><a href="#section-toc.1-1.5.2.7.2.2.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.5.2.7.2.3">
-                    <p id="section-toc.1-1.5.2.7.2.3.1"><a href="#section-5.7.3" class="xref">5.7.3</a>.  <a href="#name-policy-discovery" class="xref">Policy Discovery</a><a href="#section-toc.1-1.5.2.7.2.3.1" class="pilcrow">¶</a></p>
+                    <p id="section-toc.1-1.5.2.7.2.3.1"><a href="#section-5.7.3" class="xref">5.7.3</a>.  <a href="#name-store-results-of-dmarc-proc" class="xref">Store Results of DMARC Processing</a><a href="#section-toc.1-1.5.2.7.2.3.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.5.2.7.2.4">
-                    <p id="section-toc.1-1.5.2.7.2.4.1"><a href="#section-5.7.4" class="xref">5.7.4</a>.  <a href="#name-store-results-of-dmarc-proc" class="xref">Store Results of DMARC Processing</a><a href="#section-toc.1-1.5.2.7.2.4.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.5.2.7.2.5">
-                    <p id="section-toc.1-1.5.2.7.2.5.1"><a href="#section-5.7.5" class="xref">5.7.5</a>.  <a href="#name-send-aggregate-reports" class="xref">Send Aggregate Reports</a><a href="#section-toc.1-1.5.2.7.2.5.1" class="pilcrow">¶</a></p>
+                    <p id="section-toc.1-1.5.2.7.2.4.1"><a href="#section-5.7.4" class="xref">5.7.4</a>.  <a href="#name-send-aggregate-reports" class="xref">Send Aggregate Reports</a><a href="#section-toc.1-1.5.2.7.2.4.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
@@ -1924,7 +1927,7 @@ material before continuing.<a href="#section-3.1-2" class="pilcrow">¶</a></p>
 <a href="#section-3.2.1" class="section-number selfRef">3.2.1. </a><a href="#name-authenticated-identifiers" class="section-name selfRef">Authenticated Identifiers</a>
           </h4>
 <p id="section-3.2.1-1">Domain-level identifiers that are verified using authentication technologies
-are referred to as "Authenticated Identifiers".  See <a href="#authentication-mechanisms" class="xref">Section 4.2</a>
+are referred to as "Authenticated Identifiers".  See <a href="#authentication-mechanisms" class="xref">Section 4.3</a>
 for details about the supported mechanisms.<a href="#section-3.2.1-1" class="pilcrow">¶</a></p>
 </section>
 </div>
@@ -1959,8 +1962,8 @@ their immediate management domain.<a href="#section-3.2.3-1" class="pilcrow">¶<
 <a href="#section-3.2.4" class="section-number selfRef">3.2.4. </a><a href="#name-identifier-alignment" class="section-name selfRef">Identifier Alignment</a>
           </h4>
 <p id="section-3.2.4-1">When the domain in the address in the From: header field has the
-same Organizational Domain as a domain verified by SPF or DKIM
-(or both), it has Identifier Alignment. (see below)<a href="#section-3.2.4-1" class="pilcrow">¶</a></p>
+same Organizational Domain as a domain verified by an authenticated
+identifier, it has Identifier Alignment. (see below)<a href="#section-3.2.4-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="longest-psd">
@@ -2000,7 +2003,7 @@ is a broader definition than that in <span>[<a href="#RFC8020" class="xref">RFC8
 a domain name registrar.  More formally, it is any Public Suffix Domain
 plus one label. The Organizational Domain for the domain in the
 RFC5322.From domain is determined by applying the algorithm found in
-<a href="#determining-the-organizational-domain" class="xref">Section 4.5</a>.<a href="#section-3.2.8-1" class="pilcrow">¶</a></p>
+<a href="#determining-the-organizational-domain" class="xref">Section 4.6</a>.<a href="#section-3.2.8-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="public-suffix-domain">
@@ -2053,119 +2056,126 @@ that operate them.<a href="#section-3.2.12-1" class="pilcrow">¶</a></p>
       </h2>
 <p id="section-4-1">This section provides a general overview of the design and operation
 of the DMARC environment.<a href="#section-4-1" class="pilcrow">¶</a></p>
-<p id="section-4-2">DMARC permits a Domain Owner or PSO to enable verification of a domain's
+<div id="dmarc-basics">
+<section id="section-4.1">
+        <h3 id="name-dmarc-basics">
+<a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-dmarc-basics" class="section-name selfRef">DMARC Basics</a>
+        </h3>
+<p id="section-4.1-1">DMARC permits a Domain Owner or PSO to enable verification of a domain's
 use in an email message, to indicate the Domain Owner's or PSO's message
 handling preference regarding failed verification, and to request reports
 about use of the domain name.  All information about a Domain Owner's or
-PSO's DMARC policy is published and retrieved via the DNS.<a href="#section-4-2" class="pilcrow">¶</a></p>
-<p id="section-4-3">DMARC's verification function is based on whether the RFC5322.From
+PSO's DMARC policy is published and retrieved via the DNS.<a href="#section-4.1-1" class="pilcrow">¶</a></p>
+<p id="section-4.1-2">DMARC's verification function is based on whether the RFC5322.From
 domain is aligned with a domain name used in a supported authentication
-mechanism. <a href="#authentication-mechanisms" class="xref">Section 4.2</a> When a DMARC policy exists
+mechanism. <a href="#authentication-mechanisms" class="xref">Section 4.3</a> When a DMARC policy exists
 for the domain name found in the RFC5322.From header field, and that
 domain name is not verified through an aligned supported authentication
 mechanism, the handling of that message can be affected based on the
-DMARC policy when delivered to a participating receiver.<a href="#section-4-3" class="pilcrow">¶</a></p>
-<p id="section-4-4">A message satisfies the DMARC checks if at least one of the supported
-authentication mechanisms:<a href="#section-4-4" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-4-5">
-        <li id="section-4-5.1">
-          <p id="section-4-5.1.1">produces a "pass" result, and<a href="#section-4-5.1.1" class="pilcrow">¶</a></p>
+DMARC policy when delivered to a participating receiver.<a href="#section-4.1-2" class="pilcrow">¶</a></p>
+<p id="section-4.1-3">A message satisfies the DMARC checks if at least one of the supported
+authentication mechanisms:<a href="#section-4.1-3" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-4.1-4">
+          <li id="section-4.1-4.1">
+            <p id="section-4.1-4.1.1">produces a "pass" result, and<a href="#section-4.1-4.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-4-5.2">
-          <p id="section-4-5.2.1">produces that result based on an identifier that is in alignment,
-as described in <a href="#identifier-alignment-explained" class="xref">Section 4.4</a>.<a href="#section-4-5.2.1" class="pilcrow">¶</a></p>
+<li id="section-4.1-4.2">
+            <p id="section-4.1-4.2.1">produces that result based on an identifier that is in alignment,
+as described in <a href="#identifier-alignment-explained" class="xref">Section 4.7</a>.<a href="#section-4.1-4.2.1" class="pilcrow">¶</a></p>
 </li>
 </ol>
-<p id="section-4-6">It is important to note that the authentication mechanisms employed
+<p id="section-4.1-5">It is important to note that the authentication mechanisms employed
 by DMARC authenticate only a DNS domain and do not authenticate the
 local-part of any email address identifier found in a message, nor do
-they validate the legitimacy of message content.<a href="#section-4-6" class="pilcrow">¶</a></p>
-<p id="section-4-7">DMARC's feedback component involves the collection of information
+they validate the legitimacy of message content.<a href="#section-4.1-5" class="pilcrow">¶</a></p>
+<p id="section-4.1-6">DMARC's feedback component involves the collection of information
 about received messages claiming to be from the Author Domain
 for periodic aggregate reports to the Domain Owner or PSO.  The
 parameters and format for such reports are discussed in
-<span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-4-7" class="pilcrow">¶</a></p>
-<p id="section-4-8">A DMARC-enabled Mail Receiver might also generate per-message reports
+<span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span><a href="#section-4.1-6" class="pilcrow">¶</a></p>
+<p id="section-4.1-7">A DMARC-enabled Mail Receiver might also generate per-message reports
 that contain information related to individual messages that fail
 authentication checks. Per-message failure reports are a useful source of
 information when debugging deployments (if messages can be determined
 to be legitimate even though failing authentication) or in analyzing
 attacks.  The capability for such services is enabled by DMARC but
 defined in other referenced material such as <span>[<a href="#RFC6591" class="xref">RFC6591</a>]</span> and
-<span>[<a href="#DMARC-Failure-Reporting" class="xref">DMARC-Failure-Reporting</a>]</span><a href="#section-4-8" class="pilcrow">¶</a></p>
+<span>[<a href="#DMARC-Failure-Reporting" class="xref">DMARC-Failure-Reporting</a>]</span><a href="#section-4.1-7" class="pilcrow">¶</a></p>
+</section>
+</div>
 <div id="use-of-rfc5322-from">
-<section id="section-4.1">
+<section id="section-4.2">
         <h3 id="name-use-of-rfc5322from">
-<a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-use-of-rfc5322from" class="section-name selfRef">Use of RFC5322.From</a>
+<a href="#section-4.2" class="section-number selfRef">4.2. </a><a href="#name-use-of-rfc5322from" class="section-name selfRef">Use of RFC5322.From</a>
         </h3>
-<p id="section-4.1-1">One of the most obvious points of security scrutiny for DMARC is the
+<p id="section-4.2-1">One of the most obvious points of security scrutiny for DMARC is the
 choice to focus on an identifier, namely the RFC5322.From address,
 which is part of a body of data that has been trivially forged
 throughout the history of email. This field is the one used by end
 users to identify the source of the message, and so it has always
-been a prime target for abuse through such forgery and other means.<a href="#section-4.1-1" class="pilcrow">¶</a></p>
-<p id="section-4.1-2">Several points suggest that it is the most correct and safest thing
-to do in this context:<a href="#section-4.1-2" class="pilcrow">¶</a></p>
+been a prime target for abuse through such forgery and other means.<a href="#section-4.2-1" class="pilcrow">¶</a></p>
+<p id="section-4.2-2">Several points suggest that it is the most correct and safest thing
+to do in this context:<a href="#section-4.2-2" class="pilcrow">¶</a></p>
 <ul>
-<li id="section-4.1-3.1">
-            <p id="section-4.1-3.1.1">Of all the identifiers that are part of the message itself, this
-is the only one guaranteed to be present.<a href="#section-4.1-3.1.1" class="pilcrow">¶</a></p>
+<li id="section-4.2-3.1">
+            <p id="section-4.2-3.1.1">Of all the identifiers that are part of the message itself, this
+is the only one guaranteed to be present.<a href="#section-4.2-3.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-4.1-3.2">
-            <p id="section-4.1-3.2.1">It seems the best choice of an identifier on which to focus, as
+<li id="section-4.2-3.2">
+            <p id="section-4.2-3.2.1">It seems the best choice of an identifier on which to focus, as
 most MUAs display some or all of the contents of that field in a
 manner strongly suggesting those data as reflective of the true
-originator of the message.<a href="#section-4.1-3.2.1" class="pilcrow">¶</a></p>
+originator of the message.<a href="#section-4.2-3.2.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-4.1-3.3">
-            <p id="section-4.1-3.3.1">Many high-profile email sources, such as email service providers,
+<li id="section-4.2-3.3">
+            <p id="section-4.2-3.3.1">Many high-profile email sources, such as email service providers,
 require that the sending agent have authenticated before email
 can be generated.  Thus, for these mailboxes, the mechanism
 described in this document provides recipient end users with strong
 evidence that the message was indeed originated by the agent they
 associate with that mailbox, if the end user knows that these
-various protections have been provided.<a href="#section-4.1-3.3.1" class="pilcrow">¶</a></p>
+various protections have been provided.<a href="#section-4.2-3.3.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
-<p id="section-4.1-4">The absence of a single, properly formed RFC5322.From header field renders
+<p id="section-4.2-4">The absence of a single, properly formed RFC5322.From header field renders
 the message invalid.  Handling of such a message is outside of the
-scope of this specification.<a href="#section-4.1-4" class="pilcrow">¶</a></p>
-<p id="section-4.1-5">Since the sorts of mail typically protected by DMARC participants
+scope of this specification.<a href="#section-4.2-4" class="pilcrow">¶</a></p>
+<p id="section-4.2-5">Since the sorts of mail typically protected by DMARC participants
 tend to only have single Authors, DMARC participants generally
 operate under a slightly restricted profile of RFC5322 with respect
 to the expected syntax of this field.  See <a href="#mail-receiver-actions" class="xref">Section 5.7</a>
-for details.<a href="#section-4.1-5" class="pilcrow">¶</a></p>
+for details.<a href="#section-4.2-5" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="authentication-mechanisms">
-<section id="section-4.2">
+<section id="section-4.3">
         <h3 id="name-authentication-mechanisms">
-<a href="#section-4.2" class="section-number selfRef">4.2. </a><a href="#name-authentication-mechanisms" class="section-name selfRef">Authentication Mechanisms</a>
+<a href="#section-4.3" class="section-number selfRef">4.3. </a><a href="#name-authentication-mechanisms" class="section-name selfRef">Authentication Mechanisms</a>
         </h3>
-<p id="section-4.2-1">The following mechanisms for determining Authenticated Identifiers
-are supported in this version of DMARC:<a href="#section-4.2-1" class="pilcrow">¶</a></p>
+<p id="section-4.3-1">The following mechanisms for determining Authenticated Identifiers
+are supported in this version of DMARC:<a href="#section-4.3-1" class="pilcrow">¶</a></p>
 <ul>
-<li id="section-4.2-2.1">
-            <p id="section-4.2-2.1.1">DKIM, <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>, which provides a domain-level identifier in the content of
-the "d=" tag of a verified DKIM-Signature header field.<a href="#section-4.2-2.1.1" class="pilcrow">¶</a></p>
+<li id="section-4.3-2.1">
+            <p id="section-4.3-2.1.1">DKIM, <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>, which provides a domain-level identifier in the content of
+the "d=" tag of a verified DKIM-Signature header field.<a href="#section-4.3-2.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-4.2-2.2">
-            <p id="section-4.2-2.2.1">SPF, <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span>, which can authenticate both the domain found in
+<li id="section-4.3-2.2">
+            <p id="section-4.3-2.2.1">SPF, <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span>, which can authenticate both the domain found in
 an <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span> HELO/EHLO command (the HELO identity) and the domain
 found in an SMTP MAIL command (the MAIL FROM identity). As noted earlier,
 however, DMARC relies solely on SPF authentication of the domain found in
 SMTP MAIL FROM command. Section 2.4 of <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span> describes MAIL FROM
-processing for cases in which the MAIL command has a null path.<a href="#section-4.2-2.2.1" class="pilcrow">¶</a></p>
+processing for cases in which the MAIL command has a null path.<a href="#section-4.3-2.2.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </section>
 </div>
 <div id="flow-diagram">
-<section id="section-4.3">
+<section id="section-4.4">
         <h3 id="name-flow-diagram">
-<a href="#section-4.3" class="section-number selfRef">4.3. </a><a href="#name-flow-diagram" class="section-name selfRef">Flow Diagram</a>
+<a href="#section-4.4" class="section-number selfRef">4.4. </a><a href="#name-flow-diagram" class="section-name selfRef">Flow Diagram</a>
         </h3>
-<div id="section-4.3-1">
+<div id="section-4.4-1">
 <pre class="sourcecode lang-ascii-art"> +---------------+                             +--------------------+
  | Author Domain |&lt; . . . . . . . . . . . .    | Return-Path Domain |
  +---------------+                        .    +--------------------+
@@ -2194,196 +2204,232 @@ processing for cases in which the MAIL command has a null path.<a href="#section
 
   MSA = Mail Submission Agent
   MDA = Mail Delivery Agent
-</pre><a href="#section-4.3-1" class="pilcrow">¶</a>
+</pre><a href="#section-4.4-1" class="pilcrow">¶</a>
 </div>
-<p id="section-4.3-2">The above diagram shows a simple flow of messages through a
+<p id="section-4.4-2">The above diagram shows a simple flow of messages through a
 DMARC-aware system.  Solid lines denote the actual message flow,
 dotted lines involve DNS queries used to retrieve message policy
 related to the supported message authentication schemes, and asterisk
 lines indicate data exchange between message-handling modules and
 message authentication modules.  "sMTA" is the sending MTA, and "rMTA"
-is the receiving MTA.<a href="#section-4.3-2" class="pilcrow">¶</a></p>
-<p id="section-4.3-3">Put simply, when a message reaches a DMARC-aware rMTA, a DNS query
+is the receiving MTA.<a href="#section-4.4-2" class="pilcrow">¶</a></p>
+<p id="section-4.4-3">Put simply, when a message reaches a DMARC-aware rMTA, a DNS query
 will be initiated to determine if a DMARC policy exists that applies
 to the author domain. If a policy is found, the rMTA will use the results
 of SPF and DKIM verification checks to determine the ultimate DMARC
 authentication status. The DMARC status can then factor into the
-message handling decision made by the recipient's mail sytsem.<a href="#section-4.3-3" class="pilcrow">¶</a></p>
-<p id="section-4.3-4">More details on specific actions for the parties involved can be
-found in <a href="#domain-owner-actions" class="xref">Section 5.5</a> and <a href="#mail-receiver-actions" class="xref">Section 5.7</a>.<a href="#section-4.3-4" class="pilcrow">¶</a></p>
+message handling decision made by the recipient's mail sytsem.<a href="#section-4.4-3" class="pilcrow">¶</a></p>
+<p id="section-4.4-4">More details on specific actions for the parties involved can be
+found in <a href="#domain-owner-actions" class="xref">Section 5.5</a> and <a href="#mail-receiver-actions" class="xref">Section 5.7</a>.<a href="#section-4.4-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="dns-tree-walk">
+<section id="section-4.5">
+        <h3 id="name-dns-tree-walk">
+<a href="#section-4.5" class="section-number selfRef">4.5. </a><a href="#name-dns-tree-walk" class="section-name selfRef">DNS Tree Walk</a>
+        </h3>
+<p id="section-4.5-1">While the DMARC protocol defines a method for communicating information
+through publishing records in DNS, it is not necessarily true that a
+DMARC policy record for a given domain will be found in DNS at the same
+level as the name label for the domain in question. Instead, some domains
+will inherit their DNS policy records from parent domains one level or more
+above them in the DNS hierarchy, and these records can only be discovered
+through a technique described here, one known colloquially as a "DNS Tree Walk".<a href="#section-4.5-1" class="pilcrow">¶</a></p>
+<p id="section-4.5-2">The process for a DNS Tree Walk will always start at the point in
+the DNS hierarchy that matches the domain in the RFC5322.From header of
+the message, and will always end at the Public Suffix Domain that terminates
+the RFC5322.From domain. To prevent possible abuse of the DNS, a
+shortcut is built into the process so that RFC5322.From domains that have
+more than five labels do not result in more than five DNS queries.<a href="#section-4.5-2" class="pilcrow">¶</a></p>
+<p id="section-4.5-3">The generic steps for a DNS Tree Walk are as follows:<a href="#section-4.5-3" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-4.5-4">
+          <li id="section-4.5-4.1">
+            <p id="section-4.5-4.1.1">Query the DNS for a DMARC TXT record at the DNS domain matching the one
+found in the RFC5322.From domain in the message.  A possibly empty set
+of records is returned.<a href="#section-4.5-4.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4.5-4.2">
+            <p id="section-4.5-4.2.1">Records that do not start with a "v=" tag that identifies the
+current version of DMARC are discarded.<a href="#section-4.5-4.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4.5-4.3">
+            <p id="section-4.5-4.3.1">If the set is now empty, or the set contains one valid DMARC record that
+does not contain the information sought, then determine the target for
+additional queries, using steps 4 through 8 below.<a href="#section-4.5-4.3.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4.5-4.4">
+            <p id="section-4.5-4.4.1">Break the subject DNS domain name into a set of "n" ordered
+labels.  Number these labels from right to left; e.g., for
+"a.mail.example.com", "com" would be label 1, "example" would be
+label 2, "mail.example.com" would be label 3, and so forth.<a href="#section-4.5-4.4.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4.5-4.5">
+            <p id="section-4.5-4.5.1">Count the number of labels found in the subject DNS domain. Let that
+number be "x". If x &lt; 5, remove the left-most (highest-numbered)
+label from the subject domain. If x &gt;= 5, remove the left-most
+(highest-numbered) labels from the subject domain until 4 labels remain.
+The resulting DNS domain name is the new target for subsequent lookups.<a href="#section-4.5-4.5.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4.5-4.6">
+            <p id="section-4.5-4.6.1">Query the DNS for a DMARC TXT record at the DNS domain matching this
+new target in place of the RFC5322.From domain in the message.  A possibly
+empty set of records is returned.<a href="#section-4.5-4.6.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4.5-4.7">
+            <p id="section-4.5-4.7.1">Records that do not start with a "v=" tag that identifies the
+current version of DMARC are discarded.<a href="#section-4.5-4.7.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4.5-4.8">
+            <p id="section-4.5-4.8.1">If the set is now empty, or the set contains one valid DMARC record that
+does not contain the information sought, then determine the target for
+additional queries by removing a single label from the target domain as
+described in step 5 and repeating steps 6 and 7 until there are no more
+labels remaining or a valid DMARC record containing the information sought
+has been retrieved.<a href="#section-4.5-4.8.1" class="pilcrow">¶</a></p>
+</li>
+</ol>
+<p id="section-4.5-5">To illustrate, for a message with the arbitrary RFC5322.From domain of
+"a.b.c.d.e.mail.example.com", a full DNS Tree Walk would require the following
+five queries, in order:<a href="#section-4.5-5" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-4.5-6.1">_dmarc.a.b.c.d.e.mail.example.com<a href="#section-4.5-6.1" class="pilcrow">¶</a>
+</li>
+<li id="section-4.5-6.2">_dmarc.e.mail.example.com<a href="#section-4.5-6.2" class="pilcrow">¶</a>
+</li>
+<li id="section-4.5-6.3">_dmarc.mail.example.com<a href="#section-4.5-6.3" class="pilcrow">¶</a>
+</li>
+<li id="section-4.5-6.4">_dmarc.example.com<a href="#section-4.5-6.4" class="pilcrow">¶</a>
+</li>
+<li id="section-4.5-6.5">_dmarc.com<a href="#section-4.5-6.5" class="pilcrow">¶</a>
+</li>
+</ul>
+</section>
+</div>
+<div id="determining-the-organizational-domain">
+<section id="section-4.6">
+        <h3 id="name-determining-the-organizatio">
+<a href="#section-4.6" class="section-number selfRef">4.6. </a><a href="#name-determining-the-organizatio" class="section-name selfRef">Determining the Organizational Domain</a>
+        </h3>
+<p id="section-4.6-1">The DMARC protocol defines a method for a Public Suffix Domain to identify
+itself as such using a tag in its published DMARC policy record. An Organizational
+Domain is any subdomain of a PSD that includes exactly one more label than
+the PSD in its name.<a href="#section-4.6-1" class="pilcrow">¶</a></p>
+<p id="section-4.6-2">For any email message, the Organizational Domain of the RFC5322.From domain
+is determined by performing a DNS Tree Walk as described in <a href="#dns-tree-walk" class="xref">Section 4.5</a>.
+The target of the search is a valid DMARC record that contains a psd tag with
+a value of 'y'. Once such a record has been found, the Organizational Domain
+for the DNS domain matching the one found in the RFC5322.From domain can be
+declared to be the target domain queried for in the step just prior to the
+query that found the PSD domain.<a href="#section-4.6-2" class="pilcrow">¶</a></p>
+<p id="section-4.6-3">For example, given the RFC5322.From domain "a.mail.example.com", a series
+of DNS queries for DMARC records would be executed starting with
+"_dmarc.a.mail.example.com" and finishing with "_dmarc.com". The "_dmarc.com"
+record would contain a psd tag with a value of 'y', and so the Organizational
+Domain for this RFC5322.From domain would be determined to be "example.com",
+the domain of the DMARC query executed prior to the query for "_dmarc.com".<a href="#section-4.6-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="identifier-alignment-explained">
-<section id="section-4.4">
+<section id="section-4.7">
         <h3 id="name-identifier-alignment-explai">
-<a href="#section-4.4" class="section-number selfRef">4.4. </a><a href="#name-identifier-alignment-explai" class="section-name selfRef">Identifier Alignment Explained</a>
+<a href="#section-4.7" class="section-number selfRef">4.7. </a><a href="#name-identifier-alignment-explai" class="section-name selfRef">Identifier Alignment Explained</a>
         </h3>
-<p id="section-4.4-1">Email authentication technologies authenticate various (and
+<p id="section-4.7-1">Email authentication technologies authenticate various (and
 disparate) aspects of an individual message.  For example, DKIM <span>[<a href="#RFC6376" class="xref">RFC6376</a>]</span>
 authenticates the domain that affixed a signature to the message,
 while SPF <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span> can authenticate either the domain that appears in the
 RFC5321.MailFrom (MAIL FROM) portion of an SMTP <span>[<a href="#RFC5321" class="xref">RFC5321</a>]</span> conversation or the
 RFC5321.EHLO/HELO domain, or both.  These may be different domains, and they
-are typically not visible to the end user.<a href="#section-4.4-1" class="pilcrow">¶</a></p>
-<p id="section-4.4-2">DMARC authenticates use of the RFC5322.From domain by requiring that
-it have the same Organizational Domain as (i.e., be aligned with) an
-Authenticated Identifier. Domain names in this context are to be compared
-in a case-insensitive manner, per <span>[<a href="#RFC4343" class="xref">RFC4343</a>]</span>.<a href="#section-4.4-2" class="pilcrow">¶</a></p>
-<p id="section-4.4-3">It is important to note that Identifier Alignment cannot occur with a
+are typically not visible to the end user.<a href="#section-4.7-1" class="pilcrow">¶</a></p>
+<p id="section-4.7-2">DMARC authenticates use of the RFC5322.From domain by requiring either
+that it have the same Organizational Domain as an Authenticated Identifier
+(a condition known as "relaxed alignment") or that it be identical to the
+domain of the Authenticated Identifier (a condition known as "strict
+alignment"). The choice of relaxed or strict alignment is left to the domain
+owner and is expressed in the domain's DMARC policy record.  Domain names
+in this context are to be compared in a case-insensitive manner, per <span>[<a href="#RFC4343" class="xref">RFC4343</a>]</span>.<a href="#section-4.7-2" class="pilcrow">¶</a></p>
+<p id="section-4.7-3">It is important to note that Identifier Alignment cannot occur with a
 message that is not valid per <span>[<a href="#RFC5322" class="xref">RFC5322</a>]</span>, particularly one with a
 malformed, absent, or repeated RFC5322.From header field, since in that case
 there is no reliable way to determine a DMARC policy that applies to
 the message.  Accordingly, DMARC operation is predicated on the input
 being a valid RFC5322 message object, and handling of such
 non-compliant cases is outside of the scope of this specification.
-Further discussion of this can be found in <a href="#extract-author-domain" class="xref">Section 5.7.1</a>.<a href="#section-4.4-3" class="pilcrow">¶</a></p>
-<p id="section-4.4-4">Each of the underlying authentication technologies that DMARC takes
+Further discussion of this can be found in <a href="#extract-author-domain" class="xref">Section 5.7.1</a>.<a href="#section-4.7-3" class="pilcrow">¶</a></p>
+<p id="section-4.7-4">Each of the underlying authentication technologies that DMARC takes
 as input yields authenticated domains as their outputs when they
-succeed.<a href="#section-4.4-4" class="pilcrow">¶</a></p>
+succeed.<a href="#section-4.7-4" class="pilcrow">¶</a></p>
 <div id="dkim-identifiers">
-<section id="section-4.4.1">
+<section id="section-4.7.1">
           <h4 id="name-dkim-authenticated-identifi">
-<a href="#section-4.4.1" class="section-number selfRef">4.4.1. </a><a href="#name-dkim-authenticated-identifi" class="section-name selfRef">DKIM-Authenticated Identifiers</a>
+<a href="#section-4.7.1" class="section-number selfRef">4.7.1. </a><a href="#name-dkim-authenticated-identifi" class="section-name selfRef">DKIM-Authenticated Identifiers</a>
           </h4>
-<p id="section-4.4.1-1">DMARC requires Identifier Alignment based on the result of a DKIM
+<p id="section-4.7.1-1">DMARC requires Identifier Alignment based on the result of a DKIM
 authentication because a message can bear a valid signature from any
 domain, including domains used by a mailing list or even a bad actor.
 Therefore, merely bearing a valid signature is not enough to infer
-authenticity of the Author Domain.<a href="#section-4.4.1-1" class="pilcrow">¶</a></p>
-<p id="section-4.4.1-2">DMARC permits Identifier Alignment based on the result of a DKIM
+authenticity of the Author Domain.<a href="#section-4.7.1-1" class="pilcrow">¶</a></p>
+<p id="section-4.7.1-2">DMARC permits Identifier Alignment based on the result of a DKIM
 authentication to be strict or relaxed. (Note that these terms are
-not related to DKIM's "simple" and "relaxed" canonicalization modes.)<a href="#section-4.4.1-2" class="pilcrow">¶</a></p>
-<p id="section-4.4.1-3">In relaxed mode, the Organizational Domains of both the DKIM-authenticated
+not related to DKIM's "simple" and "relaxed" canonicalization modes.)<a href="#section-4.7.1-2" class="pilcrow">¶</a></p>
+<p id="section-4.7.1-3">In relaxed mode, the Organizational Domains of both the DKIM-authenticated
 signing domain (taken from the value of the d= tag in the signature)
 and that of the RFC5322.From domain must be equal if the identifiers
 are to be considered to be aligned. In strict mode, only an exact match
 between both Fully Qualified Domain Names (FQDNs) is considered to produce
-Identifier Alignment.<a href="#section-4.4.1-3" class="pilcrow">¶</a></p>
-<p id="section-4.4.1-4">To illustrate, in relaxed mode, if a verified DKIM signature
+Identifier Alignment.<a href="#section-4.7.1-3" class="pilcrow">¶</a></p>
+<p id="section-4.7.1-4">To illustrate, in relaxed mode, if a verified DKIM signature
 successfully verifies with a "d=" domain of "example.com", and the
 RFC5322.From address is "alerts@news.example.com", the DKIM "d="
 domain and the RFC5322.From domain are considered to be "in alignment",
 because both domains have the same Organizational Domain of "example.com".
 In strict mode, this test would fail because the d= domain does not
-exactly match the RFC5322.From domain.<a href="#section-4.4.1-4" class="pilcrow">¶</a></p>
-<p id="section-4.4.1-5">However, a DKIM signature bearing a value of "d=com" would never allow
+exactly match the RFC5322.From domain.<a href="#section-4.7.1-4" class="pilcrow">¶</a></p>
+<p id="section-4.7.1-5">However, a DKIM signature bearing a value of "d=com" would never allow
 an "in alignment" result, as "com" should be identified as a PSD and
-therefore cannot be an Organizational Domain.<a href="#section-4.4.1-5" class="pilcrow">¶</a></p>
-<p id="section-4.4.1-6">Note that a single email can contain multiple DKIM signatures, and it
+therefore cannot be an Organizational Domain.<a href="#section-4.7.1-5" class="pilcrow">¶</a></p>
+<p id="section-4.7.1-6">Note that a single email can contain multiple DKIM signatures, and it
 is considered to produce a DMARC "pass" result if any DKIM signature
-is aligned and verifies.<a href="#section-4.4.1-6" class="pilcrow">¶</a></p>
+is aligned and verifies.<a href="#section-4.7.1-6" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="spf-identifiers">
-<section id="section-4.4.2">
+<section id="section-4.7.2">
           <h4 id="name-spf-authenticated-identifie">
-<a href="#section-4.4.2" class="section-number selfRef">4.4.2. </a><a href="#name-spf-authenticated-identifie" class="section-name selfRef">SPF-Authenticated Identifiers</a>
+<a href="#section-4.7.2" class="section-number selfRef">4.7.2. </a><a href="#name-spf-authenticated-identifie" class="section-name selfRef">SPF-Authenticated Identifiers</a>
           </h4>
-<p id="section-4.4.2-1">DMARC permits Identifier Alignment based on the result of an SPF
+<p id="section-4.7.2-1">DMARC permits Identifier Alignment based on the result of an SPF
 authentication. As with DKIM, Identifier Alignement can be either
-strict or relaxed.<a href="#section-4.4.2-1" class="pilcrow">¶</a></p>
-<p id="section-4.4.2-2">In relaxed mode, the Organizational Domains of the SPF-authenticated
+strict or relaxed.<a href="#section-4.7.2-1" class="pilcrow">¶</a></p>
+<p id="section-4.7.2-2">In relaxed mode, the Organizational Domains of the SPF-authenticated
 domain and RFC5322.From domain must be equal if the identifiers are
 to be considered to be aligned. In strict mode, the two FQDNs must
-match exactly in order from them to be considered to be aligned.<a href="#section-4.4.2-2" class="pilcrow">¶</a></p>
-<p id="section-4.4.2-3">For example, in relaxed mode, if a message passes an SPF check with an
+match exactly in order from them to be considered to be aligned.<a href="#section-4.7.2-2" class="pilcrow">¶</a></p>
+<p id="section-4.7.2-3">For example, in relaxed mode, if a message passes an SPF check with an
 RFC5321.MailFrom domain of "cbg.bounces.example.com", and the address
 portion of the RFC5322.From header field contains
 "payments@example.com", the Authenticated RFC5321.MailFrom domain
 identifier and the RFC5322.From domain are considered to be "in
 alignment" because they have the same Organizational Domain
 ("example.com"). In strict mode, this test would fail because the
-two domains are not identical.<a href="#section-4.4.2-3" class="pilcrow">¶</a></p>
-<p id="section-4.4.2-4">The reader should note that SPF alignment checks in DMARC rely solely
+two domains are not identical.<a href="#section-4.7.2-3" class="pilcrow">¶</a></p>
+<p id="section-4.7.2-4">The reader should note that SPF alignment checks in DMARC rely solely
 on the RFC5321.MailFrom domain. This differs from section 2.3 of
 <span>[<a href="#RFC7208" class="xref">RFC7208</a>]</span>, which recommends that SPF checks be done on not only the
-"MAIL FROM" but also on a separate check of the "HELO" identity.<a href="#section-4.4.2-4" class="pilcrow">¶</a></p>
+"MAIL FROM" but also on a separate check of the "HELO" identity.<a href="#section-4.7.2-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="alignment-and-extension-technologies">
-<section id="section-4.4.3">
+<section id="section-4.7.3">
           <h4 id="name-alignment-and-extension-tec">
-<a href="#section-4.4.3" class="section-number selfRef">4.4.3. </a><a href="#name-alignment-and-extension-tec" class="section-name selfRef">Alignment and Extension Technologies</a>
+<a href="#section-4.7.3" class="section-number selfRef">4.7.3. </a><a href="#name-alignment-and-extension-tec" class="section-name selfRef">Alignment and Extension Technologies</a>
           </h4>
-<p id="section-4.4.3-1">If in the future DMARC is extended to include the use of other
+<p id="section-4.7.3-1">If in the future DMARC is extended to include the use of other
 authentication mechanisms, the extensions will need to allow for
 domain identifier extraction so that alignment with the RFC5322.From
-domain can be verified.<a href="#section-4.4.3-1" class="pilcrow">¶</a></p>
+domain can be verified.<a href="#section-4.7.3-1" class="pilcrow">¶</a></p>
 </section>
 </div>
-</section>
-</div>
-<div id="determining-the-organizational-domain">
-<section id="section-4.5">
-        <h3 id="name-determining-the-organizatio">
-<a href="#section-4.5" class="section-number selfRef">4.5. </a><a href="#name-determining-the-organizatio" class="section-name selfRef">Determining The Organizational Domain</a>
-        </h3>
-<p id="section-4.5-1">The DMARC protocol defines a method for a Public Suffix Domain to identify
-itself as such using a tag in its published DMARC policy record. An Organizational
-Domain is any subdomain of a PSD that includes exactly one more label than
-the PSD in its name.<a href="#section-4.5-1" class="pilcrow">¶</a></p>
-<p id="section-4.5-2">For any email message, the Organizational Domain of the RFC5322.From domain
-is determined using the following algorithm, similar to the one described
-in <a href="#policy-discovery" class="xref">Section 5.7.3</a><a href="#section-4.5-2" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-4.5-3">
-          <li id="section-4.5-3.1">
-            <p id="section-4.5-3.1.1">Query the DNS for a DMARC TXT record at the DNS domain matching the one
-found in the RFC5322.From domain in the message.  A possibly empty set
-of records is returned.<a href="#section-4.5-3.1.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-4.5-3.2">
-            <p id="section-4.5-3.2.1">Records that do not start with a "v=" tag that identifies the
-current version of DMARC are discarded.<a href="#section-4.5-3.2.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-4.5-3.3">
-            <p id="section-4.5-3.3.1">If the set is now empty, or the set contains one valid DMARC record that
-does not include a psd tag with a value of 'y', then determine the target for
-additional queries, using steps 4 through 8 below.<a href="#section-4.5-3.3.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-4.5-3.4">
-            <p id="section-4.5-3.4.1">Break the subject DNS domain name into a set of "n" ordered
-labels.  Number these labels from right to left; e.g., for
-"a.mail.example.com", "com" would be label 1 and "example" would be
-label 2 and so forth.<a href="#section-4.5-3.4.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-4.5-3.5">
-            <p id="section-4.5-3.5.1">Count the number of labels found in the subject DNS domain. Let that
-number be "x". If x &lt; 5, remove the left-most (highest-numbered)
-label from the subject domain. If x &gt;= 5, remove the left-most
-(highest-numbered) labels from the subject domain until 4 labels remain.
-The resulting DNS domain name is the new target for subsequent lookups.<a href="#section-4.5-3.5.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-4.5-3.6">
-            <p id="section-4.5-3.6.1">Query the DNS for a DMARC TXT record at the DNS domain matching this
-new target in place of the RFC5322.From domain in the message.  A possibly
-empty set of records is returned.<a href="#section-4.5-3.6.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-4.5-3.7">
-            <p id="section-4.5-3.7.1">Records that do not start with a "v=" tag that identifies the
-current version of DMARC are discarded.<a href="#section-4.5-3.7.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-4.5-3.8">
-            <p id="section-4.5-3.8.1">If the set is now empty, or the set contains one valid DMARC record that
-does not include a psd tag with the value of 'y', then determine the
-target for additional queries by removing a single label from the target
-domain as described in step 5 and repeating steps 6 and 7 until
-there are no more labels remaining or a record containing a psd tag with
-a value of 'y' is found.<a href="#section-4.5-3.8.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-4.5-3.9">
-            <p id="section-4.5-3.9.1">Once a valid DMARC record containing a psd tag with a value of 'y' has
-been found, the Organizational Domain for the DNS domain matching the
-one found in the RFC5322.From domain can be declared to be the target
-domain queried for in the step prior to the query that found the PSD
-domain.<a href="#section-4.5-3.9.1" class="pilcrow">¶</a></p>
-</li>
-</ol>
-<p id="section-4.5-4">For example, given the RFC5322.From domain "a.mail.example.com", a series
-of DNS queries for DMARC records would be executed starting with
-"<em>dmarc.a.mail.example.com" and finishing with "</em>dmarc.com". The "<em>dmarc.com"
-record would contain a psd tag with a value of 'y', and so the Organizational
-Domain for this RFC5322.From domain would be determined to be "example.com",
-the domain of the DMARC query executed prior to the query for "</em>dmarc.com".<a href="#section-4.5-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
@@ -2410,10 +2456,10 @@ results of path authorization checks ought not be considered as part
 of the overall DMARC result for a given Author Domain, then the
 Domain Owner does not publish an SPF policy record that can produce
 an SPF pass result.<a href="#section-5-3" class="pilcrow">¶</a></p>
-<p id="section-5-4">A Mail Receiver implementing the DMARC mechanism SHOULD make a
-best-effort attempt to adhere to the Domain Owner's or PSO's published DMARC
-Domain Owner Assessment Policy when a message fails the DMARC test.<br>
-Since email streams can be complicated (due to forwarding, existing RFC5322.From
+<p id="section-5-4">A Mail Receiver implementing the DMARC mechanism SHOULD make a best-effort
+attempt to adhere to the Domain Owner's or PSO's published DMARC Domain
+Owner Assessment Policy when a message fails the DMARC test. Since email
+streams can be complicated (due to forwarding, existing RFC5322.From
 domain-spoofing services, etc.), Mail Receivers MAY deviate from a published
 Domain Owner Assessment Policy during message processing and SHOULD
 make available the fact of and reason for the deviation to the Domain
@@ -2479,7 +2525,7 @@ are to be processed; unknown tags MUST be ignored.<a href="#section-5.3-2" class
 <dd id="section-5.3-4.2">
             <p id="section-5.3-4.2.1">(plain-text; OPTIONAL; default is "r".)  Indicates whether
 strict or relaxed DKIM Identifier Alignment mode is required by
-the Domain Owner.  See <a href="#dkim-identifiers" class="xref">Section 4.4.1</a> for details.  Valid values
+the Domain Owner.  See <a href="#dkim-identifiers" class="xref">Section 4.7.1</a> for details.  Valid values
 are as follows:<a href="#section-5.3-4.2.1" class="pilcrow">¶</a></p>
 <dl class="dlParallel" id="section-5.3-4.2.2">
               <dt id="section-5.3-4.2.2.1">r:</dt>
@@ -2497,7 +2543,7 @@ are as follows:<a href="#section-5.3-4.2.1" class="pilcrow">¶</a></p>
 <dd id="section-5.3-4.4">
             <p id="section-5.3-4.4.1">(plain-text; OPTIONAL; default is "r".)  Indicates whether
 strict or relaxed SPF Identifier Alignment mode is required by the
-Domain Owner.  See <a href="#spf-identifiers" class="xref">Section 4.4.2</a> for details.  Valid values are as
+Domain Owner.  See <a href="#spf-identifiers" class="xref">Section 4.7.2</a> for details.  Valid values are as
 follows:<a href="#section-5.3-4.4.1" class="pilcrow">¶</a></p>
 <dl class="dlParallel" id="section-5.3-4.4.2">
               <dt id="section-5.3-4.4.2.1">r:</dt>
@@ -2560,7 +2606,7 @@ policy specified by the "p" tag, if the "sp" tag is not present,
 MUST be applied for non-existent subdomains.  Note that "np" will
 be ignored for DMARC records published on subdomains of Organizational
 Domains and PSDs due to the effect of the DMARC policy discovery
-mechanism described in <a href="#policy-discovery" class="xref">Section 5.7.3</a>.<a href="#section-5.3-7.2" class="pilcrow">¶</a>
+mechanism described in <a href="#dmarc-policy-discovery" class="xref">Section 5.7.2.1</a>.<a href="#section-5.3-7.2" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
 <dt id="section-5.3-7.3">p:</dt>
@@ -2575,7 +2621,7 @@ reporting records (see <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">
 Possible values are as follows:<a href="#section-5.3-7.4.1" class="pilcrow">¶</a></p>
 <dl class="dlParallel" id="section-5.3-7.4.2">
               <dt id="section-5.3-7.4.2.1">none:</dt>
-<dd id="section-5.3-7.4.2.2">The Domain Owner offers no expression of concern.<a href="#section-5.3-7.4.2.2" class="pilcrow">¶</a>
+<dd id="section-5.3-7.4.2.2">The Domain Owner offers no expression of preference.<a href="#section-5.3-7.4.2.2" class="pilcrow">¶</a>
 </dd>
 <dd class="break"></dd>
 <dt id="section-5.3-7.4.2.3">quarantine:</dt>
@@ -2617,7 +2663,7 @@ for a domain that is not a PSD.<a href="#section-5.3-7.6.2.4" class="pilcrow">¶
 <dt id="section-5.3-7.7">rua:</dt>
 <dd id="section-5.3-7.8">
             <p id="section-5.3-7.8.1">Addresses to which aggregate feedback is to be sent (comma-
-separated plain-text list of DMARC URIs; OPTIONAL).  Section 3 of <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span>
+separated plain-text list of DMARC URIs; OPTIONAL).  <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span>
 discusses considerations that apply when the domain name of a URI differs
 from that of the domain advertising the policy.  See <a href="#external-report-addresses" class="xref">Section 9.5</a>
 for additional considerations.  Any valid URI can be specified.<br>
@@ -2636,7 +2682,7 @@ OPTIONAL).  If present, the Domain Owner or PSO is requesting Mail
 Receivers to send detailed failure reports about messages that
 fail the DMARC evaluation in specific ways (see the "fo" tag
 above).  The format of the message to be generated MUST follow the
-format specified for the "rf" tag. Section 3 of <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> discusses
+format specified for the "rf" tag. <span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> discusses
 considerations that apply when the domain name of a URI differs
 from that of the domain advertising the policy.  A Mail Receiver
 MUST implement support for a "mailto:" URI, i.e., the ability to
@@ -2657,7 +2703,7 @@ tag is absent and the "np" tag is either absent or not applicable,
 the policy specified by the "p" tag MUST be applied for subdomains.
 Note that "sp" will be ignored for DMARC records published on
 subdomains of Organizational Domains due to the effect of the
-DMARC policy discovery mechanism described in <a href="#policy-discovery" class="xref">Section 5.7.3</a>.<a href="#section-5.3-7.12.1" class="pilcrow">¶</a></p>
+DMARC policy discovery mechanism described in <a href="#dmarc-policy-discovery" class="xref">Section 5.7.2.1</a>.<a href="#section-5.3-7.12.1" class="pilcrow">¶</a></p>
 </dd>
 <dd class="break"></dd>
 <dt id="section-5.3-7.13">t:</dt>
@@ -2724,6 +2770,7 @@ follows:<a href="#section-5.4-1" class="pilcrow">¶</a></p>
 
   dmarc-tag       = dmarc-request /
                     dmarc-test /
+                    dmarc-psd /
                     dmarc-srequest /
                     dmarc-nprequest /
                     dmarc-adkim /
@@ -2743,6 +2790,8 @@ follows:<a href="#section-5.4-1" class="pilcrow">¶</a></p>
                     ( "none" / "quarantine" / "reject" )
 
   dmarc-test      = "t" *WSP "=" ( "y" / "n" )
+
+  dmarc-psd       = "psd" *WSP "=" ( "y" / "n" )
 
   dmarc-srequest  = "sp" *WSP "=" *WSP
                     ( "none" / "quarantine" / "reject" )
@@ -2913,8 +2962,8 @@ case is to only proceed with DMARC checking if the domain is
 identical for all of the addresses in a multi-valued RFC5322.From
 header field. Multi-valued RFC5322.From header fields with multiple
 domains MUST be exempt from DMARC checking.<a href="#section-5.7.1-3" class="pilcrow">¶</a></p>
-<p id="section-5.7.1-4">Note that domain names that appear on a public suffix list are not
-exempt from DMARC policy application and reporting.<a href="#section-5.7.1-4" class="pilcrow">¶</a></p>
+<p id="section-5.7.1-4">Note that Public Suffix Domains are not exempt from DMARC policy
+application and reporting.<a href="#section-5.7.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="determine-handling-policy">
@@ -2934,7 +2983,7 @@ input from previous steps.<a href="#section-5.7.2-1" class="pilcrow">¶</a></p>
 <li id="section-5.7.2-3.2">
               <p id="section-5.7.2-3.2.1">Query the DNS for a DMARC policy record.  Continue if one is
 found, or terminate DMARC evaluation otherwise.  See
-<a href="#policy-discovery" class="xref">Section 5.7.3</a> for details.<a href="#section-5.7.2-3.2.1" class="pilcrow">¶</a></p>
+<a href="#dmarc-policy-discovery" class="xref">Section 5.7.2.1</a> for details.<a href="#section-5.7.2-3.2.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-5.7.2-3.3">
               <p id="section-5.7.2-3.3.1">Perform DKIM signature verification checks.  A single email could
@@ -2962,8 +3011,8 @@ failures, identifier mismatches) are considered to be DMARC
 mechanism check failures.<a href="#section-5.7.2-3.5.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-5.7.2-3.6">
-              <p id="section-5.7.2-3.6.1">Apply policy.  Emails that fail the DMARC mechanism check are
-handled in accordance with the discovered DMARC policy of the
+              <p id="section-5.7.2-3.6.1">Apply policy, if appropriate.  Emails that fail the DMARC mechanism
+check are handled in accordance with the discovered DMARC policy of the
 Domain Owner and any local policy rules enforced by the Mail Receiver.
 See <a href="#general-record-format" class="xref">Section 5.3</a> for details.<a href="#section-5.7.2-3.6.1" class="pilcrow">¶</a></p>
 </li>
@@ -2983,135 +3032,75 @@ appropriate, Receivers MAY send feedback reports regarding temporary
 errors.<a href="#section-5.7.2-5" class="pilcrow">¶</a></p>
 <p id="section-5.7.2-6">Handling of messages for which SPF and/or DKIM evaluation encounter a
 permanent DNS error is left to the discretion of the Mail Receiver.<a href="#section-5.7.2-6" class="pilcrow">¶</a></p>
-</section>
-</div>
-<div id="policy-discovery">
-<section id="section-5.7.3">
-          <h4 id="name-policy-discovery">
-<a href="#section-5.7.3" class="section-number selfRef">5.7.3. </a><a href="#name-policy-discovery" class="section-name selfRef">Policy Discovery</a>
-          </h4>
-<p id="section-5.7.3-1">As stated above, the DMARC mechanism uses DNS TXT records to
-advertise policy.  Policy discovery is accomplished via a method
-similar to the method used for SPF records.  This method, and the
-important differences between DMARC and SPF mechanisms, are discussed
-below.<a href="#section-5.7.3-1" class="pilcrow">¶</a></p>
-<p id="section-5.7.3-2">To balance the conflicting requirements of supporting wildcarding and
-allowing subdomain policy overrides, the following DNS lookup scheme
-is employed:<a href="#section-5.7.3-2" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-5.7.3-3">
-            <li id="section-5.7.3-3.1">
-              <p id="section-5.7.3-3.1.1">Mail Receivers MUST query the DNS for a DMARC TXT record at the
-DNS domain matching the one found in the RFC5322.From domain in
-the message.  A possibly empty set of records is returned.<a href="#section-5.7.3-3.1.1" class="pilcrow">¶</a></p>
+<div id="dmarc-policy-discovery">
+<section id="section-5.7.2.1">
+            <h5 id="name-dmarc-policy-discovery">
+<a href="#section-5.7.2.1" class="section-number selfRef">5.7.2.1. </a><a href="#name-dmarc-policy-discovery" class="section-name selfRef">DMARC Policy Discovery</a>
+            </h5>
+<p id="section-5.7.2.1-1">Discovery of the applicable DMARC policy for any domain is accomplished
+via a DNS Tree Walk as described in <a href="#dns-tree-walk" class="xref">Section 4.5</a>.  The target of this
+tree walk is a valid DMARC policy record, and the following rules should
+be applied to records that are found in this manner:<a href="#section-5.7.2.1-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-5.7.2.1-2">
+              <li id="section-5.7.2.1-2.1">
+                <p id="section-5.7.2.1-2.1.1">If the tree walk ends in the discovery of multiple records or no
+records, DMARC processing is not applied to this message.<a href="#section-5.7.2.1-2.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-5.7.3-3.2">
-              <p id="section-5.7.3-3.2.1">Records that do not start with a "v=" tag that identifies the
-current version of DMARC are discarded.<a href="#section-5.7.3-3.2.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.7.3-3.3">
-              <p id="section-5.7.3-3.3.1">If the set is now empty, the Mail Receiver determines the target
-for additional queries, using steps 4 through 8 below.<a href="#section-5.7.3-3.3.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.7.3-3.4">
-              <p id="section-5.7.3-3.4.1">Break the subject DNS domain name into a set of "n" ordered labels.
-Number these lables from right to left; e.g., for "example.com",
-"com" would be label 1 and "example" would be label 2.<a href="#section-5.7.3-3.4.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.7.3-3.5">
-              <p id="section-5.7.3-3.5.1">Count the number of labels found in the subject DNS domain. Let that
-number be "x". If x &lt; 5, remove the left-most (highest-numbered)
-label from the subject domain. If x &gt;= 5, remove the left-most
-(highest-numbered) labels from the subject domain until 4 labels remain.
-The resulting DNS domain name is the new target for subsequent lookups.<a href="#section-5.7.3-3.5.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.7.3-3.6">
-              <p id="section-5.7.3-3.6.1">The Mail Receiver MUST query the DNS for a DMARC TXT record at
-the DNS domain matching this new target in place of the RFC5322.From
-domain in the message. This record can contain policy to be asserted
-for subdomains of the target. A possibly empty set of records is
-returned.<a href="#section-5.7.3-3.6.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.7.3-3.7">
-              <p id="section-5.7.3-3.7.1">Records that do not start with a "v=" tag that identifies the
-current version of DMARC are discarded.<a href="#section-5.7.3-3.7.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.7.3-3.8">
-              <p id="section-5.7.3-3.8.1">If the set is now empty, the Mail Receiver determines the target
-for additional queries by removing a single label from the target
-domain as described in step 5 and repeating steps 6 and 7 until
-there are no more labels remaining.<a href="#section-5.7.3-3.8.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.7.3-3.9">
-              <p id="section-5.7.3-3.9.1">If the remaining set contains multiple records or no records,
-policy discovery terminates and DMARC processing is not applied
-to this message.<a href="#section-5.7.3-3.9.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.7.3-3.10">
-              <p id="section-5.7.3-3.10.1">If a retrieved policy record does not contain a valid "p" tag, or
-contains an "sp" tag that is not valid, then:<a href="#section-5.7.3-3.10.1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-5.7.3-3.10.2">
-                <li id="section-5.7.3-3.10.2.1">
-                  <p id="section-5.7.3-3.10.2.1.1">if a "rua" tag is present and contains at least one
+<li id="section-5.7.2.1-2.2">
+                <p id="section-5.7.2.1-2.2.1">If a retrieved policy record does not contain a valid "p" tag, or
+contains an "sp" tag that is not valid, then:<a href="#section-5.7.2.1-2.2.1" class="pilcrow">¶</a></p>
+<ul>
+<li id="section-5.7.2.1-2.2.2.1">
+                    <p id="section-5.7.2.1-2.2.2.1.1">If a "rua" tag is present and contains at least one
 syntactically valid reporting URI, the Mail Receiver SHOULD
 act as if a record containing a valid "v" tag and "p=none"
-was retrieved, and continue processing;<a href="#section-5.7.3-3.10.2.1.1" class="pilcrow">¶</a></p>
+was retrieved, and continue processing;<a href="#section-5.7.2.1-2.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-5.7.3-3.10.2.2">
-                  <p id="section-5.7.3-3.10.2.2.1">otherwise, the Mail Receiver applies no DMARC processing to
-this message.<a href="#section-5.7.3-3.10.2.2.1" class="pilcrow">¶</a></p>
+<li id="section-5.7.2.1-2.2.2.2">
+                    <p id="section-5.7.2.1-2.2.2.2.1">Otherwise, the Mail Receiver applies no DMARC processing to
+this message.<a href="#section-5.7.2.1-2.2.2.2.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
 </li>
 </ol>
-</li>
-</ol>
-<p id="section-5.7.3-4">If the set produced by the mechanism above contains no DMARC policy
+<p id="section-5.7.2.1-3">If the set produced by the DNS Tree Walk contains no DMARC policy
 record (i.e., any indication that there is no such record as opposed
 to a transient DNS error), Mail Receivers SHOULD NOT apply the DMARC
-mechanism to the message.<a href="#section-5.7.3-4" class="pilcrow">¶</a></p>
-<p id="section-5.7.3-5">Handling of DNS errors when querying for the DMARC policy record is
+mechanism to the message.<a href="#section-5.7.2.1-3" class="pilcrow">¶</a></p>
+<p id="section-5.7.2.1-4">Handling of DNS errors when querying for the DMARC policy record is
 left to the discretion of the Mail Receiver.  For example, to ensure
 minimal disruption of mail flow, transient errors could result in
 delivery of the message ("fail open"), or they could result in the
 message being temporarily rejected (i.e., an SMTP 4yx reply), which
 invites the sending MTA to try again after the condition has possibly
 cleared, allowing a definite DMARC conclusion to be reached ("fail
-closed").<a href="#section-5.7.3-5" class="pilcrow">¶</a></p>
-<div id="longest-psd-example">
-<section id="section-5.7.3.1">
-            <h5 id="name-longest-psd-example">
-<a href="#section-5.7.3.1" class="section-number selfRef">5.7.3.1. </a><a href="#name-longest-psd-example" class="section-name selfRef">Longest PSD Example</a>
-            </h5>
-<p id="section-5.7.3.1-1">As an example of step 5 above, for a message with the Organizational
-Domain of "example.compute.cloudcompany.com.example", the query for
-PSD DMARC would use "compute.cloudcompany.com.example" as the longest
-PSD. The receiver would check to see if that PSD is listed in the DMARC
-PSD Registry, and if so, perform the policy lookup at
-"_dmarc.compute.cloudcompany.com.example".<a href="#section-5.7.3.1-1" class="pilcrow">¶</a></p>
-<p id="section-5.7.3.1-2">Note: Because the PSD policy query comes after the Organizational
+closed").<a href="#section-5.7.2.1-4" class="pilcrow">¶</a></p>
+<p id="section-5.7.2.1-5">Note: Because the PSD policy query comes after the Organizational
 Domain policy query, PSD policy is not used for Organizational
 domains that have published a DMARC policy.  Specifically, this is
 not a mechanism to provide feedback addresses (RUA/RUF) when an
-Organizational Domain has declined to do so.<a href="#section-5.7.3.1-2" class="pilcrow">¶</a></p>
+Organizational Domain has declined to do so.<a href="#section-5.7.2.1-5" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="store-results-of-dmarc-processing">
-<section id="section-5.7.4">
+<section id="section-5.7.3">
           <h4 id="name-store-results-of-dmarc-proc">
-<a href="#section-5.7.4" class="section-number selfRef">5.7.4. </a><a href="#name-store-results-of-dmarc-proc" class="section-name selfRef">Store Results of DMARC Processing</a>
+<a href="#section-5.7.3" class="section-number selfRef">5.7.3. </a><a href="#name-store-results-of-dmarc-proc" class="section-name selfRef">Store Results of DMARC Processing</a>
           </h4>
-<p id="section-5.7.4-1">The results of Mail Receiver-based DMARC processing should be stored
+<p id="section-5.7.3-1">The results of Mail Receiver-based DMARC processing should be stored
 for eventual presentation back to the Domain Owner in the form of
 aggregate feedback reports.  <a href="#general-record-format" class="xref">Section 5.3</a> and
-<span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> discuss aggregate feedback.<a href="#section-5.7.4-1" class="pilcrow">¶</a></p>
+<span>[<a href="#DMARC-Aggregate-Reporting" class="xref">DMARC-Aggregate-Reporting</a>]</span> discuss aggregate feedback.<a href="#section-5.7.3-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="send-aggregate-reports">
-<section id="section-5.7.5">
+<section id="section-5.7.4">
           <h4 id="name-send-aggregate-reports">
-<a href="#section-5.7.5" class="section-number selfRef">5.7.5. </a><a href="#name-send-aggregate-reports" class="section-name selfRef">Send Aggregate Reports</a>
+<a href="#section-5.7.4" class="section-number selfRef">5.7.4. </a><a href="#name-send-aggregate-reports" class="section-name selfRef">Send Aggregate Reports</a>
           </h4>
-<p id="section-5.7.5-1">For a Domain Owner, DMARC aggregate reports provide data about all
+<p id="section-5.7.4-1">For a Domain Owner, DMARC aggregate reports provide data about all
 mailstreams making use of its domain in email, to include not only
 illegitimate uses but also, and perhaps more importantly, all
 legitimate uses. Domain Owners can use aggregate reports to ensure
@@ -3122,10 +3111,10 @@ none to quarantine to reject, if appropriate. In turn, DMARC policy
 records with p= tag values of 'quarantine' or 'reject' are higher
 value signals to Mail Receivers, ones that can assist Mail Receivers
 with handling decisions for a message in ways that p= tag values of
-'none' cannot.<a href="#section-5.7.5-1" class="pilcrow">¶</a></p>
-<p id="section-5.7.5-2">In order to ensure maximum usefulness for DMARC across the email
-ecosystem, then, Mail Receivers MUST generate and send aggregate
-reports with a frequency of at least once every 24 hours.<a href="#section-5.7.5-2" class="pilcrow">¶</a></p>
+'none' cannot.<a href="#section-5.7.4-1" class="pilcrow">¶</a></p>
+<p id="section-5.7.4-2">In order to ensure maximum usefulness for DMARC across the email
+ecosystem, then, Mail Receivers SHOULD generate and send aggregate
+reports with a frequency of at least once every 24 hours.<a href="#section-5.7.4-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
@@ -3289,18 +3278,17 @@ caused the rejection.<a href="#section-7.3-5" class="pilcrow">¶</a></p>
 <p id="section-7.3-6">In the latter case, when doing an SMTP rejection, providing a clear
 hint can be useful in resolving issues.  A receiver might indicate in
 plain text the reason for the rejection by using the word "DMARC"
-somewhere in the reply text.  Many systems are able to scan the SMTP
-reply text to determine the nature of the rejection.  Thus, providing
-a machine-detectable reason for rejection allows the problems causing
-rejections to be properly addressed by automated systems.  For
-example:<a href="#section-7.3-6" class="pilcrow">¶</a></p>
+somewhere in the reply text. For example:<a href="#section-7.3-6" class="pilcrow">¶</a></p>
 <div class="artwork art-text alignLeft" id="section-7.3-7">
 <pre>550 5.7.1 Email rejected per DMARC policy for example.com
 </pre><a href="#section-7.3-7" class="pilcrow">¶</a>
 </div>
-<p id="section-7.3-8">If a Mail Receiver elects to defer delivery due to inability to
+<p id="section-7.3-8">Many systems are able to scan the SMTP reply text to determine the nature
+of the rejection.  Thus, providing a machine-detectable reason for rejection
+allows the problems causing rejections to be properly addressed by automated systems.<a href="#section-7.3-8" class="pilcrow">¶</a></p>
+<p id="section-7.3-9">If a Mail Receiver elects to defer delivery due to inability to
 retrieve or apply DMARC policy, this is best done with a 4xy SMTP
-reply code.<a href="#section-7.3-8" class="pilcrow">¶</a></p>
+reply code.<a href="#section-7.3-9" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="identifier-alignment-considerations">
@@ -3567,6 +3555,12 @@ when processed by implementations conforming to prior specifications.<a href="#s
               <td class="text-left" rowspan="1" colspan="1">Failure reporting options</td>
             </tr>
             <tr>
+              <td class="text-left" rowspan="1" colspan="1">np</td>
+              <td class="text-left" rowspan="1" colspan="1">RFC 7489</td>
+              <td class="text-left" rowspan="1" colspan="1">current</td>
+              <td class="text-left" rowspan="1" colspan="1">Requested handling policy for non-existent subdomains</td>
+            </tr>
+            <tr>
               <td class="text-left" rowspan="1" colspan="1">p</td>
               <td class="text-left" rowspan="1" colspan="1">RFC 7489</td>
               <td class="text-left" rowspan="1" colspan="1">current</td>
@@ -3577,6 +3571,12 @@ when processed by implementations conforming to prior specifications.<a href="#s
               <td class="text-left" rowspan="1" colspan="1">RFC 7489</td>
               <td class="text-left" rowspan="1" colspan="1">historic</td>
               <td class="text-left" rowspan="1" colspan="1">Sampling rate</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">psd</td>
+              <td class="text-left" rowspan="1" colspan="1">RFC 7489</td>
+              <td class="text-left" rowspan="1" colspan="1">current</td>
+              <td class="text-left" rowspan="1" colspan="1">Indicates whether policy record is published by a Public Suffix Domain</td>
             </tr>
             <tr>
               <td class="text-left" rowspan="1" colspan="1">rf</td>
@@ -4218,7 +4218,7 @@ labels; this would cause a Mail Receiver to attempt a large number of
 queries in search of a policy record.  Sending many such messages
 constitutes an amplified denial-of-service attack.<a href="#section-a.6-3" class="pilcrow">¶</a></p>
 <p id="section-a.6-4">The Organizational Domain mechanism is a necessary component to the
-goals of DMARC.  The method described in <a href="#determining-the-organizational-domain" class="xref">Section 4.5</a> is far from
+goals of DMARC.  The method described in <a href="#determining-the-organizational-domain" class="xref">Section 4.6</a> is far from
 perfect but serves this purpose reasonably well without adding undue
 burden or semantics to the DNS.  If a method is created to do so that
 is more reliable and secure than the use of a public suffix list,

--- a/draft-ietf-dmarc-dmarcbis-04.txt
+++ b/draft-ietf-dmarc-dmarcbis-04.txt
@@ -6,7 +6,7 @@ DMARC                                                       T. Herr (ed)
 Internet-Draft                                                  Valimail
 Obsoletes: 7489 (if approved)                             J. Levine (ed)
 Intended status: Standards Track                           Standcore LLC
-Expires: 24 March 2022                                 20 September 2021
+Expires: 21 May 2022                                    17 November 2021
 
 
 Domain-based Message Authentication, Reporting, and Conformance (DMARC)
@@ -41,7 +41,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 24 March 2022.
+   This Internet-Draft will expire on 21 May 2022.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                 [Page 1]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 1]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -94,165 +94,165 @@ Table of Contents
        3.14.2.  SPF-Authenticated Identifiers  . . . . . . . . . . .  12
        3.14.3.  Alignment and Extension Technologies . . . . . . . .  13
      3.15. Determining The Organizational Domain . . . . . . . . . .  13
-   4.  Overview  . . . . . . . . . . . . . . . . . . . . . . . . . .  13
+   4.  Overview  . . . . . . . . . . . . . . . . . . . . . . . . . .  14
      4.1.  Authentication Mechanisms . . . . . . . . . . . . . . . .  14
      4.2.  Key Concepts  . . . . . . . . . . . . . . . . . . . . . .  14
      4.3.  Flow Diagram  . . . . . . . . . . . . . . . . . . . . . .  15
-   5.  Use of RFC5322.From . . . . . . . . . . . . . . . . . . . . .  16
+   5.  Use of RFC5322.From . . . . . . . . . . . . . . . . . . . . .  17
    6.  Policy  . . . . . . . . . . . . . . . . . . . . . . . . . . .  17
-     6.1.  DMARC Policy Record . . . . . . . . . . . . . . . . . . .  17
-     6.2.  DMARC URIs  . . . . . . . . . . . . . . . . . . . . . . .  18
-     6.3.  General Record Format . . . . . . . . . . . . . . . . . .  18
-     6.4.  Formal Definition . . . . . . . . . . . . . . . . . . . .  22
-     6.5.  Domain Owner Actions  . . . . . . . . . . . . . . . . . .  23
-       6.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  23
+     6.1.  DMARC Policy Record . . . . . . . . . . . . . . . . . . .  18
+     6.2.  DMARC URIs  . . . . . . . . . . . . . . . . . . . . . . .  19
+     6.3.  General Record Format . . . . . . . . . . . . . . . . . .  19
+     6.4.  Formal Definition . . . . . . . . . . . . . . . . . . . .  23
+     6.5.  Domain Owner Actions  . . . . . . . . . . . . . . . . . .  24
+       6.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  24
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                 [Page 2]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 2]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
        6.5.2.  Configure Sending System for DKIM Signing Using an
                Aligned Domain  . . . . . . . . . . . . . . . . . . .  24
-       6.5.3.  Setup a Mailbox to Receive Aggregate Reports  . . . .  24
-       6.5.4.  Publish a DMARC Policy for the Author Domain  . . . .  24
+       6.5.3.  Setup a Mailbox to Receive Aggregate Reports  . . . .  25
+       6.5.4.  Publish a DMARC Policy for the Author Domain  . . . .  25
        6.5.5.  Collect and Analyze Reports and Adjust
                Authentication  . . . . . . . . . . . . . . . . . . .  25
-       6.5.6.  Decide If and When to Update DMARC Policy . . . . . .  25
-     6.6.  PSO Actions . . . . . . . . . . . . . . . . . . . . . . .  25
-     6.7.  Mail Receiver Actions . . . . . . . . . . . . . . . . . .  25
-       6.7.1.  Extract Author Domain . . . . . . . . . . . . . . . .  25
-       6.7.2.  Determine Handling Policy . . . . . . . . . . . . . .  26
-       6.7.3.  Policy Discovery  . . . . . . . . . . . . . . . . . .  27
-       6.7.4.  Store Results of DMARC Processing . . . . . . . . . .  29
-       6.7.5.  Send Aggregate Reports  . . . . . . . . . . . . . . .  29
-     6.8.  Policy Enforcement Considerations . . . . . . . . . . . .  30
-   7.  DMARC Feedback  . . . . . . . . . . . . . . . . . . . . . . .  31
-   8.  Other Topics  . . . . . . . . . . . . . . . . . . . . . . . .  31
-     8.1.  Issues Specific to SPF  . . . . . . . . . . . . . . . . .  31
-     8.2.  DNS Load and Caching  . . . . . . . . . . . . . . . . . .  32
-     8.3.  Rejecting Messages  . . . . . . . . . . . . . . . . . . .  32
-     8.4.  Identifier Alignment Considerations . . . . . . . . . . .  33
-     8.5.  Interoperability Issues . . . . . . . . . . . . . . . . .  33
-   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  34
-     9.1.  Authentication-Results Method Registry Update . . . . . .  34
-     9.2.  Authentication-Results Result Registry Update . . . . . .  35
-     9.3.  Feedback Report Header Fields Registry Update . . . . . .  36
-     9.4.  DMARC Tag Registry  . . . . . . . . . . . . . . . . . . .  36
-     9.5.  DMARC Report Format Registry  . . . . . . . . . . . . . .  38
+       6.5.6.  Decide If and When to Update DMARC Policy . . . . . .  26
+     6.6.  PSO Actions . . . . . . . . . . . . . . . . . . . . . . .  26
+     6.7.  Mail Receiver Actions . . . . . . . . . . . . . . . . . .  26
+       6.7.1.  Extract Author Domain . . . . . . . . . . . . . . . .  26
+       6.7.2.  Determine Handling Policy . . . . . . . . . . . . . .  27
+       6.7.3.  Policy Discovery  . . . . . . . . . . . . . . . . . .  28
+       6.7.4.  Store Results of DMARC Processing . . . . . . . . . .  30
+       6.7.5.  Send Aggregate Reports  . . . . . . . . . . . . . . .  30
+     6.8.  Policy Enforcement Considerations . . . . . . . . . . . .  31
+   7.  DMARC Feedback  . . . . . . . . . . . . . . . . . . . . . . .  32
+   8.  Other Topics  . . . . . . . . . . . . . . . . . . . . . . . .  32
+     8.1.  Issues Specific to SPF  . . . . . . . . . . . . . . . . .  32
+     8.2.  DNS Load and Caching  . . . . . . . . . . . . . . . . . .  33
+     8.3.  Rejecting Messages  . . . . . . . . . . . . . . . . . . .  33
+     8.4.  Identifier Alignment Considerations . . . . . . . . . . .  34
+     8.5.  Interoperability Issues . . . . . . . . . . . . . . . . .  34
+   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  35
+     9.1.  Authentication-Results Method Registry Update . . . . . .  35
+     9.2.  Authentication-Results Result Registry Update . . . . . .  36
+     9.3.  Feedback Report Header Fields Registry Update . . . . . .  37
+     9.4.  DMARC Tag Registry  . . . . . . . . . . . . . . . . . . .  37
+     9.5.  DMARC Report Format Registry  . . . . . . . . . . . . . .  39
      9.6.  Underscored and Globally Scoped DNS Node Names
-           Registry  . . . . . . . . . . . . . . . . . . . . . . . .  38
-   10. Security Considerations . . . . . . . . . . . . . . . . . . .  38
-     10.1.  Authentication Methods . . . . . . . . . . . . . . . . .  39
-     10.2.  Attacks on Reporting URIs  . . . . . . . . . . . . . . .  39
-     10.3.  DNS Security . . . . . . . . . . . . . . . . . . . . . .  39
-     10.4.  Display Name Attacks . . . . . . . . . . . . . . . . . .  40
-     10.5.  External Reporting Addresses . . . . . . . . . . . . . .  41
-     10.6.  Secure Protocols . . . . . . . . . . . . . . . . . . . .  41
-   11. Normative References  . . . . . . . . . . . . . . . . . . . .  41
-   12. Informative References  . . . . . . . . . . . . . . . . . . .  43
-   Appendix A.  Technology Considerations  . . . . . . . . . . . . .  45
-     A.1.  S/MIME  . . . . . . . . . . . . . . . . . . . . . . . . .  45
-     A.2.  Method Exclusion  . . . . . . . . . . . . . . . . . . . .  45
-     A.3.  Sender Header Field . . . . . . . . . . . . . . . . . . .  46
-     A.4.  Domain Existence Test . . . . . . . . . . . . . . . . . .  47
-     A.5.  Issues with ADSP in Operation . . . . . . . . . . . . . .  47
-     A.6.  Organizational Domain Discovery Issues  . . . . . . . . .  48
-       A.6.1.  Public Suffix Lists . . . . . . . . . . . . . . . . .  49
-     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  49
+           Registry  . . . . . . . . . . . . . . . . . . . . . . . .  39
+   10. Security Considerations . . . . . . . . . . . . . . . . . . .  39
+     10.1.  Authentication Methods . . . . . . . . . . . . . . . . .  40
+     10.2.  Attacks on Reporting URIs  . . . . . . . . . . . . . . .  40
+     10.3.  DNS Security . . . . . . . . . . . . . . . . . . . . . .  40
+     10.4.  Display Name Attacks . . . . . . . . . . . . . . . . . .  41
+     10.5.  External Reporting Addresses . . . . . . . . . . . . . .  42
+     10.6.  Secure Protocols . . . . . . . . . . . . . . . . . . . .  42
+   11. Normative References  . . . . . . . . . . . . . . . . . . . .  42
+   12. Informative References  . . . . . . . . . . . . . . . . . . .  44
+   Appendix A.  Technology Considerations  . . . . . . . . . . . . .  46
+     A.1.  S/MIME  . . . . . . . . . . . . . . . . . . . . . . . . .  46
+     A.2.  Method Exclusion  . . . . . . . . . . . . . . . . . . . .  46
+     A.3.  Sender Header Field . . . . . . . . . . . . . . . . . . .  47
+     A.4.  Domain Existence Test . . . . . . . . . . . . . . . . . .  48
+     A.5.  Issues with ADSP in Operation . . . . . . . . . . . . . .  48
+     A.6.  Organizational Domain Discovery Issues  . . . . . . . . .  49
+       A.6.1.  Public Suffix Lists . . . . . . . . . . . . . . . . .  50
+     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  50
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                 [Page 3]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 3]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
-   Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  50
-     B.1.  Identifier Alignment Examples . . . . . . . . . . . . . .  50
-       B.1.1.  SPF . . . . . . . . . . . . . . . . . . . . . . . . .  50
-       B.1.2.  DKIM  . . . . . . . . . . . . . . . . . . . . . . . .  51
-     B.2.  Domain Owner Example  . . . . . . . . . . . . . . . . . .  52
-       B.2.1.  Entire Domain, Monitoring Only  . . . . . . . . . . .  52
+   Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  51
+     B.1.  Identifier Alignment Examples . . . . . . . . . . . . . .  51
+       B.1.1.  SPF . . . . . . . . . . . . . . . . . . . . . . . . .  51
+       B.1.2.  DKIM  . . . . . . . . . . . . . . . . . . . . . . . .  52
+     B.2.  Domain Owner Example  . . . . . . . . . . . . . . . . . .  53
+       B.2.1.  Entire Domain, Monitoring Only  . . . . . . . . . . .  53
        B.2.2.  Entire Domain, Monitoring Only, Per-Message
-               Reports . . . . . . . . . . . . . . . . . . . . . . .  53
+               Reports . . . . . . . . . . . . . . . . . . . . . . .  54
        B.2.3.  Per-Message Failure Reports Directed to Third
-               Party . . . . . . . . . . . . . . . . . . . . . . . .  54
+               Party . . . . . . . . . . . . . . . . . . . . . . . .  55
        B.2.4.  Subdomain, Testing, and Multiple Aggregate Report
-               URIs  . . . . . . . . . . . . . . . . . . . . . . . .  56
-     B.3.  Mail Receiver Example . . . . . . . . . . . . . . . . . .  57
-     B.4.  Processing of SMTP Time . . . . . . . . . . . . . . . . .  58
-     B.5.  Utilization of Aggregate Feedback: Example  . . . . . . .  59
-   Appendix C.  Change Log . . . . . . . . . . . . . . . . . . . . .  60
-     C.1.  January 5, 2021 . . . . . . . . . . . . . . . . . . . . .  60
+               URIs  . . . . . . . . . . . . . . . . . . . . . . . .  57
+     B.3.  Mail Receiver Example . . . . . . . . . . . . . . . . . .  58
+     B.4.  Processing of SMTP Time . . . . . . . . . . . . . . . . .  59
+     B.5.  Utilization of Aggregate Feedback: Example  . . . . . . .  60
+   Appendix C.  Change Log . . . . . . . . . . . . . . . . . . . . .  61
+     C.1.  January 5, 2021 . . . . . . . . . . . . . . . . . . . . .  61
        C.1.1.  Ticket 80 - DMARCbis SHould Have Clear and Concise
-               Defintion of DMARC  . . . . . . . . . . . . . . . . .  60
-     C.2.  February 4, 2021  . . . . . . . . . . . . . . . . . . . .  60
-       C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208 . . . . . . . . . . .  60
-     C.3.  February 10, 2021 . . . . . . . . . . . . . . . . . . . .  61
-       C.3.1.  Ticket 84 - Remove Erroneous References to RFC3986  .  61
-     C.4.  March 1, 2021 . . . . . . . . . . . . . . . . . . . . . .  61
-       C.4.1.  Design Team Work Begins . . . . . . . . . . . . . . .  61
-     C.5.  March 8, 2021 . . . . . . . . . . . . . . . . . . . . . .  61
-       C.5.1.  Removed E.  Gustafsson as editor  . . . . . . . . . .  61
-       C.5.2.  Ticket 3 - Two tiny nits  . . . . . . . . . . . . . .  61
-       C.5.3.  Ticket 4 - Definition of "fo" parameter . . . . . . .  61
-     C.6.  March 16, 2021  . . . . . . . . . . . . . . . . . . . . .  61
-       C.6.1.  Ticket 7 - ABNF for dmarc-record is slightly wrong  .  61
-       C.6.2.  Ticket 26 - ABNF for pct allows "999" . . . . . . . .  62
-     C.7.  March 23, 2021  . . . . . . . . . . . . . . . . . . . . .  62
+               Defintion of DMARC  . . . . . . . . . . . . . . . . .  61
+     C.2.  February 4, 2021  . . . . . . . . . . . . . . . . . . . .  61
+       C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208 . . . . . . . . . . .  61
+     C.3.  February 10, 2021 . . . . . . . . . . . . . . . . . . . .  62
+       C.3.1.  Ticket 84 - Remove Erroneous References to RFC3986  .  62
+     C.4.  March 1, 2021 . . . . . . . . . . . . . . . . . . . . . .  62
+       C.4.1.  Design Team Work Begins . . . . . . . . . . . . . . .  62
+     C.5.  March 8, 2021 . . . . . . . . . . . . . . . . . . . . . .  62
+       C.5.1.  Removed E.  Gustafsson as editor  . . . . . . . . . .  62
+       C.5.2.  Ticket 3 - Two tiny nits  . . . . . . . . . . . . . .  62
+       C.5.3.  Ticket 4 - Definition of "fo" parameter . . . . . . .  62
+     C.6.  March 16, 2021  . . . . . . . . . . . . . . . . . . . . .  62
+       C.6.1.  Ticket 7 - ABNF for dmarc-record is slightly wrong  .  62
+       C.6.2.  Ticket 26 - ABNF for pct allows "999" . . . . . . . .  63
+     C.7.  March 23, 2021  . . . . . . . . . . . . . . . . . . . . .  63
        C.7.1.  Ticket 75 - Using wording alternatives to
-               'disposition', 'dispose', and the like  . . . . . . .  62
+               'disposition', 'dispose', and the like  . . . . . . .  63
        C.7.2.  Ticket 72 - Remove absolute requirement for p= tag in
-               DMARC record  . . . . . . . . . . . . . . . . . . . .  62
-     C.8.  March 29, 2021  . . . . . . . . . . . . . . . . . . . . .  62
+               DMARC record  . . . . . . . . . . . . . . . . . . . .  63
+     C.8.  March 29, 2021  . . . . . . . . . . . . . . . . . . . . .  63
        C.8.1.  Ticket 54 - Remove or expand limits on number of
-               recipients per report . . . . . . . . . . . . . . . .  62
-     C.9.  April 12, 2021  . . . . . . . . . . . . . . . . . . . . .  63
-       C.9.1.  Ticket 50 - Remove ri= tag  . . . . . . . . . . . . .  63
+               recipients per report . . . . . . . . . . . . . . . .  63
+     C.9.  April 12, 2021  . . . . . . . . . . . . . . . . . . . . .  64
+       C.9.1.  Ticket 50 - Remove ri= tag  . . . . . . . . . . . . .  64
        C.9.2.  Ticket 66 - Define what it means to have implemented
-               DMARC . . . . . . . . . . . . . . . . . . . . . . . .  63
-       C.9.3.  Ticket 96 - Tweaks to Abstract and Introduction . . .  63
-     C.10. April 13, 2021  . . . . . . . . . . . . . . . . . . . . .  63
+               DMARC . . . . . . . . . . . . . . . . . . . . . . . .  64
+       C.9.3.  Ticket 96 - Tweaks to Abstract and Introduction . . .  64
+     C.10. April 13, 2021  . . . . . . . . . . . . . . . . . . . . .  64
        C.10.1.  Ticket 53 - Remove reporting message size
-               chunking  . . . . . . . . . . . . . . . . . . . . . .  63
+               chunking  . . . . . . . . . . . . . . . . . . . . . .  64
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                 [Page 4]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 4]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
        C.10.2.  Ticket 52 - Remove strict alignment (and adkim and
-               aspf tags)  . . . . . . . . . . . . . . . . . . . . .  63
-       C.10.3.  Ticket 47 - Remove pct= tag  . . . . . . . . . . . .  63
-       C.10.4.  Ticket 2 - Flow of operations text in dmarc-base . .  64
-     C.11. April 14, 2021  . . . . . . . . . . . . . . . . . . . . .  64
+               aspf tags)  . . . . . . . . . . . . . . . . . . . . .  64
+       C.10.3.  Ticket 47 - Remove pct= tag  . . . . . . . . . . . .  64
+       C.10.4.  Ticket 2 - Flow of operations text in dmarc-base . .  65
+     C.11. April 14, 2021  . . . . . . . . . . . . . . . . . . . . .  65
        C.11.1.  Ticket 107 - DMARCbis should take a stand on
-               multi-valued From fields  . . . . . . . . . . . . . .  64
-       C.11.2.  Ticket 82 - Deprecate rf= and maybe fo= tag  . . . .  64
+               multi-valued From fields  . . . . . . . . . . . . . .  65
+       C.11.2.  Ticket 82 - Deprecate rf= and maybe fo= tag  . . . .  65
        C.11.3.  Ticket 85 - Proposed change to wording describing 'p'
-               tag and values  . . . . . . . . . . . . . . . . . . .  64
-     C.12. April 15, 2021  . . . . . . . . . . . . . . . . . . . . .  64
-       C.12.1.  Ticket 86 - A-R results for DMARC  . . . . . . . . .  64
+               tag and values  . . . . . . . . . . . . . . . . . . .  65
+     C.12. April 15, 2021  . . . . . . . . . . . . . . . . . . . . .  65
+       C.12.1.  Ticket 86 - A-R results for DMARC  . . . . . . . . .  65
        C.12.2.  Ticket 62 - Make aggregate reporting a normative
-               MUST  . . . . . . . . . . . . . . . . . . . . . . . .  64
-     C.13. April 19, 2021  . . . . . . . . . . . . . . . . . . . . .  64
-       C.13.1.  Ticket 109 - Sanity Check DMARCbis Document  . . . .  65
-     C.14. April 20, 2021  . . . . . . . . . . . . . . . . . . . . .  65
-       C.14.1.  Ticket 108 - Changes to DMARCbis for PSD . . . . . .  65
-     C.15. April 22, 2021  . . . . . . . . . . . . . . . . . . . . .  65
+               MUST  . . . . . . . . . . . . . . . . . . . . . . . .  65
+     C.13. April 19, 2021  . . . . . . . . . . . . . . . . . . . . .  65
+       C.13.1.  Ticket 109 - Sanity Check DMARCbis Document  . . . .  66
+     C.14. April 20, 2021  . . . . . . . . . . . . . . . . . . . . .  66
+       C.14.1.  Ticket 108 - Changes to DMARCbis for PSD . . . . . .  66
+     C.15. April 22, 2021  . . . . . . . . . . . . . . . . . . . . .  66
        C.15.1.  Ticket 104 - Update the Security Considerations
-               section 11.3 on DNS . . . . . . . . . . . . . . . . .  65
-     C.16. June 16, 2021 . . . . . . . . . . . . . . . . . . . . . .  65
-       C.16.1.  Publication of draft-ietf-dmarc-dmarcbis-02  . . . .  65
-     C.17. August 12, 2021 . . . . . . . . . . . . . . . . . . . . .  65
-       C.17.1.  Publication of draft-ietf-dmarc-dmarcbis-03  . . . .  65
-   Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . .  66
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  66
+               section 11.3 on DNS . . . . . . . . . . . . . . . . .  66
+     C.16. June 16, 2021 . . . . . . . . . . . . . . . . . . . . . .  66
+       C.16.1.  Publication of draft-ietf-dmarc-dmarcbis-02  . . . .  66
+     C.17. August 12, 2021 . . . . . . . . . . . . . . . . . . . . .  66
+       C.17.1.  Publication of draft-ietf-dmarc-dmarcbis-03  . . . .  66
+   Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . .  67
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  67
 
 1.  Introduction
 
@@ -277,9 +277,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                 [Page 5]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 5]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    *  Desire for reports about email use of the domain name
@@ -333,9 +333,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                 [Page 6]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 6]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 2.  Requirements
@@ -389,9 +389,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                 [Page 7]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 7]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    *  content analysis.
@@ -445,9 +445,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                 [Page 8]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 8]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    Readers are encouraged to be familiar with the contents of [RFC5598].
@@ -501,9 +501,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                 [Page 9]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 9]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 3.7.  Mail Receiver
@@ -557,9 +557,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 10]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 10]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 3.14.  More on Identifier Alignment
@@ -613,9 +613,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 11]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 11]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    In relaxed mode, the Organizational Domains of both the DKIM-
@@ -669,9 +669,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 12]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 12]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 3.14.3.  Alignment and Extension Technologies
@@ -683,52 +683,78 @@ Internet-Draft                  DMARCbis                  September 2021
 
 3.15.  Determining The Organizational Domain
 
-   The Organizational Domain is determined using the following
-   algorithm:
+   The Organizational Domain for a subject DNS domain name is defined as
+   the domain that is found in the DNS hierarchy one level below the PSD
+   in the subject DNS domain name.  The Organizational Domain is
+   determined using the following algorithm, similar to the one
+   described in Section 6.7.3
 
-   1.  Acquire a "public suffix" list, i.e., a list of DNS domain names
-       reserved for registrations.  Some country Top-Level Domains
-       (TLDs) make specific registration requirements, e.g., the United
-       Kingdom places company registrations under ".co.uk"; other TLDs
-       such as ".com" appear in the IANA registry of top-level DNS
-       domains.  A public suffix list is the union of all of these.
-       Appendix A.6.1 contains some discussion about obtaining a public
-       suffix list.
+   1.  Query the DNS for a DMARC TXT record at the DNS domain matching
+       the one found in the RFC5322.From domain in the message.  A
+       possibly empty set of records is returned.
 
-   2.  Break the subject DNS domain name into a set of "n" ordered
+   2.  Records that do not start with a "v=" tag that identifies the
+       current version of DMARC are discarded.
+
+   3.  If the set is now empty, or the set contains one valid DMARC
+       record that does not include a psd tag with a value of 'y', then
+       determine the target for additional queries, using steps 4
+       through 8 below.
+
+   4.  Break the subject DNS domain name into a set of "n" ordered
        labels.  Number these labels from right to left; e.g., for
        "example.com", "com" would be label 1 and "example" would be
        label 2.
 
-   3.  Search the public suffix list for the name that matches the
-       largest number of labels found in the subject DNS domain.  Let
-       that number be "x".
+   5.  Count the number of labels found in the subject DNS domain.  Let
+       that number be "x".  If x < 5, remove the left-most (highest-
+       numbered) label from the subject domain.  If x >= 5, remove the
+       left-most (highest-numbered) labels from the subject domain until
+       4 labels remain.  The resulting DNS domain name is the new target
+       for subsequent lookups.
 
-   4.  Construct a new DNS domain name using the name that matched from
-       the public suffix list and prefixing to it the "x+1"th label from
-       the subject domain.  This new name is the Organizational Domain.
+   6.  Query the DNS for a DMARC TXT record at the DNS domain matching
+       this new target in place of the RFC5322.From domain in the
+       message.  A possibly empty set of records is returned.
 
-   Thus, since "com" is an IANA-registered TLD, a subject domain of
-   "a.b.c.d.example.com" would have an Organizational Domain of
-   "example.com".
+   7.  Records that do not start with a "v=" tag that identifies the
+       current version of DMARC are discarded.
 
-   The process of determining a suffix is currently a heuristic one.  No
-   list is guaranteed to be accurate or current.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 13]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+   8.  If the set is now empty, or the set contains one valid DMARC
+       record that does not include a psd tag with the value of 'y',
+       then determine the target for additional queries by removing a
+       single label from the target domain as described in step 5 and
+       repeating steps 6 and 7 until there are no more labels remaining
+       or a record containing a psd tag with a value of 'y' is found.
+
+   9.  Once a valid DMARC record containing a psd tag with a value of
+       'y' has been found, the Organizational Domain for the DNS domain
+       matching the one found in the RFC5322.From domain can be declared
+       to be the target domain queried for in the step prior to the
+       query that found the PSD domain.
+
+   For example, given the RFC5322.From domain "a.mail.example.com", a
+   series of DNS queries for DMARC records would be executed starting
+   with "_dmarc.a.mail.example.com" and finishing with "_dmarc.com".
+   The "_dmarc.com" record would contain a psd tag with a value of 'y',
+   and so the Organizational Domain for this RFC5322.From domain would
+   be determined to be "example.com", the domain of the DMARC query
+   executed prior to the query for "_dmarc.com".
 
 4.  Overview
 
    This section provides a general overview of the design and operation
    of the DMARC environment.
-
-
-
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 13]
-
-Internet-Draft                  DMARCbis                  September 2021
-
 
 4.1.  Authentication Mechanisms
 
@@ -750,6 +776,15 @@ Internet-Draft                  DMARCbis                  September 2021
 
    DMARC policies are published by the Domain Owner or PSO, and
    retrieved by the Mail Receiver during the SMTP session, via the DNS.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 14]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    DMARC's verification function is based on whether the RFC5322.From
    domain is aligned with an authenticated domain name from SPF or DKIM.
@@ -778,14 +813,6 @@ Internet-Draft                  DMARCbis                  September 2021
    defined in other referenced material such as [RFC6591] and
    [DMARC-Failure-Reporting]
 
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 14]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
    A message satisfies the DMARC checks if at least one of the supported
    authentication mechanisms:
 
@@ -795,6 +822,25 @@ Internet-Draft                  DMARCbis                  September 2021
        as defined in Section 3.
 
 4.3.  Flow Diagram
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 15]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
     +---------------+                             +--------------------+
     | Author Domain |< . . . . . . . . . . . .    | Return-Path Domain |
@@ -833,15 +879,6 @@ Internet-Draft                  DMARCbis                  September 2021
    authentication modules.  "sMTA" is the sending MTA, and "rMTA" is the
    receiving MTA.
 
-
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 15]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
    Put simply, when a message reaches a DMARC-aware rMTA, a DNS query
    will be initiated to determine if the author domain has published a
    DMARC policy.  If a policy is found, the rMTA will use the results of
@@ -851,6 +888,15 @@ Internet-Draft                  DMARCbis                  September 2021
 
    More details on specific actions for the parties involved can be
    found in Section 6.5 and Section 6.7.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 16]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 5.  Use of RFC5322.From
 
@@ -889,15 +935,6 @@ Internet-Draft                  DMARCbis                  September 2021
    operate under a slightly restricted profile of RFC5322 with respect
    to the expected syntax of this field.  See Section 6.7 for details.
 
-
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 16]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
 6.  Policy
 
    DMARC policies are published by Domain Owners and PSOs and can be
@@ -909,6 +946,14 @@ Internet-Draft                  DMARCbis                  September 2021
    severity of concern regarding failed authentication for email
    messages making use of their domain in the RFC5322.From header field
    as well as the provision of feedback about those messages.  Mail
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 17]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    Receivers in turn can take into account the Domain Owner's severity
    of concern when making handling decisions about email messages that
    fail DMARC authentication checks.
@@ -944,16 +989,6 @@ Internet-Draft                  DMARCbis                  September 2021
    "_dmarc.example.com".  The DNS-located DMARC preference data will
    hereafter be called the "DMARC record".
 
-
-
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 17]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
    DMARC's use of the Domain Name Service is driven by DMARC's use of
    domain names and the nature of the query it performs.  The query
    requirement matches with the DNS, for obtaining simple parametric
@@ -963,6 +998,17 @@ Internet-Draft                  DMARCbis                  September 2021
    the DNS as the query service has the benefit of reusing an extremely
    well-established operations, administration, and management
    infrastructure, rather than creating a new one.
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 18]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    Per [RFC1035], a TXT record can comprise several "character-string"
    objects.  Where this is the case, the module performing DMARC
@@ -995,21 +1041,6 @@ Internet-Draft                  DMARCbis                  September 2021
 
    The following tags are valid DMARC tags:
 
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 18]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
    adkim:  (plain-text; OPTIONAL; default is "r".)  Indicates whether
       strict or relaxed DKIM Identifier Alignment mode is required by
       the Domain Owner.  See Section 3.14.1 for details.  Valid values
@@ -1027,6 +1058,13 @@ Internet-Draft                  DMARCbis                  September 2021
       r:  relaxed mode
 
       s:  strict mode
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 19]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    fo:  Failure reporting options (plain-text; OPTIONAL; default is "0")
       Provides requested options for generation of failure reports.
@@ -1058,14 +1096,6 @@ Internet-Draft                  DMARCbis                  September 2021
       evaluation, regardless of its alignment.  SPF-specific
       reporting is described in [@!RFC6652].
 
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 19]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
    np:  Domain Owner Assessment Policy for non-existent subdomains
       (plain-text; OPTIONAL).  Indicates the severity of concern the
       Domain Owner or PSO has for mail using non-existent subdomains of
@@ -1084,6 +1114,14 @@ Internet-Draft                  DMARCbis                  September 2021
       policy records).  Indicates the severity of concern the Domain
       Owner or PSO has for mail using its domain but not passing DMARC
       verification.  Policy applies to the domain queried and to
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 20]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
       subdomains, unless subdomain policy is explicitly described using
       the "sp" or "np" tags.  This tag is mandatory for policy records
       only, but not for third-party reporting records (see
@@ -1101,6 +1139,18 @@ Internet-Draft                  DMARCbis                  September 2021
          See Section 8.3 for some discussion of SMTP rejection methods
          and their implications.
 
+   psd:  A flag indicating whether the domain is a PSD. (plain-text;
+      OPTIONAL; default is 'n').  Possible values are:
+
+      y:  Domains on the PSL that publish DMARC policy records SHOULD
+         include this tag with a value of 'y' to indicate that the
+         domain is a PSD.  This information will be used during policy
+         discovery to determine how to apply any DMARC policy records
+         that are discovered during the tree walk.
+
+      n:  The default, indicating that the DMARC policy record is
+         published for a domain that is not a PSD.
+
    rua:  Addresses to which aggregate feedback is to be sent (comma-
       separated plain-text list of DMARC URIs; OPTIONAL).  Section 3 of
       [DMARC-Aggregate-Reporting] discusses considerations that apply
@@ -1114,20 +1164,20 @@ Internet-Draft                  DMARCbis                  September 2021
       The aggregate feedback report format is described in
       [DMARC-Aggregate-Reporting]
 
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 20]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
    ruf:  Addresses to which message-specific failure information is to
       be reported (comma-separated plain-text list of DMARC URIs;
       OPTIONAL).  If present, the Domain Owner or PSO is requesting Mail
       Receivers to send detailed failure reports about messages that
       fail the DMARC evaluation in specific ways (see the "fo" tag
       above).  The format of the message to be generated MUST follow the
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 21]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
       format specified for the "rf" tag.  Section 3 of
       [DMARC-Aggregate-Reporting] discusses considerations that apply
       when the domain name of a URI differs from that of the domain
@@ -1167,22 +1217,22 @@ Internet-Draft                  DMARCbis                  September 2021
       n:  The default, a request to apply the policy as specified to any
          message that produces a DMARC "fail" result.
 
-
-
-
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 21]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
    v:  Version (plain-text; REQUIRED).  Identifies the record retrieved
       as a DMARC record.  It MUST have the value of "DMARC1".  The value
       of this tag MUST match precisely; if it does not or it is absent,
       the entire retrieved record MUST be ignored.  It MUST be the first
       tag in the list.
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 22]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    A DMARC policy record MUST comply with the formal specification found
    in Section 6.4 in that the "v" tag MUST be present and MUST appear
@@ -1226,20 +1276,19 @@ Internet-Draft                  DMARCbis                  September 2021
      dmarc-sep       = *WSP %x3b *WSP
 
      dmarc-request   = "p" *WSP "=" *WSP
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 22]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
                        ( "none" / "quarantine" / "reject" )
 
      dmarc-test      = "t" *WSP "=" ( "y" / "n" )
 
      dmarc-srequest  = "sp" *WSP "=" *WSP
                        ( "none" / "quarantine" / "reject" )
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 23]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
      dmarc-nprequest  = "np" *WSP "=" *WSP
                        ( "none" / "quarantine" / "reject" )
@@ -1277,19 +1326,6 @@ Internet-Draft                  DMARCbis                  September 2021
    with the Author Domain, and then publish an SPF policy in DNS for
    that domain.
 
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 23]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
 6.5.2.  Configure Sending System for DKIM Signing Using an Aligned
         Domain
 
@@ -1300,6 +1336,15 @@ Internet-Draft                  DMARCbis                  September 2021
    Signing domain (i.e., the d= domain in the DKIM-Signature header)
    that aligns with the Author Domain and configure its system to sign
    using that domain.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 24]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 6.5.3.  Setup a Mailbox to Receive Aggregate Reports
 
@@ -1328,24 +1373,6 @@ Internet-Draft                  DMARCbis                  September 2021
    SHOULD start with "p=none", with the rua tag containg the mailbox
    created in the previous step.
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 24]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
 6.5.5.  Collect and Analyze Reports and Adjust Authentication
 
    The reason for starting at "p=none" is to ensure that nothing's been
@@ -1357,6 +1384,23 @@ Internet-Draft                  DMARCbis                  September 2021
    its own mail streams.  Should any overlooked systems be found in the
    reports, the Domain Owner can adjust the SPF record and/or configure
    DKIM signing for those systems.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 25]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 6.5.6.  Decide If and When to Update DMARC Policy
 
@@ -1394,14 +1438,6 @@ Internet-Draft                  DMARCbis                  September 2021
    the handling of those that are forbidden under [RFC5322] or that
    contain no meaningful domains is outside the scope of this document.
 
-
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 25]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
    The case of a syntactically valid multi-valued RFC5322.From header
    field presents a particular challenge.  When a single RFC5322.From
    header field contains multiple addresses, it is possible that there
@@ -1413,6 +1449,14 @@ Internet-Draft                  DMARCbis                  September 2021
 
    Note that domain names that appear on a public suffix list are not
    exempt from DMARC policy application and reporting.
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 26]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 6.7.2.  Determine Handling Policy
 
@@ -1451,13 +1495,6 @@ Internet-Draft                  DMARCbis                  September 2021
        failures, identifier mismatches) are considered to be DMARC
        mechanism check failures.
 
-
-
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 26]
-
-Internet-Draft                  DMARCbis                  September 2021
-
-
    6.  Apply policy.  Emails that fail the DMARC mechanism check are
        handled in accordance with the discovered DMARC policy of the
        Domain Owner and any local policy rules enforced by the Mail
@@ -1468,6 +1505,14 @@ Internet-Draft                  DMARCbis                  September 2021
    the case that the Domain Owner wishes a Message Receiver not to
    consider the results of that underlying authentication protocol at
    all.
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 27]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    DMARC evaluation can only yield a "pass" result after one of the
    underlying authentication mechanisms passes for an aligned
@@ -1489,60 +1534,70 @@ Internet-Draft                  DMARCbis                  September 2021
    important differences between DMARC and SPF mechanisms, are discussed
    below.
 
-   To balance the conflicting requirements of supporting wildcarding,
-   allowing subdomain policy overrides, and limiting DNS query load, the
-   following DNS lookup scheme is employed:
+   To balance the conflicting requirements of supporting wildcarding and
+   allowing subdomain policy overrides, the following DNS lookup scheme
+   is employed:
 
-   1.  Mail Receivers MUST query the DNS for a DMARC TXT record at the
-       DNS domain matching the one found in the RFC5322.From domain in
-       the message.  A possibly empty set of records is returned.
+   1.   Mail Receivers MUST query the DNS for a DMARC TXT record at the
+        DNS domain matching the one found in the RFC5322.From domain in
+        the message.  A possibly empty set of records is returned.
 
-   2.  Records that do not start with a "v=" tag that identifies the
-       current version of DMARC are discarded.
+   2.   Records that do not start with a "v=" tag that identifies the
+        current version of DMARC are discarded.
 
-   3.  If the set is now empty, the Mail Receiver MUST query the DNS for
-       a DMARC TXT record at the DNS domain matching the Organizational
-       Domain in place of the RFC5322.From domain in the message (if
-       different).  This record can contain policy to be asserted for
-       subdomains of the Organizational Domain.  A possibly empty set of
-       records is returned.
+   3.   If the set is now empty, the Mail Receiver determines the target
+        for additional queries, using steps 4 through 8 below.
+
+   4.   Break the subject DNS domain name into a set of "n" ordered
+        labels.  Number these lables from right to left; e.g., for
+        "example.com", "com" would be label 1 and "example" would be
+        label 2.
+
+   5.   Count the number of labels found in the subject DNS domain.  Let
+        that number be "x".  If x < 5, remove the left-most (highest-
+        numbered) label from the subject domain.  If x >= 5, remove the
+        left-most (highest-numbered) labels from the subject domain
+        until 4 labels remain.  The resulting DNS domain name is the new
+        target for subsequent lookups.
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 27]
+
+
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 28]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
-   4.  Records that do not start with a "v=" tag that identifies the
-       current version of DMARC are discarded.
+   6.   The Mail Receiver MUST query the DNS for a DMARC TXT record at
+        the DNS domain matching this new target in place of the
+        RFC5322.From domain in the message.  This record can contain
+        policy to be asserted for subdomains of the target.  A possibly
+        empty set of records is returned.
 
-   5.  If the set is now empty and the longest PSD Section 3.6 of the
-       Organizational Domain is one that the receiver has determined is
-       acceptable for PSD DMARC (based on the data in one of the DMARC
-       PSD Registry Examples decribed in Appendix B of [RFC9091]) the
-       Mail Receiver MUST query the DNS for a DMARC TXT record at the
-       DNS domain matching the longest PSD in place of the RFC5322.From
-       domain in the message (if different).  A possibly empty set of
-       records is returned.
+   7.   Records that do not start with a "v=" tag that identifies the
+        current version of DMARC are discarded.
 
-   6.  Records that do not start with a "v=" tag that identifies the
-       current version of DMARC are discarded.
+   8.   If the set is now empty, the Mail Receiver determines the target
+        for additional queries by removing a single label from the
+        target domain as described in step 5 and repeating steps 6 and 7
+        until there are no more labels remaining.
 
-   7.  If the remaining set contains multiple records or no records,
-       policy discovery terminates and DMARC processing is not applied
-       to this message.
+   9.   If the remaining set contains multiple records or no records,
+        policy discovery terminates and DMARC processing is not applied
+        to this message.
 
-   8.  If a retrieved policy record does not contain a valid "p" tag, or
-       contains an "sp" tag that is not valid, then:
+   10.  If a retrieved policy record does not contain a valid "p" tag,
+        or contains an "sp" tag that is not valid, then:
 
-       1.  if a "rua" tag is present and contains at least one
-           syntactically valid reporting URI, the Mail Receiver SHOULD
-           act as if a record containing a valid "v" tag and "p=none"
-           was retrieved, and continue processing;
+        1.  if a "rua" tag is present and contains at least one
+            syntactically valid reporting URI, the Mail Receiver SHOULD
+            act as if a record containing a valid "v" tag and "p=none"
+            was retrieved, and continue processing;
 
-       2.  otherwise, the Mail Receiver applies no DMARC processing to
-           this message.
+        2.  otherwise, the Mail Receiver applies no DMARC processing to
+            this message.
 
    If the set produced by the mechanism above contains no DMARC policy
    record (i.e., any indication that there is no such record as opposed
@@ -1565,9 +1620,10 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 28]
+
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 29]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 6.7.3.1.  Longest PSD Example
@@ -1621,9 +1677,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 29]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 30]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 6.8.  Policy Enforcement Considerations
@@ -1677,9 +1733,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 30]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 31]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    Mail Receivers MUST also implement reporting instructions of DMARC,
@@ -1733,9 +1789,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 31]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 32]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 8.2.  DNS Load and Caching
@@ -1789,9 +1845,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 32]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 33]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    Similarly, the text portion of the SMTP reply may be important to
@@ -1845,9 +1901,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 33]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 34]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    Additional DMARC constraints occur when a message is processed by
@@ -1901,9 +1957,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 34]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 35]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 9.2.  Authentication-Results Result Registry Update
@@ -1957,9 +2013,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 35]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 36]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    |           |           |           |(added)| error occurred |      |
@@ -2013,9 +2069,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 36]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 37]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    specification adequately describes the new tag and clearly presents
@@ -2069,9 +2125,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 37]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 38]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 9.5.  DMARC Report Format Registry
@@ -2125,9 +2181,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 38]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 39]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 10.1.  Authentication Methods
@@ -2181,9 +2237,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 39]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 40]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    *  DNS over TLS [RFC7858] or DNS over HTTPS [RFC8484] can mitigate
@@ -2237,9 +2293,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 40]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 41]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 10.5.  External Reporting Addresses
@@ -2293,9 +2349,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 41]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 42]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    [DMARC-Failure-Reporting]
@@ -2349,9 +2405,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 42]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 43]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    [RFC6591]  Fontana, H., "Authentication Failure Reporting Using the
@@ -2405,9 +2461,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 43]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 44]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    [RFC3464]  Moore, K. and G. Vaudreuil, "An Extensible Message Format
@@ -2461,9 +2517,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 44]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 45]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    [RFC8601]  Kucherawy, M., "Message Header Field for Indicating
@@ -2517,9 +2573,9 @@ A.2.  Method Exclusion
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 45]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 46]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    Specifically, consider a Domain Owner that has deployed one of the
@@ -2573,9 +2629,9 @@ A.3.  Sender Header Field
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 46]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 47]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    3.  Allowing multiple ways to discover policy introduces unacceptable
@@ -2629,9 +2685,9 @@ A.5.  Issues with ADSP in Operation
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 47]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 48]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    5.  ADSP has no support for a slow rollout, i.e., no way to configure
@@ -2685,9 +2741,9 @@ A.6.  Organizational Domain Discovery Issues
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 48]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 49]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 A.6.1.  Public Suffix Lists
@@ -2741,9 +2797,9 @@ A.7.  Removal of the "pct" Tag
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 49]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 50]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    These custom actions when the pct= tag was set to "0" proved valuable
@@ -2797,9 +2853,9 @@ B.1.1.  SPF
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 50]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 51]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
         MAIL FROM: <sender@example.com>
@@ -2853,9 +2909,9 @@ B.1.2.  DKIM
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 51]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 52]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
         DKIM-Signature: v=1; ...; d=example.com; ...
@@ -2909,9 +2965,9 @@ B.2.1.  Entire Domain, Monitoring Only
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 52]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 53]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    *  Confirm that its legitimate messages are authenticating correctly
@@ -2965,9 +3021,9 @@ B.2.2.  Entire Domain, Monitoring Only, Per-Message Reports
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 53]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 54]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    Not all Receivers will honor such a request, but the Domain Owner
@@ -3021,9 +3077,9 @@ B.2.3.  Per-Message Failure Reports Directed to Third Party
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 54]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 55]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    The DMARC policy record might look like this when retrieved using a
@@ -3077,9 +3133,9 @@ Internet-Draft                  DMARCbis                  September 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 55]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 56]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    Mediators and other third parties should refer to Section 3 of
@@ -3133,9 +3189,9 @@ B.2.4.  Subdomain, Testing, and Multiple Aggregate Report URIs
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 56]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 57]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
      % dig +short TXT _dmarc.test.example.com
@@ -3189,9 +3245,9 @@ B.3.  Mail Receiver Example
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 57]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 58]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 B.4.  Processing of SMTP Time
@@ -3245,9 +3301,9 @@ B.4.  Processing of SMTP Time
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 58]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 59]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    If no Authenticated Identifiers align with the Author Domain, then
@@ -3301,9 +3357,9 @@ B.5.  Utilization of Aggregate Feedback: Example
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 59]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 60]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    directly correct the problem or understand where authentication-
@@ -3357,9 +3413,9 @@ C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 60]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 61]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 C.3.  February 10, 2021
@@ -3413,9 +3469,9 @@ C.6.1.  Ticket 7 - ABNF for dmarc-record is slightly wrong
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 61]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 62]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    *  New text documented here - https://trac.ietf.org/trac/dmarc/
@@ -3469,9 +3525,9 @@ C.8.1.  Ticket 54 - Remove or expand limits on number of recipients per
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 62]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 63]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 C.9.  April 12, 2021
@@ -3525,9 +3581,9 @@ C.10.3.  Ticket 47 - Remove pct= tag
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 63]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 64]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
    *  Data demonstrating lack of use of feature entered into ticket -
@@ -3581,9 +3637,9 @@ C.13.  April 19, 2021
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 64]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 65]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 C.13.1.  Ticket 109 - Sanity Check DMARCbis Document
@@ -3637,9 +3693,9 @@ C.17.1.  Publication of draft-ietf-dmarc-dmarcbis-03
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 65]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 66]
 
-Internet-Draft                  DMARCbis                  September 2021
+Internet-Draft                  DMARCbis                   November 2021
 
 
 Acknowledgements
@@ -3693,4 +3749,4 @@ Authors' Addresses
 
 
 
-Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 66]
+Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 67]

--- a/draft-ietf-dmarc-dmarcbis-04.txt
+++ b/draft-ietf-dmarc-dmarcbis-04.txt
@@ -6,7 +6,7 @@ DMARC                                                       T. Herr (ed)
 Internet-Draft                                                  Valimail
 Obsoletes: 7489 (if approved)                             J. Levine (ed)
 Intended status: Standards Track                           Standcore LLC
-Expires: 21 May 2022                                    17 November 2021
+Expires: 22 May 2022                                    18 November 2021
 
 
 Domain-based Message Authentication, Reporting, and Conformance (DMARC)
@@ -19,7 +19,7 @@ Abstract
 
    DMARC permits the owner of an email author's domain name to enable
    verification of the domain's use, to indicate the Domain Owner's or
-   Public Suffix Operator's severity of concern regarding failed
+   Public Suffix Operator's message handling preference regarding failed
    verification, and to request reports about use of the domain name.
    Mail receiving organizations can use this information when evaluating
    handling choices for incoming mail.
@@ -41,7 +41,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 21 May 2022.
+   This Internet-Draft will expire on 22 May 2022.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 1]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 1]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -76,28 +76,29 @@ Table of Contents
      2.3.  Scalability . . . . . . . . . . . . . . . . . . . . . . .   8
      2.4.  Anti-Phishing . . . . . . . . . . . . . . . . . . . . . .   8
    3.  Terminology and Definitions . . . . . . . . . . . . . . . . .   8
-     3.1.  Conventions Used in This Document . . . . . . . . . . . .   8
-     3.2.  Authenticated Identifiers . . . . . . . . . . . . . . . .   9
-     3.3.  Author Domain . . . . . . . . . . . . . . . . . . . . . .   9
-     3.4.  Domain Owner  . . . . . . . . . . . . . . . . . . . . . .   9
-     3.5.  Identifier Alignment  . . . . . . . . . . . . . . . . . .   9
-     3.6.  Longest PSD . . . . . . . . . . . . . . . . . . . . . . .   9
-     3.7.  Mail Receiver . . . . . . . . . . . . . . . . . . . . . .  10
-     3.8.  Non-existent Domains  . . . . . . . . . . . . . . . . . .  10
-     3.9.  Organizational Domain . . . . . . . . . . . . . . . . . .  10
-     3.10. Public Suffix Domain (PSD)  . . . . . . . . . . . . . . .  10
-     3.11. Public Suffix Operator (PSO)  . . . . . . . . . . . . . .  10
-     3.12. PSO Controlled Domain Names . . . . . . . . . . . . . . .  10
-     3.13. Report Receiver . . . . . . . . . . . . . . . . . . . . .  10
-     3.14. More on Identifier Alignment  . . . . . . . . . . . . . .  11
-       3.14.1.  DKIM-Authenticated Identifiers . . . . . . . . . . .  11
-       3.14.2.  SPF-Authenticated Identifiers  . . . . . . . . . . .  12
-       3.14.3.  Alignment and Extension Technologies . . . . . . . .  13
-     3.15. Determining The Organizational Domain . . . . . . . . . .  13
+     3.1.  Conventions Used in This Document . . . . . . . . . . . .   9
+     3.2.  Defintions  . . . . . . . . . . . . . . . . . . . . . . .   9
+       3.2.1.  Authenticated Identifiers . . . . . . . . . . . . . .   9
+       3.2.2.  Author Domain . . . . . . . . . . . . . . . . . . . .   9
+       3.2.3.  Domain Owner  . . . . . . . . . . . . . . . . . . . .   9
+       3.2.4.  Identifier Alignment  . . . . . . . . . . . . . . . .  10
+       3.2.5.  Longest PSD . . . . . . . . . . . . . . . . . . . . .  10
+       3.2.6.  Mail Receiver . . . . . . . . . . . . . . . . . . . .  10
+       3.2.7.  Non-existent Domains  . . . . . . . . . . . . . . . .  10
+       3.2.8.  Organizational Domain . . . . . . . . . . . . . . . .  10
+       3.2.9.  Public Suffix Domain (PSD)  . . . . . . . . . . . . .  10
+       3.2.10. Public Suffix Operator (PSO)  . . . . . . . . . . . .  10
+       3.2.11. PSO Controlled Domain Names . . . . . . . . . . . . .  10
+       3.2.12. Report Receiver . . . . . . . . . . . . . . . . . . .  11
+     3.3.  More on Identifier Alignment  . . . . . . . . . . . . . .  11
+       3.3.1.  DKIM-Authenticated Identifiers  . . . . . . . . . . .  12
+       3.3.2.  SPF-Authenticated Identifiers . . . . . . . . . . . .  12
+       3.3.3.  Alignment and Extension Technologies  . . . . . . . .  13
+     3.4.  Determining The Organizational Domain . . . . . . . . . .  13
    4.  Overview  . . . . . . . . . . . . . . . . . . . . . . . . . .  14
      4.1.  Authentication Mechanisms . . . . . . . . . . . . . . . .  14
-     4.2.  Key Concepts  . . . . . . . . . . . . . . . . . . . . . .  14
-     4.3.  Flow Diagram  . . . . . . . . . . . . . . . . . . . . . .  15
+     4.2.  Key Concepts  . . . . . . . . . . . . . . . . . . . . . .  15
+     4.3.  Flow Diagram  . . . . . . . . . . . . . . . . . . . . . .  16
    5.  Use of RFC5322.From . . . . . . . . . . . . . . . . . . . . .  17
    6.  Policy  . . . . . . . . . . . . . . . . . . . . . . . . . . .  17
      6.1.  DMARC Policy Record . . . . . . . . . . . . . . . . . . .  18
@@ -105,15 +106,15 @@ Table of Contents
      6.3.  General Record Format . . . . . . . . . . . . . . . . . .  19
      6.4.  Formal Definition . . . . . . . . . . . . . . . . . . . .  23
      6.5.  Domain Owner Actions  . . . . . . . . . . . . . . . . . .  24
-       6.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  24
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 2]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 2]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
+       6.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  24
        6.5.2.  Configure Sending System for DKIM Signing Using an
                Aligned Domain  . . . . . . . . . . . . . . . . . . .  24
        6.5.3.  Setup a Mailbox to Receive Aggregate Reports  . . . .  25
@@ -161,15 +162,15 @@ Internet-Draft                  DMARCbis                   November 2021
      A.5.  Issues with ADSP in Operation . . . . . . . . . . . . . .  48
      A.6.  Organizational Domain Discovery Issues  . . . . . . . . .  49
        A.6.1.  Public Suffix Lists . . . . . . . . . . . . . . . . .  50
-     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  50
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 3]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 3]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
+     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  50
    Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  51
      B.1.  Identifier Alignment Examples . . . . . . . . . . . . . .  51
        B.1.1.  SPF . . . . . . . . . . . . . . . . . . . . . . . . .  51
@@ -216,16 +217,17 @@ Internet-Draft                  DMARCbis                   November 2021
                DMARC . . . . . . . . . . . . . . . . . . . . . . . .  64
        C.9.3.  Ticket 96 - Tweaks to Abstract and Introduction . . .  64
      C.10. April 13, 2021  . . . . . . . . . . . . . . . . . . . . .  64
-       C.10.1.  Ticket 53 - Remove reporting message size
-               chunking  . . . . . . . . . . . . . . . . . . . . . .  64
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 4]
+
+Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 4]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
+       C.10.1.  Ticket 53 - Remove reporting message size
+               chunking  . . . . . . . . . . . . . . . . . . . . . .  64
        C.10.2.  Ticket 52 - Remove strict alignment (and adkim and
                aspf tags)  . . . . . . . . . . . . . . . . . . . . .  64
        C.10.3.  Ticket 47 - Remove pct= tag  . . . . . . . . . . . .  64
@@ -265,47 +267,40 @@ Internet-Draft                  DMARCbis                   November 2021
    domain name in the RFC5322.From header field.  The domain typically
    belongs to an organization expected to be known to - and presumably
    trusted by - the recipient.  The Sender Policy Framework (SPF)
-   ([RFC7208]) and DomainKeys Identified Mail (DKIM) ([RFC6376])
-   protocols provide domain-level authentication but are not directly
-   associated with the RFC5322.From domain.  DMARC leverages them, so
-   that Domain Owners publish a DNS record indicating their RFC5322.From
-   field:
-
-   *  Email authentication policies
-
-   *  Level of concern for mail that fails authentication checks
+   [RFC7208] and DomainKeys Identified Mail (DKIM) [RFC6376] protocols
+   provide domain-level authentication but are not directly associated
+   with the RFC5322.From domain.  DMARC leverages them, and provides a
+   method for Domain Owners to publish a DNS record describing the email
+   authentication policies for the RFC5322.From domain and to request a
+   specific handling for messages using that domain that fail
+   authentication checks.
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 5]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 5]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-   *  Desire for reports about email use of the domain name
-
-   DMARC can cover non-existent sub-domains, below the "Organizational
-   Domain", as well as domains at the top of the name hierarchy,
-   controlled by Public Suffix Operators (PSOs).
-
-   As with SPF and DKIM, DMARC classes results as "pass" or "fail".  A
-   pass from either SPF or DKIM is required.  Depending on the stated
-   DMARC policy, the passed domain must be "aligned" with the
-   RFC5322.From domain in one of two modes - "relaxed" or "strict".
-   Domains are said to be "in relaxed alignment" if they have the same
-   Organizational Domain, which is at the top of the domain hierarchy,
-   while having the same administrative authority as the RFC5322.From
-   domain, while domains are "in strict alignment" if and only if they
-   are identical.
+   As with SPF and DKIM, DMARC classes results as "pass" or "fail".  In
+   order to get a DMARC result of "pass", a pass from either SPF or DKIM
+   is required.  In addition, the passed domain must be "aligned" with
+   the RFC5322.From domain in one of two modes - "relaxed" or "strict".
+   The mode is expressed in the domain's DMARC policy record.  Domains
+   are said to be "in relaxed alignment" if they have the same
+   "Organizational Domain", which is the domain at the top of the domain
+   hierarchy for the RFC5322.From domain while having the same
+   administrative authority as the RFC5322.From domain.  Domains are "in
+   strict alignment" if and only if they are identical.
 
    A DMARC pass indicates only that the RFC5322.From domain has been
-   authenticated for that message; authentication does not carry an
+   authenticated for that message.  Authentication does not carry an
    explicit or implicit value assertion about that message or about the
-   Domain Owner.  Indeed, a mail-receiving organization that performs
-   DMARC verification can choose to follow the Domain Owner's requested
-   disposition for authentication failures, and to inform the Domain
-   Owner of the mail handling decision for that message.  It also might
-   choose different actions.
+   Domain Owner.  Furthermore, a mail-receiving organization that
+   performs DMARC verification can choose to honor the Domain Owner's
+   requested message handling for authentication failures, but it is
+   under no obligation to do so; it might choose different actions
+   entirely.
 
    For a mail-receiving organization supporting DMARC, a message that
    passes verification is part of a message stream that is reliably
@@ -316,27 +311,37 @@ Internet-Draft                  DMARCbis                   November 2021
    verification is not necessarily associated with the Domain Owner's
    domain and its reputation.
 
+   DMARC policy records can also cover non-existent sub-domains, below
+   the "Organizational Domain", as well as domains at the top of the
+   name hierarchy, controlled by Public Suffix Operators (PSOs).
+
    DMARC, in the associated [DMARC-Aggregate-Reporting] and
    [DMARC-Failure-Reporting] documents, also specifies a reporting
    framework.  Using it, a mail-receiving domain can generate regular
    reports about messages that claim to be from a domain publishing
    DMARC policies, sending those reports to the address(es) specified by
-   the Domain Owner.
+   the Domain Owner in the latter's DMARC policy record.  Domain Owners
+   can use these reports, especially the aggregate reports, to identify
+   not only sources of mail attempting to fraudulently use their domain,
+   but also (and perhaps more importantly) gaps in their own
+   authentication practices.  However, as with honoring the Domain
+   Owner's stated mail handling preference, a mail-receiving
+   organization supporting DMARC is under no obligation to send
+   requested reports.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 6]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    Use of DMARC creates some interoperability challenges that require
    due consideration before deployment, particularly with configurations
    that can cause mail to be rejected.  These are discussed in
    Section 8.
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 6]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 2.  Requirements
 
@@ -348,9 +353,9 @@ Internet-Draft                  DMARCbis                   November 2021
 
    DMARC has the following high-level goals:
 
-   *  Allow Domain Owners and PSOs to assert their severity of concern
-      for authentication failures for messages purporting to have
-      authorship within the domain.
+   *  Allow Domain Owners and PSOs to assert their desired message
+      handling for authentication failures for messages purporting to
+      have authorship within the domain.
 
    *  Allow Domain Owners and PSOs to verify their authentication
       deployment.
@@ -368,33 +373,34 @@ Internet-Draft                  DMARCbis                   November 2021
    Several topics and issues are specifically out of scope for this
    work.  These include the following:
 
-   *  different treatment of messages that are not authenticated versus
+   *  Different treatment of messages that are not authenticated versus
       those that fail authentication;
 
-   *  evaluation of anything other than RFC5322.From header field;
+   *  Evaluation of anything other than RFC5322.From header field;
 
-   *  multiple reporting formats;
+   *  Multiple reporting formats;
 
-   *  publishing policy other than via the DNS;
+   *  Publishing policy other than via the DNS;
 
-   *  reporting or otherwise evaluating other than the last-hop IP
+   *  Reporting or otherwise evaluating other than the last-hop IP
       address;
 
-   *  attacks in the From: header field, also known as "display name"
-      attacks;
-
-   *  authentication of entities other than domains, since DMARC is
-      built upon SPF and DKIM, which authenticate domains; and
 
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 7]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 7]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-   *  content analysis.
+   *  Attacks in the From: header field, also known as "display name"
+      attacks;
+
+   *  Authentication of entities other than domains, since DMARC is
+      built upon SPF and DKIM, which authenticate domains; and
+
+   *  Content analysis.
 
 2.3.  Scalability
 
@@ -433,22 +439,24 @@ Internet-Draft                  DMARCbis                   November 2021
 
    This section defines terms used in the rest of the document.
 
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 8]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 3.1.  Conventions Used in This Document
 
    The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
    "OPTIONAL" in this document are to be interpreted as described in BCP
-   14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   14 [RFC2119] and [RFC8174] when, and only when, they appear in all
    capitals, as shown here.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 8]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    Readers are encouraged to be familiar with the contents of [RFC5598].
    In particular, that document defines various roles in the messaging
@@ -460,18 +468,22 @@ Internet-Draft                  DMARCbis                   November 2021
    reader is encouraged to become familiar with that material before
    continuing.
 
-3.2.  Authenticated Identifiers
+3.2.  Defintions
+
+   The following sections define terms used in this document.
+
+3.2.1.  Authenticated Identifiers
 
    Domain-level identifiers that are verified using authentication
    technologies are referred to as "Authenticated Identifiers".  See
    Section 4.1 for details about the supported mechanisms.
 
-3.3.  Author Domain
+3.2.2.  Author Domain
 
    The domain name of the apparent author, as extracted from the From:
    header field.
 
-3.4.  Domain Owner
+3.2.3.  Domain Owner
 
    An entity or organization that owns a DNS domain.  The term "owns"
    here indicates that the entity or organization being referenced holds
@@ -484,63 +496,73 @@ Internet-Draft                  DMARCbis                   November 2021
    Receivers, when those are outside of their immediate management
    domain.
 
-3.5.  Identifier Alignment
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 9]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+3.2.4.  Identifier Alignment
 
    When the domain in the address in the From: header field has the same
    Organizational Domain as a domain verified by SPF or DKIM (or both),
    it has Identifier Alignment. (see below)
 
-3.6.  Longest PSD
+3.2.5.  Longest PSD
 
    The term Longest PSD is defined in [RFC9091].
 
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                  [Page 9]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-3.7.  Mail Receiver
+3.2.6.  Mail Receiver
 
    The entity or organization that receives and processes email.
    Mail Receivers operate one or more Internet-facing Mail Transport
    Agents (MTAs).
 
-3.8.  Non-existent Domains
+3.2.7.  Non-existent Domains
 
    For DMARC purposes, a non-existent domain is a domain for which there
    is an NXDOMAIN or NODATA response for A, AAAA, and MX records.  This
    is a broader definition than that in [RFC8020].
 
-3.9.  Organizational Domain
+3.2.8.  Organizational Domain
 
-   The domain that was registered with a domain name registrar.  In the
-   absence of more accurate methods, heuristics are used to determine
-   this, since it is not always the case that the registered domain name
-   is simply a top-level DNS domain plus one component (e.g.,
-   "example.com", where "com" is a top-level domain).  The
-   Organizational Domain is determined by applying the algorithm found
-   in Section 3.15.
+   The Organizational Domain is typically a domain that was registered
+   with a domain name registrar.  More formally, it is a Public Suffix
+   Domain plus one label.  The Organizational Domain for the domain in
+   the RFC5322.From domain is determined by applying the algorithm found
+   in Section 3.4.
 
-3.10.  Public Suffix Domain (PSD)
+3.2.9.  Public Suffix Domain (PSD)
 
    The term Public Suffix Domain is defined in [RFC9091].
 
-3.11.  Public Suffix Operator (PSO)
+3.2.10.  Public Suffix Operator (PSO)
 
    The term Public Suffix Operator is defined in [RFC9091].
 
-3.12.  PSO Controlled Domain Names
+3.2.11.  PSO Controlled Domain Names
 
    The term PSO Controlled Domain Names is defined in [RFC9091].
 
-3.13.  Report Receiver
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 10]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+3.2.12.  Report Receiver
 
    An operator that receives reports from another operator implementing
    the reporting mechanisms described in this document and/or the
@@ -551,18 +573,7 @@ Internet-Draft                  DMARCbis                   November 2021
    collectively to the system components that receive and process these
    reports and the organizations that operate them.
 
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 10]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-3.14.  More on Identifier Alignment
+3.3.  More on Identifier Alignment
 
    Email authentication technologies authenticate various (and
    disparate) aspects of an individual message.  For example, DKIM
@@ -598,7 +609,16 @@ Internet-Draft                  DMARCbis                   November 2021
    as input yields authenticated domains as their outputs when they
    succeed.
 
-3.14.1.  DKIM-Authenticated Identifiers
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 11]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+3.3.1.  DKIM-Authenticated Identifiers
 
    DMARC requires Identifier Alignment based on the result of a DKIM
    authentication because a message can bear a valid signature from any
@@ -609,14 +629,6 @@ Internet-Draft                  DMARCbis                   November 2021
    DMARC permits Identifier Alignment based on the result of a DKIM
    authentication to be strict or relaxed.  (Note that these terms are
    not related to DKIM's "simple" and "relaxed" canonicalization modes.)
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 11]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    In relaxed mode, the Organizational Domains of both the DKIM-
    authenticated signing domain (taken from the value of the d= tag in
@@ -634,15 +646,14 @@ Internet-Draft                  DMARCbis                   November 2021
    d= domain does not exactly match the RFC5322.From domain.
 
    However, a DKIM signature bearing a value of "d=com" would never
-   allow an "in alignment" result, as "com" should appear on all public
-   suffix lists (see Appendix A.6.1) and therefore cannot be an
-   Organizational Domain.
+   allow an "in alignment" result, as "com" should be identified as a
+   PSD and therefore cannot be an Organizational Domain.
 
    Note that a single email can contain multiple DKIM signatures, and it
    is considered to produce a DMARC "pass" result if any DKIM signature
    is aligned and verifies.
 
-3.14.2.  SPF-Authenticated Identifiers
+3.3.2.  SPF-Authenticated Identifiers
 
    DMARC permits Identifier Alignment based on the result of an SPF
    authentication.  As with DKIM, Identifier Alignement can be either
@@ -652,6 +663,16 @@ Internet-Draft                  DMARCbis                   November 2021
    domain and RFC5322.From domain must be equal if the identifiers are
    to be considered to be aligned.  In strict mode, the two FQDNs must
    match exactly in order from them to be considered to be aligned.
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 12]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    For example, in relaxed mode, if a message passes an SPF check with
    an RFC5321.MailFrom domain of "cbg.bounces.example.com", and the
@@ -667,21 +688,14 @@ Internet-Draft                  DMARCbis                   November 2021
    [RFC7208], which recommends that SPF checks be done on not only the
    "MAIL FROM" but also on a separate check of the "HELO" identity.
 
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 12]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-3.14.3.  Alignment and Extension Technologies
+3.3.3.  Alignment and Extension Technologies
 
    If in the future DMARC is extended to include the use of other
    authentication mechanisms, the extensions will need to allow for
    domain identifier extraction so that alignment with the RFC5322.From
    domain can be verified.
 
-3.15.  Determining The Organizational Domain
+3.4.  Determining The Organizational Domain
 
    The Organizational Domain for a subject DNS domain name is defined as
    the domain that is found in the DNS hierarchy one level below the PSD
@@ -706,6 +720,16 @@ Internet-Draft                  DMARCbis                   November 2021
        "example.com", "com" would be label 1 and "example" would be
        label 2.
 
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 13]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    5.  Count the number of labels found in the subject DNS domain.  Let
        that number be "x".  If x < 5, remove the left-most (highest-
        numbered) label from the subject domain.  If x >= 5, remove the
@@ -719,16 +743,6 @@ Internet-Draft                  DMARCbis                   November 2021
 
    7.  Records that do not start with a "v=" tag that identifies the
        current version of DMARC are discarded.
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 13]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    8.  If the set is now empty, or the set contains one valid DMARC
        record that does not include a psd tag with the value of 'y',
@@ -764,6 +778,14 @@ Internet-Draft                  DMARCbis                   November 2021
    *  DKIM, [RFC6376], which provides a domain-level identifier in the
       content of the "d=" tag of a verified DKIM-Signature header field.
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 14]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    *  SPF, [RFC7208], which can authenticate both the domain found in an
       [RFC5321] HELO/EHLO command (the HELO identity) and the domain
       found in an SMTP MAIL command (the MAIL FROM identity).  As noted
@@ -776,15 +798,6 @@ Internet-Draft                  DMARCbis                   November 2021
 
    DMARC policies are published by the Domain Owner or PSO, and
    retrieved by the Mail Receiver during the SMTP session, via the DNS.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 14]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    DMARC's verification function is based on whether the RFC5322.From
    domain is aligned with an authenticated domain name from SPF or DKIM.
@@ -821,26 +834,15 @@ Internet-Draft                  DMARCbis                   November 2021
    2.  produces that result based on an identifier that is in alignment,
        as defined in Section 3.
 
-4.3.  Flow Diagram
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 15]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 15]
 
 Internet-Draft                  DMARCbis                   November 2021
 
+
+4.3.  Flow Diagram
 
     +---------------+                             +--------------------+
     | Author Domain |< . . . . . . . . . . . .    | Return-Path Domain |
@@ -891,9 +893,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-
-
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 16]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 16]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -943,19 +943,19 @@ Internet-Draft                  DMARCbis                   November 2021
    A Domain Owner or PSO advertises DMARC participation of one or more
    of its domains by adding a DNS TXT record (described in Section 6.1)
    to those domains.  In doing so, Domain Owners and PSOs indicate their
-   severity of concern regarding failed authentication for email
+   handling preference regarding failed authentication for email
    messages making use of their domain in the RFC5322.From header field
    as well as the provision of feedback about those messages.  Mail
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 17]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 17]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-   Receivers in turn can take into account the Domain Owner's severity
-   of concern when making handling decisions about email messages that
+   Receivers in turn can take into account the Domain Owner's stated
+   preference when making handling decisions about email messages that
    fail DMARC authentication checks.
 
    A Domain Owner or PSO may choose not to participate in DMARC
@@ -1005,7 +1005,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 18]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 18]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1043,7 +1043,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    adkim:  (plain-text; OPTIONAL; default is "r".)  Indicates whether
       strict or relaxed DKIM Identifier Alignment mode is required by
-      the Domain Owner.  See Section 3.14.1 for details.  Valid values
+      the Domain Owner.  See Section 3.3.1 for details.  Valid values
       are as follows:
 
       r:  relaxed mode
@@ -1052,8 +1052,8 @@ Internet-Draft                  DMARCbis                   November 2021
 
    aspf:  (plain-text; OPTIONAL; default is "r".)  Indicates whether
       strict or relaxed SPF Identifier Alignment mode is required by the
-      Domain Owner.  See Section 3.14.2 for details.  Valid values are
-      as follows:
+      Domain Owner.  See Section 3.3.2 for details.  Valid values are as
+      follows:
 
       r:  relaxed mode
 
@@ -1061,7 +1061,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 19]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 19]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1097,27 +1097,27 @@ Internet-Draft                  DMARCbis                   November 2021
       reporting is described in [@!RFC6652].
 
    np:  Domain Owner Assessment Policy for non-existent subdomains
-      (plain-text; OPTIONAL).  Indicates the severity of concern the
-      Domain Owner or PSO has for mail using non-existent subdomains of
-      the domain queried.  It applies only to non-existent subdomains of
-      the domain queried and not to either existing subdomains or the
-      domain itself.  Its syntax is identical to that of the "p" tag
-      defined below.  If the "np" tag is absent, the policy specified by
-      the "sp" tag (if the "sp" tag is present) or the policy specified
-      by the "p" tag, if the "sp" tag is not present, MUST be applied
-      for non-existent subdomains.  Note that "np" will be ignored for
-      DMARC records published on subdomains of Organizational Domains
-      and PSDs due to the effect of the DMARC policy discovery mechanism
-      described in Section 6.7.3.
+      (plain-text; OPTIONAL).  Indicates the message handling preference
+      that the Domain Owner or PSO has for mail using non-existent
+      subdomains of the domain queried.  It applies only to non-existent
+      subdomains of the domain queried and not to either existing
+      subdomains or the domain itself.  Its syntax is identical to that
+      of the "p" tag defined below.  If the "np" tag is absent, the
+      policy specified by the "sp" tag (if the "sp" tag is present) or
+      the policy specified by the "p" tag, if the "sp" tag is not
+      present, MUST be applied for non-existent subdomains.  Note that
+      "np" will be ignored for DMARC records published on subdomains of
+      Organizational Domains and PSDs due to the effect of the DMARC
+      policy discovery mechanism described in Section 6.7.3.
 
    p:  Domain Owner Assessment Policy (plain-text; RECOMMENDED for
-      policy records).  Indicates the severity of concern the Domain
-      Owner or PSO has for mail using its domain but not passing DMARC
-      verification.  Policy applies to the domain queried and to
+      policy records).  Indicates the message handling preference the
+      Domain Owner or PSO has for mail using its domain but not passing
+      DMARC verification.  Policy applies to the domain queried and to
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 20]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 20]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1173,7 +1173,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 21]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 21]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1188,17 +1188,17 @@ Internet-Draft                  DMARCbis                   November 2021
       considerations.
 
    sp:  Domain Owner Assessment Policy for all subdomains (plain-text;
-      OPTIONAL).  Indicates the severity of concern the Domain Owner or
-      PSO has for mail using an existing subdomain of the domain queried
-      but not passing DMARC verification.  It applies only to subdomains
-      of the domain queried and not to the domain itself.  Its syntax is
-      identical to that of the "p" tag defined above.  If both the "sp"
-      tag is absent and the "np" tag is either absent or not applicable,
-      the policy specified by the "p" tag MUST be applied for
-      subdomains.  Note that "sp" will be ignored for DMARC records
-      published on subdomains of Organizational Domains due to the
-      effect of the DMARC policy discovery mechanism described in
-      Section 6.7.3.
+      OPTIONAL).  Indicates the message handling preference the Domain
+      Owner or PSO has for mail using an existing subdomain of the
+      domain queried but not passing DMARC verification.  It applies
+      only to subdomains of the domain queried and not to the domain
+      itself.  Its syntax is identical to that of the "p" tag defined
+      above.  If both the "sp" tag is absent and the "np" tag is either
+      absent or not applicable, the policy specified by the "p" tag MUST
+      be applied for subdomains.  Note that "sp" will be ignored for
+      DMARC records published on subdomains of Organizational Domains
+      due to the effect of the DMARC policy discovery mechanism
+      described in Section 6.7.3.
 
    t:  DMARC policy test mode (plain-text; OPTIONAL; default is 'n').
       For the RFC5322.From domain to which the DMARC record applies, the
@@ -1229,7 +1229,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 22]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 22]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1285,7 +1285,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 23]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 23]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1341,7 +1341,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 24]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 24]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1397,7 +1397,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 25]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 25]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1453,7 +1453,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 26]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 26]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1509,7 +1509,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 27]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 27]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1565,7 +1565,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 28]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 28]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1621,7 +1621,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 29]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 29]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1655,8 +1655,8 @@ Internet-Draft                  DMARCbis                   November 2021
    illegitimate uses but also, and perhaps more importantly, all
    legitimate uses.  Domain Owners can use aggregate reports to ensure
    that all legitimate uses of their domain for sending email are
-   properly authenticated, and once they are, increase the severity of
-   concern expressed in the p= tag in their DMARC policy records from
+   properly authenticated, and once they are, express a stricter message
+   handling preference in the p= tag in their DMARC policy records from
    none to quarantine to reject, if appropriate.  In turn, DMARC policy
    records with p= tag values of 'quarantine' or 'reject' are higher
    value signals to Mail Receivers, ones that can assist Mail Receivers
@@ -1677,7 +1677,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 30]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 30]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1733,7 +1733,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 31]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 31]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1789,7 +1789,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 32]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 32]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1845,7 +1845,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 33]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 33]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1901,7 +1901,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 34]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 34]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1957,7 +1957,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 35]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 35]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2013,7 +2013,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 36]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 36]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2069,7 +2069,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 37]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 37]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2125,7 +2125,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 38]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 38]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2181,7 +2181,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 39]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 39]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2237,7 +2237,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 40]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 40]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2293,7 +2293,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 41]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 41]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2349,7 +2349,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 42]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 42]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2405,7 +2405,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 43]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 43]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2461,7 +2461,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 44]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 44]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2517,7 +2517,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 45]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 45]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2573,7 +2573,7 @@ A.2.  Method Exclusion
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 46]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 46]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2629,7 +2629,7 @@ A.3.  Sender Header Field
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 47]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 47]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2685,7 +2685,7 @@ A.5.  Issues with ADSP in Operation
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 48]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 48]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2730,7 +2730,7 @@ A.6.  Organizational Domain Discovery Issues
    constitutes an amplified denial-of-service attack.
 
    The Organizational Domain mechanism is a necessary component to the
-   goals of DMARC.  The method described in Section 3.15 is far from
+   goals of DMARC.  The method described in Section 3.4 is far from
    perfect but serves this purpose reasonably well without adding undue
    burden or semantics to the DNS.  If a method is created to do so that
    is more reliable and secure than the use of a public suffix list,
@@ -2741,7 +2741,7 @@ A.6.  Organizational Domain Discovery Issues
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 49]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 49]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2797,7 +2797,7 @@ A.7.  Removal of the "pct" Tag
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 50]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 50]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2853,7 +2853,7 @@ B.1.1.  SPF
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 51]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 51]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2909,7 +2909,7 @@ B.1.2.  DKIM
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 52]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 52]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2965,7 +2965,7 @@ B.2.1.  Entire Domain, Monitoring Only
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 53]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 53]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3021,7 +3021,7 @@ B.2.2.  Entire Domain, Monitoring Only, Per-Message Reports
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 54]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 54]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3077,7 +3077,7 @@ B.2.3.  Per-Message Failure Reports Directed to Third Party
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 55]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 55]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3133,7 +3133,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 56]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 56]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3145,7 +3145,7 @@ B.2.4.  Subdomain, Testing, and Multiple Aggregate Report URIs
 
    The Domain Owner has implemented SPF and DKIM in a subdomain used for
    pre-production testing of messaging services.  It now wishes to
-   express a severity of concern for messages from this subdomain that
+   express a handling preference for messages from this subdomain that
    fail to authenticate to indicate to participating receivers that use
    of this domain is not valid.
 
@@ -3189,7 +3189,7 @@ B.2.4.  Subdomain, Testing, and Multiple Aggregate Report URIs
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 57]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 57]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3245,7 +3245,7 @@ B.3.  Mail Receiver Example
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 58]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 58]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3301,7 +3301,7 @@ B.4.  Processing of SMTP Time
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 59]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 59]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3357,7 +3357,7 @@ B.5.  Utilization of Aggregate Feedback: Example
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 60]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 60]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3413,7 +3413,7 @@ C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 61]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 61]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3469,7 +3469,7 @@ C.6.1.  Ticket 7 - ABNF for dmarc-record is slightly wrong
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 62]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 62]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3525,7 +3525,7 @@ C.8.1.  Ticket 54 - Remove or expand limits on number of recipients per
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 63]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 63]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3581,7 +3581,7 @@ C.10.3.  Ticket 47 - Remove pct= tag
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 64]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 64]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3637,7 +3637,7 @@ C.13.  April 19, 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 65]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 65]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3693,7 +3693,7 @@ C.17.1.  Publication of draft-ietf-dmarc-dmarcbis-03
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 66]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 66]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3749,4 +3749,4 @@ Authors' Addresses
 
 
 
-Herr (ed) & Levine (ed)    Expires 21 May 2022                 [Page 67]
+Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 67]

--- a/draft-ietf-dmarc-dmarcbis-04.txt
+++ b/draft-ietf-dmarc-dmarcbis-04.txt
@@ -6,7 +6,7 @@ DMARC                                                       T. Herr (ed)
 Internet-Draft                                                  Valimail
 Obsoletes: 7489 (if approved)                             J. Levine (ed)
 Intended status: Standards Track                           Standcore LLC
-Expires: 22 May 2022                                    18 November 2021
+Expires: 26 May 2022                                    22 November 2021
 
 
 Domain-based Message Authentication, Reporting, and Conformance (DMARC)
@@ -41,7 +41,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 22 May 2022.
+   This Internet-Draft will expire on 26 May 2022.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 1]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 1]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -90,108 +90,107 @@ Table of Contents
        3.2.10. Public Suffix Operator (PSO)  . . . . . . . . . . . .  10
        3.2.11. PSO Controlled Domain Names . . . . . . . . . . . . .  10
        3.2.12. Report Receiver . . . . . . . . . . . . . . . . . . .  11
-     3.3.  More on Identifier Alignment  . . . . . . . . . . . . . .  11
-       3.3.1.  DKIM-Authenticated Identifiers  . . . . . . . . . . .  12
-       3.3.2.  SPF-Authenticated Identifiers . . . . . . . . . . . .  12
-       3.3.3.  Alignment and Extension Technologies  . . . . . . . .  13
-     3.4.  Determining The Organizational Domain . . . . . . . . . .  13
-   4.  Overview  . . . . . . . . . . . . . . . . . . . . . . . . . .  14
-     4.1.  Authentication Mechanisms . . . . . . . . . . . . . . . .  14
-     4.2.  Key Concepts  . . . . . . . . . . . . . . . . . . . . . .  15
-     4.3.  Flow Diagram  . . . . . . . . . . . . . . . . . . . . . .  16
-   5.  Use of RFC5322.From . . . . . . . . . . . . . . . . . . . . .  17
-   6.  Policy  . . . . . . . . . . . . . . . . . . . . . . . . . . .  17
-     6.1.  DMARC Policy Record . . . . . . . . . . . . . . . . . . .  18
-     6.2.  DMARC URIs  . . . . . . . . . . . . . . . . . . . . . . .  19
-     6.3.  General Record Format . . . . . . . . . . . . . . . . . .  19
-     6.4.  Formal Definition . . . . . . . . . . . . . . . . . . . .  23
-     6.5.  Domain Owner Actions  . . . . . . . . . . . . . . . . . .  24
+   4.  Overview and Key Concepts . . . . . . . . . . . . . . . . . .  11
+     4.1.  Use of RFC5322.From . . . . . . . . . . . . . . . . . . .  12
+     4.2.  Authentication Mechanisms . . . . . . . . . . . . . . . .  13
+     4.3.  Flow Diagram  . . . . . . . . . . . . . . . . . . . . . .  13
+     4.4.  Identifier Alignment Explained  . . . . . . . . . . . . .  15
+       4.4.1.  DKIM-Authenticated Identifiers  . . . . . . . . . . .  15
+       4.4.2.  SPF-Authenticated Identifiers . . . . . . . . . . . .  16
+       4.4.3.  Alignment and Extension Technologies  . . . . . . . .  16
+     4.5.  Determining The Organizational Domain . . . . . . . . . .  17
+   5.  Policy  . . . . . . . . . . . . . . . . . . . . . . . . . . .  18
+     5.1.  DMARC Policy Record . . . . . . . . . . . . . . . . . . .  19
+     5.2.  DMARC URIs  . . . . . . . . . . . . . . . . . . . . . . .  19
+     5.3.  General Record Format . . . . . . . . . . . . . . . . . .  19
+     5.4.  Formal Definition . . . . . . . . . . . . . . . . . . . .  24
+     5.5.  Domain Owner Actions  . . . . . . . . . . . . . . . . . .  25
+       5.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  25
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 2]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 2]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-       6.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  24
-       6.5.2.  Configure Sending System for DKIM Signing Using an
-               Aligned Domain  . . . . . . . . . . . . . . . . . . .  24
-       6.5.3.  Setup a Mailbox to Receive Aggregate Reports  . . . .  25
-       6.5.4.  Publish a DMARC Policy for the Author Domain  . . . .  25
-       6.5.5.  Collect and Analyze Reports and Adjust
-               Authentication  . . . . . . . . . . . . . . . . . . .  25
-       6.5.6.  Decide If and When to Update DMARC Policy . . . . . .  26
-     6.6.  PSO Actions . . . . . . . . . . . . . . . . . . . . . . .  26
-     6.7.  Mail Receiver Actions . . . . . . . . . . . . . . . . . .  26
-       6.7.1.  Extract Author Domain . . . . . . . . . . . . . . . .  26
-       6.7.2.  Determine Handling Policy . . . . . . . . . . . . . .  27
-       6.7.3.  Policy Discovery  . . . . . . . . . . . . . . . . . .  28
-       6.7.4.  Store Results of DMARC Processing . . . . . . . . . .  30
-       6.7.5.  Send Aggregate Reports  . . . . . . . . . . . . . . .  30
-     6.8.  Policy Enforcement Considerations . . . . . . . . . . . .  31
-   7.  DMARC Feedback  . . . . . . . . . . . . . . . . . . . . . . .  32
-   8.  Other Topics  . . . . . . . . . . . . . . . . . . . . . . . .  32
-     8.1.  Issues Specific to SPF  . . . . . . . . . . . . . . . . .  32
-     8.2.  DNS Load and Caching  . . . . . . . . . . . . . . . . . .  33
-     8.3.  Rejecting Messages  . . . . . . . . . . . . . . . . . . .  33
-     8.4.  Identifier Alignment Considerations . . . . . . . . . . .  34
-     8.5.  Interoperability Issues . . . . . . . . . . . . . . . . .  34
-   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  35
-     9.1.  Authentication-Results Method Registry Update . . . . . .  35
-     9.2.  Authentication-Results Result Registry Update . . . . . .  36
-     9.3.  Feedback Report Header Fields Registry Update . . . . . .  37
-     9.4.  DMARC Tag Registry  . . . . . . . . . . . . . . . . . . .  37
-     9.5.  DMARC Report Format Registry  . . . . . . . . . . . . . .  39
-     9.6.  Underscored and Globally Scoped DNS Node Names
-           Registry  . . . . . . . . . . . . . . . . . . . . . . . .  39
-   10. Security Considerations . . . . . . . . . . . . . . . . . . .  39
-     10.1.  Authentication Methods . . . . . . . . . . . . . . . . .  40
-     10.2.  Attacks on Reporting URIs  . . . . . . . . . . . . . . .  40
-     10.3.  DNS Security . . . . . . . . . . . . . . . . . . . . . .  40
-     10.4.  Display Name Attacks . . . . . . . . . . . . . . . . . .  41
-     10.5.  External Reporting Addresses . . . . . . . . . . . . . .  42
-     10.6.  Secure Protocols . . . . . . . . . . . . . . . . . . . .  42
-   11. Normative References  . . . . . . . . . . . . . . . . . . . .  42
-   12. Informative References  . . . . . . . . . . . . . . . . . . .  44
+       5.5.2.  Configure Sending System for DKIM Signing Using an
+               Aligned Domain  . . . . . . . . . . . . . . . . . . .  25
+       5.5.3.  Setup a Mailbox to Receive Aggregate Reports  . . . .  25
+       5.5.4.  Publish a DMARC Policy for the Author Domain  . . . .  26
+       5.5.5.  Collect and Analyze Reports and Adjust
+               Authentication  . . . . . . . . . . . . . . . . . . .  26
+       5.5.6.  Decide If and When to Update DMARC Policy . . . . . .  26
+     5.6.  PSO Actions . . . . . . . . . . . . . . . . . . . . . . .  26
+     5.7.  Mail Receiver Actions . . . . . . . . . . . . . . . . . .  27
+       5.7.1.  Extract Author Domain . . . . . . . . . . . . . . . .  27
+       5.7.2.  Determine Handling Policy . . . . . . . . . . . . . .  27
+       5.7.3.  Policy Discovery  . . . . . . . . . . . . . . . . . .  29
+       5.7.4.  Store Results of DMARC Processing . . . . . . . . . .  31
+       5.7.5.  Send Aggregate Reports  . . . . . . . . . . . . . . .  31
+     5.8.  Policy Enforcement Considerations . . . . . . . . . . . .  31
+   6.  DMARC Feedback  . . . . . . . . . . . . . . . . . . . . . . .  32
+   7.  Other Topics  . . . . . . . . . . . . . . . . . . . . . . . .  33
+     7.1.  Issues Specific to SPF  . . . . . . . . . . . . . . . . .  33
+     7.2.  DNS Load and Caching  . . . . . . . . . . . . . . . . . .  33
+     7.3.  Rejecting Messages  . . . . . . . . . . . . . . . . . . .  34
+     7.4.  Identifier Alignment Considerations . . . . . . . . . . .  35
+     7.5.  Interoperability Issues . . . . . . . . . . . . . . . . .  35
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  35
+     8.1.  Authentication-Results Method Registry Update . . . . . .  35
+     8.2.  Authentication-Results Result Registry Update . . . . . .  36
+     8.3.  Feedback Report Header Fields Registry Update . . . . . .  37
+     8.4.  DMARC Tag Registry  . . . . . . . . . . . . . . . . . . .  38
+     8.5.  DMARC Report Format Registry  . . . . . . . . . . . . . .  39
+     8.6.  Underscored and Globally Scoped DNS Node Names
+           Registry  . . . . . . . . . . . . . . . . . . . . . . . .  40
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  40
+     9.1.  Authentication Methods  . . . . . . . . . . . . . . . . .  40
+     9.2.  Attacks on Reporting URIs . . . . . . . . . . . . . . . .  41
+     9.3.  DNS Security  . . . . . . . . . . . . . . . . . . . . . .  41
+     9.4.  Display Name Attacks  . . . . . . . . . . . . . . . . . .  42
+     9.5.  External Reporting Addresses  . . . . . . . . . . . . . .  42
+     9.6.  Secure Protocols  . . . . . . . . . . . . . . . . . . . .  43
+   10. Normative References  . . . . . . . . . . . . . . . . . . . .  43
+   11. Informative References  . . . . . . . . . . . . . . . . . . .  45
    Appendix A.  Technology Considerations  . . . . . . . . . . . . .  46
-     A.1.  S/MIME  . . . . . . . . . . . . . . . . . . . . . . . . .  46
-     A.2.  Method Exclusion  . . . . . . . . . . . . . . . . . . . .  46
-     A.3.  Sender Header Field . . . . . . . . . . . . . . . . . . .  47
+     A.1.  S/MIME  . . . . . . . . . . . . . . . . . . . . . . . . .  47
+     A.2.  Method Exclusion  . . . . . . . . . . . . . . . . . . . .  47
+     A.3.  Sender Header Field . . . . . . . . . . . . . . . . . . .  48
      A.4.  Domain Existence Test . . . . . . . . . . . . . . . . . .  48
-     A.5.  Issues with ADSP in Operation . . . . . . . . . . . . . .  48
-     A.6.  Organizational Domain Discovery Issues  . . . . . . . . .  49
+     A.5.  Issues with ADSP in Operation . . . . . . . . . . . . . .  49
+     A.6.  Organizational Domain Discovery Issues  . . . . . . . . .  50
        A.6.1.  Public Suffix Lists . . . . . . . . . . . . . . . . .  50
+     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  51
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 3]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 3]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  50
-   Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  51
-     B.1.  Identifier Alignment Examples . . . . . . . . . . . . . .  51
-       B.1.1.  SPF . . . . . . . . . . . . . . . . . . . . . . . . .  51
-       B.1.2.  DKIM  . . . . . . . . . . . . . . . . . . . . . . . .  52
-     B.2.  Domain Owner Example  . . . . . . . . . . . . . . . . . .  53
-       B.2.1.  Entire Domain, Monitoring Only  . . . . . . . . . . .  53
+   Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  52
+     B.1.  Identifier Alignment Examples . . . . . . . . . . . . . .  52
+       B.1.1.  SPF . . . . . . . . . . . . . . . . . . . . . . . . .  52
+       B.1.2.  DKIM  . . . . . . . . . . . . . . . . . . . . . . . .  53
+     B.2.  Domain Owner Example  . . . . . . . . . . . . . . . . . .  54
+       B.2.1.  Entire Domain, Monitoring Only  . . . . . . . . . . .  54
        B.2.2.  Entire Domain, Monitoring Only, Per-Message
-               Reports . . . . . . . . . . . . . . . . . . . . . . .  54
+               Reports . . . . . . . . . . . . . . . . . . . . . . .  55
        B.2.3.  Per-Message Failure Reports Directed to Third
-               Party . . . . . . . . . . . . . . . . . . . . . . . .  55
+               Party . . . . . . . . . . . . . . . . . . . . . . . .  56
        B.2.4.  Subdomain, Testing, and Multiple Aggregate Report
                URIs  . . . . . . . . . . . . . . . . . . . . . . . .  57
-     B.3.  Mail Receiver Example . . . . . . . . . . . . . . . . . .  58
+     B.3.  Mail Receiver Example . . . . . . . . . . . . . . . . . .  59
      B.4.  Processing of SMTP Time . . . . . . . . . . . . . . . . .  59
-     B.5.  Utilization of Aggregate Feedback: Example  . . . . . . .  60
+     B.5.  Utilization of Aggregate Feedback: Example  . . . . . . .  61
    Appendix C.  Change Log . . . . . . . . . . . . . . . . . . . . .  61
      C.1.  January 5, 2021 . . . . . . . . . . . . . . . . . . . . .  61
        C.1.1.  Ticket 80 - DMARCbis SHould Have Clear and Concise
                Defintion of DMARC  . . . . . . . . . . . . . . . . .  61
-     C.2.  February 4, 2021  . . . . . . . . . . . . . . . . . . . .  61
-       C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208 . . . . . . . . . . .  61
+     C.2.  February 4, 2021  . . . . . . . . . . . . . . . . . . . .  62
+       C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208 . . . . . . . . . . .  62
      C.3.  February 10, 2021 . . . . . . . . . . . . . . . . . . . .  62
        C.3.1.  Ticket 84 - Remove Erroneous References to RFC3986  .  62
      C.4.  March 1, 2021 . . . . . . . . . . . . . . . . . . . . . .  62
@@ -199,38 +198,37 @@ Internet-Draft                  DMARCbis                   November 2021
      C.5.  March 8, 2021 . . . . . . . . . . . . . . . . . . . . . .  62
        C.5.1.  Removed E.  Gustafsson as editor  . . . . . . . . . .  62
        C.5.2.  Ticket 3 - Two tiny nits  . . . . . . . . . . . . . .  62
-       C.5.3.  Ticket 4 - Definition of "fo" parameter . . . . . . .  62
-     C.6.  March 16, 2021  . . . . . . . . . . . . . . . . . . . . .  62
-       C.6.1.  Ticket 7 - ABNF for dmarc-record is slightly wrong  .  62
+       C.5.3.  Ticket 4 - Definition of "fo" parameter . . . . . . .  63
+     C.6.  March 16, 2021  . . . . . . . . . . . . . . . . . . . . .  63
+       C.6.1.  Ticket 7 - ABNF for dmarc-record is slightly wrong  .  63
        C.6.2.  Ticket 26 - ABNF for pct allows "999" . . . . . . . .  63
      C.7.  March 23, 2021  . . . . . . . . . . . . . . . . . . . . .  63
        C.7.1.  Ticket 75 - Using wording alternatives to
                'disposition', 'dispose', and the like  . . . . . . .  63
        C.7.2.  Ticket 72 - Remove absolute requirement for p= tag in
                DMARC record  . . . . . . . . . . . . . . . . . . . .  63
-     C.8.  March 29, 2021  . . . . . . . . . . . . . . . . . . . . .  63
+     C.8.  March 29, 2021  . . . . . . . . . . . . . . . . . . . . .  64
        C.8.1.  Ticket 54 - Remove or expand limits on number of
-               recipients per report . . . . . . . . . . . . . . . .  63
+               recipients per report . . . . . . . . . . . . . . . .  64
      C.9.  April 12, 2021  . . . . . . . . . . . . . . . . . . . . .  64
        C.9.1.  Ticket 50 - Remove ri= tag  . . . . . . . . . . . . .  64
        C.9.2.  Ticket 66 - Define what it means to have implemented
                DMARC . . . . . . . . . . . . . . . . . . . . . . . .  64
        C.9.3.  Ticket 96 - Tweaks to Abstract and Introduction . . .  64
      C.10. April 13, 2021  . . . . . . . . . . . . . . . . . . . . .  64
+       C.10.1.  Ticket 53 - Remove reporting message size
+               chunking  . . . . . . . . . . . . . . . . . . . . . .  64
 
 
 
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 4]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 4]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-       C.10.1.  Ticket 53 - Remove reporting message size
-               chunking  . . . . . . . . . . . . . . . . . . . . . .  64
        C.10.2.  Ticket 52 - Remove strict alignment (and adkim and
                aspf tags)  . . . . . . . . . . . . . . . . . . . . .  64
-       C.10.3.  Ticket 47 - Remove pct= tag  . . . . . . . . . . . .  64
+       C.10.3.  Ticket 47 - Remove pct= tag  . . . . . . . . . . . .  65
        C.10.4.  Ticket 2 - Flow of operations text in dmarc-base . .  65
      C.11. April 14, 2021  . . . . . . . . . . . . . . . . . . . . .  65
        C.11.1.  Ticket 107 - DMARCbis should take a stand on
@@ -241,8 +239,8 @@ Internet-Draft                  DMARCbis                   November 2021
      C.12. April 15, 2021  . . . . . . . . . . . . . . . . . . . . .  65
        C.12.1.  Ticket 86 - A-R results for DMARC  . . . . . . . . .  65
        C.12.2.  Ticket 62 - Make aggregate reporting a normative
-               MUST  . . . . . . . . . . . . . . . . . . . . . . . .  65
-     C.13. April 19, 2021  . . . . . . . . . . . . . . . . . . . . .  65
+               MUST  . . . . . . . . . . . . . . . . . . . . . . . .  66
+     C.13. April 19, 2021  . . . . . . . . . . . . . . . . . . . . .  66
        C.13.1.  Ticket 109 - Sanity Check DMARCbis Document  . . . .  66
      C.14. April 20, 2021  . . . . . . . . . . . . . . . . . . . . .  66
        C.14.1.  Ticket 108 - Changes to DMARCbis for PSD . . . . . .  66
@@ -277,7 +275,9 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 5]
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 5]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -333,7 +333,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 6]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 6]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -341,7 +341,7 @@ Internet-Draft                  DMARCbis                   November 2021
    Use of DMARC creates some interoperability challenges that require
    due consideration before deployment, particularly with configurations
    that can cause mail to be rejected.  These are discussed in
-   Section 8.
+   Section 7.
 
 2.  Requirements
 
@@ -389,7 +389,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 7]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 7]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -445,7 +445,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 8]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 8]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -476,7 +476,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    Domain-level identifiers that are verified using authentication
    technologies are referred to as "Authenticated Identifiers".  See
-   Section 4.1 for details about the supported mechanisms.
+   Section 4.2 for details about the supported mechanisms.
 
 3.2.2.  Author Domain
 
@@ -501,7 +501,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                  [Page 9]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 9]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -531,10 +531,10 @@ Internet-Draft                  DMARCbis                   November 2021
 3.2.8.  Organizational Domain
 
    The Organizational Domain is typically a domain that was registered
-   with a domain name registrar.  More formally, it is a Public Suffix
+   with a domain name registrar.  More formally, it is any Public Suffix
    Domain plus one label.  The Organizational Domain for the domain in
    the RFC5322.From domain is determined by applying the algorithm found
-   in Section 3.4.
+   in Section 4.5.
 
 3.2.9.  Public Suffix Domain (PSD)
 
@@ -557,7 +557,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 10]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 10]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -573,218 +573,119 @@ Internet-Draft                  DMARCbis                   November 2021
    collectively to the system components that receive and process these
    reports and the organizations that operate them.
 
-3.3.  More on Identifier Alignment
-
-   Email authentication technologies authenticate various (and
-   disparate) aspects of an individual message.  For example, DKIM
-   [RFC6376] authenticates the domain that affixed a signature to the
-   message, while SPF [RFC7208] can authenticate either the domain that
-   appears in the RFC5321.MailFrom (MAIL FROM) portion of an SMTP
-   [RFC5321] conversation or the RFC5321.EHLO/HELO domain, or both.
-   These may be different domains, and they are typically not visible to
-   the end user.
-
-   DMARC authenticates use of the RFC5322.From domain by requiring that
-   it have the same Organizational Domain as (i.e., be aligned with) an
-   Authenticated Identifier.  Domain names in this context are to be
-   compared in a case-insensitive manner, per [RFC4343].  The
-   RFC5322.From domain was selected as the central identity of the DMARC
-   mechanism because it is a required message header field and therefore
-   guaranteed to be present in compliant messages, and most Mail User
-   Agents (MUAs) represent the RFC5322.From header field as the
-   originator of the message and render some or all of this header
-   field's content to end users.
-
-   It is important to note that Identifier Alignment cannot occur with a
-   message that is not valid per [RFC5322], particularly one with a
-   malformed, absent, or repeated RFC5322.From header field, since in
-   that case there is no reliable way to determine a DMARC policy that
-   applies to the message.  Accordingly, DMARC operation is predicated
-   on the input being a valid RFC5322 message object, and handling of
-   such non-compliant cases is outside of the scope of this
-   specification.  Further discussion of this can be found in
-   Section 6.7.1.
-
-   Each of the underlying authentication technologies that DMARC takes
-   as input yields authenticated domains as their outputs when they
-   succeed.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 11]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-3.3.1.  DKIM-Authenticated Identifiers
-
-   DMARC requires Identifier Alignment based on the result of a DKIM
-   authentication because a message can bear a valid signature from any
-   domain, including domains used by a mailing list or even a bad actor.
-   Therefore, merely bearing a valid signature is not enough to infer
-   authenticity of the Author Domain.
-
-   DMARC permits Identifier Alignment based on the result of a DKIM
-   authentication to be strict or relaxed.  (Note that these terms are
-   not related to DKIM's "simple" and "relaxed" canonicalization modes.)
-
-   In relaxed mode, the Organizational Domains of both the DKIM-
-   authenticated signing domain (taken from the value of the d= tag in
-   the signature) and that of the RFC5322.From domain must be equal if
-   the identifiers are to be considered to be aligned.  In strict mode,
-   only an exact match between both Fully Qualified Domain Names (FQDNs)
-   is considered to produce Identifier Alignment.
-
-   To illustrate, in relaxed mode, if a verified DKIM signature
-   successfully verifies with a "d=" domain of "example.com", and the
-   RFC5322.From address is "alerts@news.example.com", the DKIM "d="
-   domain and the RFC5322.From domain are considered to be "in
-   alignment", because both domains have the same Organizational Domain
-   of "example.com".  In strict mode, this test would fail because the
-   d= domain does not exactly match the RFC5322.From domain.
-
-   However, a DKIM signature bearing a value of "d=com" would never
-   allow an "in alignment" result, as "com" should be identified as a
-   PSD and therefore cannot be an Organizational Domain.
-
-   Note that a single email can contain multiple DKIM signatures, and it
-   is considered to produce a DMARC "pass" result if any DKIM signature
-   is aligned and verifies.
-
-3.3.2.  SPF-Authenticated Identifiers
-
-   DMARC permits Identifier Alignment based on the result of an SPF
-   authentication.  As with DKIM, Identifier Alignement can be either
-   strict or relaxed.
-
-   In relaxed mode, the Organizational Domains of the SPF-authenticated
-   domain and RFC5322.From domain must be equal if the identifiers are
-   to be considered to be aligned.  In strict mode, the two FQDNs must
-   match exactly in order from them to be considered to be aligned.
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 12]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-   For example, in relaxed mode, if a message passes an SPF check with
-   an RFC5321.MailFrom domain of "cbg.bounces.example.com", and the
-   address portion of the RFC5322.From header field contains
-   "payments@example.com", the Authenticated RFC5321.MailFrom domain
-   identifier and the RFC5322.From domain are considered to be "in
-   alignment" because they have the same Organizational Domain
-   ("example.com").  In strict mode, this test would fail because the
-   two domains are not identical.
-
-   The reader should note that SPF alignment checks in DMARC rely solely
-   on the RFC5321.MailFrom domain.  This differs from section 2.3 of
-   [RFC7208], which recommends that SPF checks be done on not only the
-   "MAIL FROM" but also on a separate check of the "HELO" identity.
-
-3.3.3.  Alignment and Extension Technologies
-
-   If in the future DMARC is extended to include the use of other
-   authentication mechanisms, the extensions will need to allow for
-   domain identifier extraction so that alignment with the RFC5322.From
-   domain can be verified.
-
-3.4.  Determining The Organizational Domain
-
-   The Organizational Domain for a subject DNS domain name is defined as
-   the domain that is found in the DNS hierarchy one level below the PSD
-   in the subject DNS domain name.  The Organizational Domain is
-   determined using the following algorithm, similar to the one
-   described in Section 6.7.3
-
-   1.  Query the DNS for a DMARC TXT record at the DNS domain matching
-       the one found in the RFC5322.From domain in the message.  A
-       possibly empty set of records is returned.
-
-   2.  Records that do not start with a "v=" tag that identifies the
-       current version of DMARC are discarded.
-
-   3.  If the set is now empty, or the set contains one valid DMARC
-       record that does not include a psd tag with a value of 'y', then
-       determine the target for additional queries, using steps 4
-       through 8 below.
-
-   4.  Break the subject DNS domain name into a set of "n" ordered
-       labels.  Number these labels from right to left; e.g., for
-       "example.com", "com" would be label 1 and "example" would be
-       label 2.
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 13]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-   5.  Count the number of labels found in the subject DNS domain.  Let
-       that number be "x".  If x < 5, remove the left-most (highest-
-       numbered) label from the subject domain.  If x >= 5, remove the
-       left-most (highest-numbered) labels from the subject domain until
-       4 labels remain.  The resulting DNS domain name is the new target
-       for subsequent lookups.
-
-   6.  Query the DNS for a DMARC TXT record at the DNS domain matching
-       this new target in place of the RFC5322.From domain in the
-       message.  A possibly empty set of records is returned.
-
-   7.  Records that do not start with a "v=" tag that identifies the
-       current version of DMARC are discarded.
-
-   8.  If the set is now empty, or the set contains one valid DMARC
-       record that does not include a psd tag with the value of 'y',
-       then determine the target for additional queries by removing a
-       single label from the target domain as described in step 5 and
-       repeating steps 6 and 7 until there are no more labels remaining
-       or a record containing a psd tag with a value of 'y' is found.
-
-   9.  Once a valid DMARC record containing a psd tag with a value of
-       'y' has been found, the Organizational Domain for the DNS domain
-       matching the one found in the RFC5322.From domain can be declared
-       to be the target domain queried for in the step prior to the
-       query that found the PSD domain.
-
-   For example, given the RFC5322.From domain "a.mail.example.com", a
-   series of DNS queries for DMARC records would be executed starting
-   with "_dmarc.a.mail.example.com" and finishing with "_dmarc.com".
-   The "_dmarc.com" record would contain a psd tag with a value of 'y',
-   and so the Organizational Domain for this RFC5322.From domain would
-   be determined to be "example.com", the domain of the DMARC query
-   executed prior to the query for "_dmarc.com".
-
-4.  Overview
+4.  Overview and Key Concepts
 
    This section provides a general overview of the design and operation
    of the DMARC environment.
 
-4.1.  Authentication Mechanisms
+   DMARC permits a Domain Owner or PSO to enable verification of a
+   domain's use in an email message, to indicate the Domain Owner's or
+   PSO's message handling preference regarding failed verification, and
+   to request reports about use of the domain name.  All information
+   about a Domain Owner's or PSO's DMARC policy is published and
+   retrieved via the DNS.
+
+   DMARC's verification function is based on whether the RFC5322.From
+   domain is aligned with a domain name used in a supported
+   authentication mechanism.  Section 4.2 When a DMARC policy exists for
+   the domain name found in the RFC5322.From header field, and that
+   domain name is not verified through an aligned supported
+   authentication mechanism, the handling of that message can be
+   affected based on the DMARC policy when delivered to a participating
+   receiver.
+
+   A message satisfies the DMARC checks if at least one of the supported
+   authentication mechanisms:
+
+   1.  produces a "pass" result, and
+
+   2.  produces that result based on an identifier that is in alignment,
+       as described in Section 4.4.
+
+   It is important to note that the authentication mechanisms employed
+   by DMARC authenticate only a DNS domain and do not authenticate the
+   local-part of any email address identifier found in a message, nor do
+   they validate the legitimacy of message content.
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 11]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+   DMARC's feedback component involves the collection of information
+   about received messages claiming to be from the Author Domain for
+   periodic aggregate reports to the Domain Owner or PSO.  The
+   parameters and format for such reports are discussed in
+   [DMARC-Aggregate-Reporting]
+
+   A DMARC-enabled Mail Receiver might also generate per-message reports
+   that contain information related to individual messages that fail
+   authentication checks.  Per-message failure reports are a useful
+   source of information when debugging deployments (if messages can be
+   determined to be legitimate even though failing authentication) or in
+   analyzing attacks.  The capability for such services is enabled by
+   DMARC but defined in other referenced material such as [RFC6591] and
+   [DMARC-Failure-Reporting]
+
+4.1.  Use of RFC5322.From
+
+   One of the most obvious points of security scrutiny for DMARC is the
+   choice to focus on an identifier, namely the RFC5322.From address,
+   which is part of a body of data that has been trivially forged
+   throughout the history of email.  This field is the one used by end
+   users to identify the source of the message, and so it has always
+   been a prime target for abuse through such forgery and other means.
+
+   Several points suggest that it is the most correct and safest thing
+   to do in this context:
+
+   *  Of all the identifiers that are part of the message itself, this
+      is the only one guaranteed to be present.
+
+   *  It seems the best choice of an identifier on which to focus, as
+      most MUAs display some or all of the contents of that field in a
+      manner strongly suggesting those data as reflective of the true
+      originator of the message.
+
+   *  Many high-profile email sources, such as email service providers,
+      require that the sending agent have authenticated before email can
+      be generated.  Thus, for these mailboxes, the mechanism described
+      in this document provides recipient end users with strong evidence
+      that the message was indeed originated by the agent they associate
+      with that mailbox, if the end user knows that these various
+      protections have been provided.
+
+   The absence of a single, properly formed RFC5322.From header field
+   renders the message invalid.  Handling of such a message is outside
+   of the scope of this specification.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 12]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+   Since the sorts of mail typically protected by DMARC participants
+   tend to only have single Authors, DMARC participants generally
+   operate under a slightly restricted profile of RFC5322 with respect
+   to the expected syntax of this field.  See Section 5.7 for details.
+
+4.2.  Authentication Mechanisms
 
    The following mechanisms for determining Authenticated Identifiers
    are supported in this version of DMARC:
 
    *  DKIM, [RFC6376], which provides a domain-level identifier in the
       content of the "d=" tag of a verified DKIM-Signature header field.
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 14]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    *  SPF, [RFC7208], which can authenticate both the domain found in an
       [RFC5321] HELO/EHLO command (the HELO identity) and the domain
@@ -794,55 +695,40 @@ Internet-Draft                  DMARCbis                   November 2021
       describes MAIL FROM processing for cases in which the MAIL command
       has a null path.
 
-4.2.  Key Concepts
-
-   DMARC policies are published by the Domain Owner or PSO, and
-   retrieved by the Mail Receiver during the SMTP session, via the DNS.
-
-   DMARC's verification function is based on whether the RFC5322.From
-   domain is aligned with an authenticated domain name from SPF or DKIM.
-   When a DMARC policy is published for the domain name found in the
-   RFC5322.From header field, and that domain name is not verified
-   through SPF or DKIM, the handling of that message can be affected by
-   that DMARC policy when delivered to a participating receiver.
-
-   It is important to note that the authentication mechanisms employed
-   by DMARC authenticate only a DNS domain and do not authenticate the
-   local-part of any email address identifier found in a message, nor do
-   they validate the legitimacy of message content.
-
-   DMARC's feedback component involves the collection of information
-   about received messages claiming to be from the Author Domain for
-   periodic aggregate reports to the Domain Owner or PSO.  The
-   parameters and format for such reports are discussed in
-   [DMARC-Aggregate-Reporting]
-
-   A DMARC-enabled Mail Receiver might also generate per-message reports
-   that contain information related to individual messages that fail SPF
-   and/or DKIM.  Per-message failure reports are a useful source of
-   information when debugging deployments (if messages can be determined
-   to be legitimate even though failing authentication) or in analyzing
-   attacks.  The capability for such services is enabled by DMARC but
-   defined in other referenced material such as [RFC6591] and
-   [DMARC-Failure-Reporting]
-
-   A message satisfies the DMARC checks if at least one of the supported
-   authentication mechanisms:
-
-   1.  produces a "pass" result, and
-
-   2.  produces that result based on an identifier that is in alignment,
-       as defined in Section 3.
+4.3.  Flow Diagram
 
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 15]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 13]
 
 Internet-Draft                  DMARCbis                   November 2021
 
-
-4.3.  Flow Diagram
 
     +---------------+                             +--------------------+
     | Author Domain |< . . . . . . . . . . . .    | Return-Path Domain |
@@ -882,78 +768,217 @@ Internet-Draft                  DMARCbis                   November 2021
    receiving MTA.
 
    Put simply, when a message reaches a DMARC-aware rMTA, a DNS query
-   will be initiated to determine if the author domain has published a
-   DMARC policy.  If a policy is found, the rMTA will use the results of
-   SPF and DKIM verification checks to determine the ultimate DMARC
-   authentication status.  The DMARC status can then factor into the
-   message handling decision made by the recipient's mail sytsem.
+   will be initiated to determine if a DMARC policy exists that applies
+   to the author domain.  If a policy is found, the rMTA will use the
+   results of SPF and DKIM verification checks to determine the ultimate
+   DMARC authentication status.  The DMARC status can then factor into
+   the message handling decision made by the recipient's mail sytsem.
 
    More details on specific actions for the parties involved can be
-   found in Section 6.5 and Section 6.7.
+   found in Section 5.5 and Section 5.7.
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 16]
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 14]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-5.  Use of RFC5322.From
+4.4.  Identifier Alignment Explained
 
-   One of the most obvious points of security scrutiny for DMARC is the
-   choice to focus on an identifier, namely the RFC5322.From address,
-   which is part of a body of data that has been trivially forged
-   throughout the history of email.  This field is the one used by end
-   users to identify the source of the message, and so it has always
-   been a prime target for abuse through such forgery and other means.
+   Email authentication technologies authenticate various (and
+   disparate) aspects of an individual message.  For example, DKIM
+   [RFC6376] authenticates the domain that affixed a signature to the
+   message, while SPF [RFC7208] can authenticate either the domain that
+   appears in the RFC5321.MailFrom (MAIL FROM) portion of an SMTP
+   [RFC5321] conversation or the RFC5321.EHLO/HELO domain, or both.
+   These may be different domains, and they are typically not visible to
+   the end user.
 
-   Several points suggest that it is the most correct and safest thing
-   to do in this context:
+   DMARC authenticates use of the RFC5322.From domain by requiring that
+   it have the same Organizational Domain as (i.e., be aligned with) an
+   Authenticated Identifier.  Domain names in this context are to be
+   compared in a case-insensitive manner, per [RFC4343].
 
-   *  Of all the identifiers that are part of the message itself, this
-      is the only one guaranteed to be present.
+   It is important to note that Identifier Alignment cannot occur with a
+   message that is not valid per [RFC5322], particularly one with a
+   malformed, absent, or repeated RFC5322.From header field, since in
+   that case there is no reliable way to determine a DMARC policy that
+   applies to the message.  Accordingly, DMARC operation is predicated
+   on the input being a valid RFC5322 message object, and handling of
+   such non-compliant cases is outside of the scope of this
+   specification.  Further discussion of this can be found in
+   Section 5.7.1.
 
-   *  It seems the best choice of an identifier on which to focus, as
-      most MUAs display some or all of the contents of that field in a
-      manner strongly suggesting those data as reflective of the true
-      originator of the message.
+   Each of the underlying authentication technologies that DMARC takes
+   as input yields authenticated domains as their outputs when they
+   succeed.
 
-   *  Many high-profile email sources, such as email service providers,
-      require that the sending agent have authenticated before email can
-      be generated.  Thus, for these mailboxes, the mechanism described
-      in this document provides recipient end users with strong evidence
-      that the message was indeed originated by the agent they associate
-      with that mailbox, if the end user knows that these various
-      protections have been provided.
+4.4.1.  DKIM-Authenticated Identifiers
 
-   The absence of a single, properly formed RFC5322.From header field
-   renders the message invalid.  Handling of such a message is outside
-   of the scope of this specification.
+   DMARC requires Identifier Alignment based on the result of a DKIM
+   authentication because a message can bear a valid signature from any
+   domain, including domains used by a mailing list or even a bad actor.
+   Therefore, merely bearing a valid signature is not enough to infer
+   authenticity of the Author Domain.
 
-   Since the sorts of mail typically protected by DMARC participants
-   tend to only have single Authors, DMARC participants generally
-   operate under a slightly restricted profile of RFC5322 with respect
-   to the expected syntax of this field.  See Section 6.7 for details.
+   DMARC permits Identifier Alignment based on the result of a DKIM
+   authentication to be strict or relaxed.  (Note that these terms are
+   not related to DKIM's "simple" and "relaxed" canonicalization modes.)
 
-6.  Policy
+   In relaxed mode, the Organizational Domains of both the DKIM-
+   authenticated signing domain (taken from the value of the d= tag in
+   the signature) and that of the RFC5322.From domain must be equal if
+   the identifiers are to be considered to be aligned.  In strict mode,
+   only an exact match between both Fully Qualified Domain Names (FQDNs)
+   is considered to produce Identifier Alignment.
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 15]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+   To illustrate, in relaxed mode, if a verified DKIM signature
+   successfully verifies with a "d=" domain of "example.com", and the
+   RFC5322.From address is "alerts@news.example.com", the DKIM "d="
+   domain and the RFC5322.From domain are considered to be "in
+   alignment", because both domains have the same Organizational Domain
+   of "example.com".  In strict mode, this test would fail because the
+   d= domain does not exactly match the RFC5322.From domain.
+
+   However, a DKIM signature bearing a value of "d=com" would never
+   allow an "in alignment" result, as "com" should be identified as a
+   PSD and therefore cannot be an Organizational Domain.
+
+   Note that a single email can contain multiple DKIM signatures, and it
+   is considered to produce a DMARC "pass" result if any DKIM signature
+   is aligned and verifies.
+
+4.4.2.  SPF-Authenticated Identifiers
+
+   DMARC permits Identifier Alignment based on the result of an SPF
+   authentication.  As with DKIM, Identifier Alignement can be either
+   strict or relaxed.
+
+   In relaxed mode, the Organizational Domains of the SPF-authenticated
+   domain and RFC5322.From domain must be equal if the identifiers are
+   to be considered to be aligned.  In strict mode, the two FQDNs must
+   match exactly in order from them to be considered to be aligned.
+
+   For example, in relaxed mode, if a message passes an SPF check with
+   an RFC5321.MailFrom domain of "cbg.bounces.example.com", and the
+   address portion of the RFC5322.From header field contains
+   "payments@example.com", the Authenticated RFC5321.MailFrom domain
+   identifier and the RFC5322.From domain are considered to be "in
+   alignment" because they have the same Organizational Domain
+   ("example.com").  In strict mode, this test would fail because the
+   two domains are not identical.
+
+   The reader should note that SPF alignment checks in DMARC rely solely
+   on the RFC5321.MailFrom domain.  This differs from section 2.3 of
+   [RFC7208], which recommends that SPF checks be done on not only the
+   "MAIL FROM" but also on a separate check of the "HELO" identity.
+
+4.4.3.  Alignment and Extension Technologies
+
+   If in the future DMARC is extended to include the use of other
+   authentication mechanisms, the extensions will need to allow for
+   domain identifier extraction so that alignment with the RFC5322.From
+   domain can be verified.
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 16]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+4.5.  Determining The Organizational Domain
+
+   The DMARC protocol defines a method for a Public Suffix Domain to
+   identify itself as such using a tag in its published DMARC policy
+   record.  An Organizational Domain is any subdomain of a PSD that
+   includes exactly one more label than the PSD in its name.
+
+   For any email message, the Organizational Domain of the RFC5322.From
+   domain is determined using the following algorithm, similar to the
+   one described in Section 5.7.3
+
+   1.  Query the DNS for a DMARC TXT record at the DNS domain matching
+       the one found in the RFC5322.From domain in the message.  A
+       possibly empty set of records is returned.
+
+   2.  Records that do not start with a "v=" tag that identifies the
+       current version of DMARC are discarded.
+
+   3.  If the set is now empty, or the set contains one valid DMARC
+       record that does not include a psd tag with a value of 'y', then
+       determine the target for additional queries, using steps 4
+       through 8 below.
+
+   4.  Break the subject DNS domain name into a set of "n" ordered
+       labels.  Number these labels from right to left; e.g., for
+       "a.mail.example.com", "com" would be label 1 and "example" would
+       be label 2 and so forth.
+
+   5.  Count the number of labels found in the subject DNS domain.  Let
+       that number be "x".  If x < 5, remove the left-most (highest-
+       numbered) label from the subject domain.  If x >= 5, remove the
+       left-most (highest-numbered) labels from the subject domain until
+       4 labels remain.  The resulting DNS domain name is the new target
+       for subsequent lookups.
+
+   6.  Query the DNS for a DMARC TXT record at the DNS domain matching
+       this new target in place of the RFC5322.From domain in the
+       message.  A possibly empty set of records is returned.
+
+   7.  Records that do not start with a "v=" tag that identifies the
+       current version of DMARC are discarded.
+
+   8.  If the set is now empty, or the set contains one valid DMARC
+       record that does not include a psd tag with the value of 'y',
+       then determine the target for additional queries by removing a
+       single label from the target domain as described in step 5 and
+       repeating steps 6 and 7 until there are no more labels remaining
+       or a record containing a psd tag with a value of 'y' is found.
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 17]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+   9.  Once a valid DMARC record containing a psd tag with a value of
+       'y' has been found, the Organizational Domain for the DNS domain
+       matching the one found in the RFC5322.From domain can be declared
+       to be the target domain queried for in the step prior to the
+       query that found the PSD domain.
+
+   For example, given the RFC5322.From domain "a.mail.example.com", a
+   series of DNS queries for DMARC records would be executed starting
+   with "_dmarc.a.mail.example.com" and finishing with "_dmarc.com".
+   The "_dmarc.com" record would contain a psd tag with a value of 'y',
+   and so the Organizational Domain for this RFC5322.From domain would
+   be determined to be "example.com", the domain of the DMARC query
+   executed prior to the query for "_dmarc.com".
+
+5.  Policy
 
    DMARC policies are published by Domain Owners and PSOs and can be
    used by Mail Receivers to inform their message handling decisions.
 
    A Domain Owner or PSO advertises DMARC participation of one or more
-   of its domains by adding a DNS TXT record (described in Section 6.1)
+   of its domains by adding a DNS TXT record (described in Section 5.1)
    to those domains.  In doing so, Domain Owners and PSOs indicate their
    handling preference regarding failed authentication for email
    messages making use of their domain in the RFC5322.From header field
    as well as the provision of feedback about those messages.  Mail
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 17]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    Receivers in turn can take into account the Domain Owner's stated
    preference when making handling decisions about email messages that
    fail DMARC authentication checks.
@@ -978,7 +1003,14 @@ Internet-Draft                  DMARCbis                   November 2021
    specifically using the "PolicyOverride" feature of the aggregate
    report defined in [DMARC-Aggregate-Reporting]
 
-6.1.  DMARC Policy Record
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 18]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+5.1.  DMARC Policy Record
 
    Domain Owner and PSO DMARC preferences are stored as DNS TXT records
    in subdomains named "_dmarc".  For example, the Domain Owner of
@@ -999,42 +1031,42 @@ Internet-Draft                  DMARCbis                   November 2021
    well-established operations, administration, and management
    infrastructure, rather than creating a new one.
 
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 18]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    Per [RFC1035], a TXT record can comprise several "character-string"
    objects.  Where this is the case, the module performing DMARC
    evaluation MUST concatenate these strings by joining together the
    objects in order and parsing the result as a single string.
 
-6.2.  DMARC URIs
+5.2.  DMARC URIs
 
    [RFC3986] defines a generic syntax for identifying a resource.  The
    DMARC mechanism uses this as the format by which a Domain Owner or
    PSO specifies the destination for the two report types that are
    supported.
 
-   The place such URIs are specified (see Section 6.3) allows a list of
+   The place such URIs are specified (see Section 5.3) allows a list of
    these to be provided.  The list of URIs is separated by commas (ASCII
    0x2c).  A report SHOULD be sent to each listed URI provided in the
    DMARC record.
 
-   A formal definition is provided in Section 6.4.
+   A formal definition is provided in Section 5.4.
 
-6.3.  General Record Format
+5.3.  General Record Format
 
    DMARC records follow the extensible "tag-value" syntax for DNS-based
    key records defined in DKIM [RFC6376].
 
-   Section 9 creates a registry for known DMARC tags and registers the
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 19]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+   Section 8 creates a registry for known DMARC tags and registers the
    initial set defined in this document.  Only tags defined in this
    document or in later extensions, and thus added to that registry, are
    to be processed; unknown tags MUST be ignored.
@@ -1043,7 +1075,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    adkim:  (plain-text; OPTIONAL; default is "r".)  Indicates whether
       strict or relaxed DKIM Identifier Alignment mode is required by
-      the Domain Owner.  See Section 3.3.1 for details.  Valid values
+      the Domain Owner.  See Section 4.4.1 for details.  Valid values
       are as follows:
 
       r:  relaxed mode
@@ -1052,19 +1084,12 @@ Internet-Draft                  DMARCbis                   November 2021
 
    aspf:  (plain-text; OPTIONAL; default is "r".)  Indicates whether
       strict or relaxed SPF Identifier Alignment mode is required by the
-      Domain Owner.  See Section 3.3.2 for details.  Valid values are as
+      Domain Owner.  See Section 4.4.2 for details.  Valid values are as
       follows:
 
       r:  relaxed mode
 
       s:  strict mode
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 19]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    fo:  Failure reporting options (plain-text; OPTIONAL; default is "0")
       Provides requested options for generation of failure reports.
@@ -1075,6 +1100,27 @@ Internet-Draft                  DMARCbis                   November 2021
       the options represented by alphabetic characters.
 
    The valid values and their meanings are:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 20]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    0:
    :  Generate a DMARC failure report if all underlying
@@ -1108,20 +1154,12 @@ Internet-Draft                  DMARCbis                   November 2021
       present, MUST be applied for non-existent subdomains.  Note that
       "np" will be ignored for DMARC records published on subdomains of
       Organizational Domains and PSDs due to the effect of the DMARC
-      policy discovery mechanism described in Section 6.7.3.
+      policy discovery mechanism described in Section 5.7.3.
 
    p:  Domain Owner Assessment Policy (plain-text; RECOMMENDED for
       policy records).  Indicates the message handling preference the
       Domain Owner or PSO has for mail using its domain but not passing
       DMARC verification.  Policy applies to the domain queried and to
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 20]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
       subdomains, unless subdomain policy is explicitly described using
       the "sp" or "np" tags.  This tag is mandatory for policy records
       only, but not for third-party reporting records (see
@@ -1132,11 +1170,19 @@ Internet-Draft                  DMARCbis                   November 2021
 
       quarantine:  The Domain Owner considers such mail to be
          suspicious.  It is possible the mail is valid, although the
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 21]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
          failure creates a significant concern.
 
       reject:  The Domain Owner considers all such failures to be a
          clear indication that the use of the domain name is not valid.
-         See Section 8.3 for some discussion of SMTP rejection methods
+         See Section 7.3 for some discussion of SMTP rejection methods
          and their implications.
 
    psd:  A flag indicating whether the domain is a PSD. (plain-text;
@@ -1155,7 +1201,7 @@ Internet-Draft                  DMARCbis                   November 2021
       separated plain-text list of DMARC URIs; OPTIONAL).  Section 3 of
       [DMARC-Aggregate-Reporting] discusses considerations that apply
       when the domain name of a URI differs from that of the domain
-      advertising the policy.  See Section 10.5 for additional
+      advertising the policy.  See Section 9.5 for additional
       considerations.  Any valid URI can be specified.
          A Mail Receiver MUST implement support for a "mailto:" URI,
       i.e., the ability to send a DMARC report via electronic mail.  If
@@ -1170,22 +1216,23 @@ Internet-Draft                  DMARCbis                   November 2021
       Receivers to send detailed failure reports about messages that
       fail the DMARC evaluation in specific ways (see the "fo" tag
       above).  The format of the message to be generated MUST follow the
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 21]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
       format specified for the "rf" tag.  Section 3 of
       [DMARC-Aggregate-Reporting] discusses considerations that apply
       when the domain name of a URI differs from that of the domain
       advertising the policy.  A Mail Receiver MUST implement support
       for a "mailto:" URI, i.e., the ability to send a DMARC report via
       electronic mail.  If not provided, Mail Receivers MUST NOT
-      generate failure reports.  See Section 10.5 for additional
+      generate failure reports.  See Section 9.5 for additional
       considerations.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 22]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    sp:  Domain Owner Assessment Policy for all subdomains (plain-text;
       OPTIONAL).  Indicates the message handling preference the Domain
@@ -1198,7 +1245,7 @@ Internet-Draft                  DMARCbis                   November 2021
       be applied for subdomains.  Note that "sp" will be ignored for
       DMARC records published on subdomains of Organizational Domains
       due to the effect of the DMARC policy discovery mechanism
-      described in Section 6.7.3.
+      described in Section 5.7.3.
 
    t:  DMARC policy test mode (plain-text; OPTIONAL; default is 'n').
       For the RFC5322.From domain to which the DMARC record applies, the
@@ -1223,19 +1270,8 @@ Internet-Draft                  DMARCbis                   November 2021
       the entire retrieved record MUST be ignored.  It MUST be the first
       tag in the list.
 
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 22]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    A DMARC policy record MUST comply with the formal specification found
-   in Section 6.4 in that the "v" tag MUST be present and MUST appear
+   in Section 5.4 in that the "v" tag MUST be present and MUST appear
    first.  Unknown tags MUST be ignored.  Syntax errors in the remainder
    of the record SHOULD be discarded in favor of default values (if any)
    or ignored outright.
@@ -1246,7 +1282,15 @@ Internet-Draft                  DMARCbis                   November 2021
    the "v" tag's value), but a change to any existing tags does require
    a new version of DMARC.
 
-6.4.  Formal Definition
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 23]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+5.4.  Formal Definition
 
    The formal definition of the DMARC format, using [RFC5234], is as
    follows:
@@ -1283,13 +1327,6 @@ Internet-Draft                  DMARCbis                   November 2021
      dmarc-srequest  = "sp" *WSP "=" *WSP
                        ( "none" / "quarantine" / "reject" )
 
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 23]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
      dmarc-nprequest  = "np" *WSP "=" *WSP
                        ( "none" / "quarantine" / "reject" )
 
@@ -1301,6 +1338,14 @@ Internet-Draft                  DMARCbis                   November 2021
                        dmarc-uri *(*WSP "," *WSP dmarc-uri)
 
      dmarc-furi      = "ruf" *WSP "=" *WSP
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 24]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
                        dmarc-uri *(*WSP "," *WSP dmarc-uri)
 
      dmarc-fo        = "fo" *WSP "=" *WSP
@@ -1311,12 +1356,12 @@ Internet-Draft                  DMARCbis                   November 2021
 
    "Keyword" is imported from Section 4.1.2 of [RFC5321].
 
-6.5.  Domain Owner Actions
+5.5.  Domain Owner Actions
 
    This section describes Domain Owner actions to fully implement the
    DMARC mechanism.
 
-6.5.1.  Publish an SPF Policy for an Aligned Domain
+5.5.1.  Publish an SPF Policy for an Aligned Domain
 
    Because DMARC relies on SPF [RFC7208] and DKIM [RFC6376], in order to
    take full advantage of DMARC, a Domain Owner SHOULD first ensure that
@@ -1326,7 +1371,7 @@ Internet-Draft                  DMARCbis                   November 2021
    with the Author Domain, and then publish an SPF policy in DNS for
    that domain.
 
-6.5.2.  Configure Sending System for DKIM Signing Using an Aligned
+5.5.2.  Configure Sending System for DKIM Signing Using an Aligned
         Domain
 
    While it is possible to secure a DMARC pass verdict based on only SPF
@@ -1337,16 +1382,7 @@ Internet-Draft                  DMARCbis                   November 2021
    that aligns with the Author Domain and configure its system to sign
    using that domain.
 
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 24]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-6.5.3.  Setup a Mailbox to Receive Aggregate Reports
+5.5.3.  Setup a Mailbox to Receive Aggregate Reports
 
    Proper consumption and analysis of DMARC aggregate reports is the key
    to any successful DMARC deployment for a Domain Owner.  DMARC
@@ -1357,6 +1393,15 @@ Internet-Draft                  DMARCbis                   November 2021
    could be legitimate ones that were overlooked during the intial
    deployment of SPF and/or DKIM.
 
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 25]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    Because the aggregate reports are XML documents, it is strongly
    advised that they be machine-parsed, so setting up a mailbox involves
    more than just the physical creation of the mailbox.  Many third-
@@ -1366,14 +1411,14 @@ Internet-Draft                  DMARCbis                   November 2021
    data contained in them will go a long way to ensuring a successful
    deployment.
 
-6.5.4.  Publish a DMARC Policy for the Author Domain
+5.5.4.  Publish a DMARC Policy for the Author Domain
 
    Once SPF, DKIM, and the aggregate reports mailbox are all in place,
    it's time to publish a DMARC record.  For best results, Domain Owners
    SHOULD start with "p=none", with the rua tag containg the mailbox
    created in the previous step.
 
-6.5.5.  Collect and Analyze Reports and Adjust Authentication
+5.5.5.  Collect and Analyze Reports and Adjust Authentication
 
    The reason for starting at "p=none" is to ensure that nothing's been
    missed in the initial SPF and DKIM deployments.  In all but the most
@@ -1385,24 +1430,7 @@ Internet-Draft                  DMARCbis                   November 2021
    reports, the Domain Owner can adjust the SPF record and/or configure
    DKIM signing for those systems.
 
-
-
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 25]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-6.5.6.  Decide If and When to Update DMARC Policy
+5.5.6.  Decide If and When to Update DMARC Policy
 
    Once the Domain Owner is satisfied that it is properly authenticating
    all of its mail, then it is time to decide if it is appropriate to
@@ -1413,7 +1441,7 @@ Internet-Draft                  DMARCbis                   November 2021
    mail, and the decision on which p= value to use will depend on its
    needs.
 
-6.6.  PSO Actions
+5.6.  PSO Actions
 
    In addition to the DMARC Domain Owner actions, PSOs that require use
    of DMARC and participate in PSD DMARC ought to make that information
@@ -1421,11 +1449,20 @@ Internet-Draft                  DMARCbis                   November 2021
    for doing so, and the experiment is described in Appendix B of that
    document.
 
-6.7.  Mail Receiver Actions
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 26]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+5.7.  Mail Receiver Actions
 
    This section describes receiver actions in the DMARC environment.
 
-6.7.1.  Extract Author Domain
+5.7.1.  Extract Author Domain
 
    The domain in the RFC5322.From header field is extracted as the
    domain to be evaluated by DMARC.  If the domain is encoded with UTF-
@@ -1450,15 +1487,7 @@ Internet-Draft                  DMARCbis                   November 2021
    Note that domain names that appear on a public suffix list are not
    exempt from DMARC policy application and reporting.
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 26]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-6.7.2.  Determine Handling Policy
+5.7.2.  Determine Handling Policy
 
    To arrive at a policy for an individual message, Mail Receivers MUST
    perform the following actions or their semantic equivalents.  Steps
@@ -1471,7 +1500,19 @@ Internet-Draft                  DMARCbis                   November 2021
 
    2.  Query the DNS for a DMARC policy record.  Continue if one is
        found, or terminate DMARC evaluation otherwise.  See
-       Section 6.7.3 for details.
+       Section 5.7.3 for details.
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 27]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    3.  Perform DKIM signature verification checks.  A single email could
        contain multiple DKIM signatures.  The results of this step are
@@ -1498,21 +1539,13 @@ Internet-Draft                  DMARCbis                   November 2021
    6.  Apply policy.  Emails that fail the DMARC mechanism check are
        handled in accordance with the discovered DMARC policy of the
        Domain Owner and any local policy rules enforced by the Mail
-       Receiver.  See Section 6.3 for details.
+       Receiver.  See Section 5.3 for details.
 
    Heuristics applied in the absence of use by a Domain Owner of either
    SPF or DKIM (e.g., [Best-Guess-SPF]) SHOULD NOT be used, as it may be
    the case that the Domain Owner wishes a Message Receiver not to
    consider the results of that underlying authentication protocol at
    all.
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 27]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    DMARC evaluation can only yield a "pass" result after one of the
    underlying authentication mechanisms passes for an aligned
@@ -1526,7 +1559,18 @@ Internet-Draft                  DMARCbis                   November 2021
    Handling of messages for which SPF and/or DKIM evaluation encounter a
    permanent DNS error is left to the discretion of the Mail Receiver.
 
-6.7.3.  Policy Discovery
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 28]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+5.7.3.  Policy Discovery
 
    As stated above, the DMARC mechanism uses DNS TXT records to
    advertise policy.  Policy discovery is accomplished via a method
@@ -1560,16 +1604,6 @@ Internet-Draft                  DMARCbis                   November 2021
         until 4 labels remain.  The resulting DNS domain name is the new
         target for subsequent lookups.
 
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 28]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    6.   The Mail Receiver MUST query the DNS for a DMARC TXT record at
         the DNS domain matching this new target in place of the
         RFC5322.From domain in the message.  This record can contain
@@ -1583,6 +1617,14 @@ Internet-Draft                  DMARCbis                   November 2021
         for additional queries by removing a single label from the
         target domain as described in step 5 and repeating steps 6 and 7
         until there are no more labels remaining.
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 29]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    9.   If the remaining set contains multiple records or no records,
         policy discovery terminates and DMARC processing is not applied
@@ -1613,20 +1655,7 @@ Internet-Draft                  DMARCbis                   November 2021
    cleared, allowing a definite DMARC conclusion to be reached ("fail
    closed").
 
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 29]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-6.7.3.1.  Longest PSD Example
+5.7.3.1.  Longest PSD Example
 
    As an example of step 5 above, for a message with the Organizational
    Domain of "example.compute.cloudcompany.com.example", the query for
@@ -1641,14 +1670,26 @@ Internet-Draft                  DMARCbis                   November 2021
    not a mechanism to provide feedback addresses (RUA/RUF) when an
    Organizational Domain has declined to do so.
 
-6.7.4.  Store Results of DMARC Processing
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 30]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+5.7.4.  Store Results of DMARC Processing
 
    The results of Mail Receiver-based DMARC processing should be stored
    for eventual presentation back to the Domain Owner in the form of
-   aggregate feedback reports.  Section 6.3 and
+   aggregate feedback reports.  Section 5.3 and
    [DMARC-Aggregate-Reporting] discuss aggregate feedback.
 
-6.7.5.  Send Aggregate Reports
+5.7.5.  Send Aggregate Reports
 
    For a Domain Owner, DMARC aggregate reports provide data about all
    mailstreams making use of its domain in email, to include not only
@@ -1667,22 +1708,7 @@ Internet-Draft                  DMARCbis                   November 2021
    ecosystem, then, Mail Receivers MUST generate and send aggregate
    reports with a frequency of at least once every 24 hours.
 
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 30]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-6.8.  Policy Enforcement Considerations
+5.8.  Policy Enforcement Considerations
 
    Mail Receivers MAY choose to reject or quarantine email even if email
    passes the DMARC mechanism check.  The DMARC mechanism does not
@@ -1701,6 +1727,16 @@ Internet-Draft                  DMARCbis                   November 2021
    is RECOMMENDED when delivery of failing mail is done.  When this is
    done, the DNS domain name thus recorded MUST be encoded as an
    A-label.
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 31]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    Mail Receivers are only obligated to report reject or quarantine
    policy actions in aggregate feedback reports that are due to
@@ -1730,20 +1766,12 @@ Internet-Draft                  DMARCbis                   November 2021
    existing mail processing, discovered policies of "p=none" SHOULD NOT
    modify existing mail handling processes.
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 31]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    Mail Receivers MUST also implement reporting instructions of DMARC,
    even in the absence of a request for DKIM reporting [RFC6651] or SPF
    reporting [RFC6652].  Furthermore, the presence of such requests
    SHOULD NOT affect DMARC reporting.
 
-7.  DMARC Feedback
+6.  DMARC Feedback
 
    Providing Domain Owners with visibility into how Mail Receivers
    implement and enforce the DMARC mechanism in the form of feedback is
@@ -1755,17 +1783,28 @@ Internet-Draft                  DMARCbis                   November 2021
    The details of this feedback are described in
    [DMARC-Aggregate-Reporting]
 
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 32]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    Operational note for PSD DMARC: For PSOs, feedback for non-existent
    domains is desirable and useful, just as it is for org-level DMARC
    operators.  See Section 4 of [RFC9091] for discussion of Privacy
    Considerations for PSD DMARC
 
-8.  Other Topics
+7.  Other Topics
 
    This section discusses some topics regarding choices made in the
    development of DMARC, largely to commit the history to record.
 
-8.1.  Issues Specific to SPF
+7.1.  Issues Specific to SPF
 
    Though DMARC does not inherently change the semantics of an SPF
    policy record, historically lax enforcement of such policies has led
@@ -1781,20 +1820,7 @@ Internet-Draft                  DMARCbis                   November 2021
    processing takes place.  Operators choosing to use "-all" should be
    aware of this.
 
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 32]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-8.2.  DNS Load and Caching
+7.2.  DNS Load and Caching
 
    DMARC policies are communicated using the DNS and therefore inherit a
    number of considerations related to DNS caching.  The inherent
@@ -1816,7 +1842,15 @@ Internet-Draft                  DMARCbis                   November 2021
    responsiveness of DMARC preference changes while preserving the
    benefits of DNS caching.
 
-8.3.  Rejecting Messages
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 33]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+7.3.  Rejecting Messages
 
    This protocol calls for rejection of a message during the SMTP
    session under certain circumstances.  This is preferable to
@@ -1842,14 +1876,6 @@ Internet-Draft                  DMARCbis                   November 2021
    server has to be programmed to give a false result, which can
    confound external debugging efforts.
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 33]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    Similarly, the text portion of the SMTP reply may be important to
    consider.  For example, when rejecting a message, revealing the
    reason for the rejection might give an attacker enough information to
@@ -1872,7 +1898,15 @@ Internet-Draft                  DMARCbis                   November 2021
    retrieve or apply DMARC policy, this is best done with a 4xy SMTP
    reply code.
 
-8.4.  Identifier Alignment Considerations
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 34]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+7.4.  Identifier Alignment Considerations
 
    The DMARC mechanism allows both DKIM and SPF-authenticated
    identifiers to authenticate email on behalf of a Domain Owner and,
@@ -1890,21 +1924,12 @@ Internet-Draft                  DMARCbis                   November 2021
    delegate control of subdomains if this is an issue, and to consider
    using the "strict" Identifier Alignment option if appropriate.
 
-8.5.  Interoperability Issues
+7.5.  Interoperability Issues
 
    DMARC limits which end-to-end scenarios can achieve a "pass" result.
 
    Because DMARC relies on SPF [RFC7208] and/or DKIM [RFC6376] to
    achieve a "pass", their limitations also apply.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 34]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    Additional DMARC constraints occur when a message is processed by
    some Mediators, such as mailing lists.  Transiting a Mediator often
@@ -1919,14 +1944,23 @@ Internet-Draft                  DMARCbis                   November 2021
    Issues specific to the use of policy mechanisms alongside DKIM are
    further discussed in [RFC6377], particularly Section 5.2.
 
-9.  IANA Considerations
+8.  IANA Considerations
 
    This section describes actions completed by IANA.
 
-9.1.  Authentication-Results Method Registry Update
+8.1.  Authentication-Results Method Registry Update
 
    IANA has added the following to the "Email Authentication Methods"
    registry:
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 35]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    +------+-----------+------+----------+--------------+------+--------+
    |Method| Defined   |ptype | Property | Value        |Status|Version |
@@ -1954,15 +1988,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
           Table 1: "Authentication-Results Method Registry Update"
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 35]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-9.2.  Authentication-Results Result Registry Update
+8.2.  Authentication-Results Result Registry Update
 
    IANA has added the following in the "Email Authentication Result
    Names" registry:
@@ -1984,6 +2010,14 @@ Internet-Draft                  DMARCbis                   November 2021
    |           |           |           |(added)| record was     |      |
    |           |           |           |       | published for  |      |
    |           |           |           |       | the aligned    |      |
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 36]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    |           |           |           |       |identifier, and |      |
    |           |           |           |       |at least one of |      |
    |           |           |           |       | the            |      |
@@ -2010,14 +2044,6 @@ Internet-Draft                  DMARCbis                   November 2021
    |           |           |           |       | final result.  |      |
    +-----------+-----------+-----------+-------+----------------+------+
    | permerror | existing  | [RFC8601] | dmarc | A permanent    |active|
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 36]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    |           |           |           |(added)| error occurred |      |
    |           |           |           |       | during DMARC   |      |
    |           |           |           |       |evaluation, such|      |
@@ -2033,12 +2059,20 @@ Internet-Draft                  DMARCbis                   November 2021
 
           Table 2: "Authentication-Results Result Registry Update"
 
-9.3.  Feedback Report Header Fields Registry Update
+8.3.  Feedback Report Header Fields Registry Update
 
    The following has been added to the "Feedback Report Header Fields"
    registry:
 
    Field Name: Identity-Alignment
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 37]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    Description:  indicates whether the message about which a report is
       being generated had any identifiers in alignment as defined in RFC
@@ -2052,7 +2086,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    Status: current
 
-9.4.  DMARC Tag Registry
+8.4.  DMARC Tag Registry
 
    A new registry tree called "Domain-based Message Authentication,
    Reporting, and Conformance (DMARC) Parameters" has been created.
@@ -2066,14 +2100,6 @@ Internet-Draft                  DMARCbis                   November 2021
    name; the specification that defines it; a brief description; and its
    status, which must be one of "current", "experimental", or
    "historic".  The Designated Expert needs to confirm that the provided
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 37]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    specification adequately describes the new tag and clearly presents
    how it would be used within the DMARC context by Domain Owners and
    Mail Receivers.
@@ -2083,6 +2109,26 @@ Internet-Draft                  DMARCbis                   November 2021
    when processed by implementations conforming to prior specifications.
 
    The initial set of entries in this registry is as follows:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 38]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    +----------+-----------+----------+------------------------------+
    | Tag Name | Reference | Status   | Description                  |
@@ -2118,23 +2164,27 @@ Internet-Draft                  DMARCbis                   November 2021
 
                      Table 3: "DMARC Tag Registry"
 
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 38]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-9.5.  DMARC Report Format Registry
+8.5.  DMARC Report Format Registry
 
    Also within "Domain-based Message Authentication, Reporting, and
    Conformance (DMARC) Parameters", a new sub-registry called "DMARC
    Report Format Registry" has been created.
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 39]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    Names of DMARC failure reporting formats must be registered with IANA
    in this registry.  New entries are assigned only for values that
@@ -2159,7 +2209,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
                  Table 4: "DMARC Report Format Registry"
 
-9.6.  Underscored and Globally Scoped DNS Node Names Registry
+8.6.  Underscored and Globally Scoped DNS Node Names Registry
 
    Per [RFC8552], please add the following entry to the "Underscored and
    Globally Scoped DNS Node Names" registry:
@@ -2174,24 +2224,25 @@ Internet-Draft                  DMARCbis                   November 2021
      Globally Scoped DNS Node Names"
                  registry
 
-10.  Security Considerations
+9.  Security Considerations
 
    This section discusses security issues and possible remediations
    (where available) for DMARC.
 
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 39]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-10.1.  Authentication Methods
+9.1.  Authentication Methods
 
    Security considerations from the authentication methods used by DMARC
    are incorporated here by reference.
 
-10.2.  Attacks on Reporting URIs
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 40]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+9.2.  Attacks on Reporting URIs
 
    URIs published in DNS TXT records are well-understood possible
    targets for attack.  Specifications such as [RFC1035] and [RFC2142]
@@ -2214,7 +2265,7 @@ Internet-Draft                  DMARCbis                   November 2021
       Submitter or Reported-Domain fields, including the possibility of
       false data from compromised but known Mail Receivers.
 
-10.3.  DNS Security
+9.3.  DNS Security
 
    The DMARC mechanism and its underlying technologies (SPF, DKIM)
    depend on the security of the DNS.  Examples of how hostile parties
@@ -2234,18 +2285,20 @@ Internet-Draft                  DMARCbis                   November 2021
    *  Signing DNS records with DNSSEC [RFC4033], which enables
       recipients to detect and discard forged responses.
 
+   *  DNS over TLS [RFC7858] or DNS over HTTPS [RFC8484] can mitigate
+      snooping and forged responses.
 
 
 
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 40]
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 41]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-   *  DNS over TLS [RFC7858] or DNS over HTTPS [RFC8484] can mitigate
-      snooping and forged responses.
-
-10.4.  Display Name Attacks
+9.4.  Display Name Attacks
 
    A common attack in messaging abuse is the presentation of false
    information in the display-name portion of the RFC5322.From header
@@ -2285,20 +2338,7 @@ Internet-Draft                  DMARCbis                   November 2021
       passes and the email address thus verified matches one found in
       the receiving user's list of known addresses.
 
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 41]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-10.5.  External Reporting Addresses
+9.5.  External Reporting Addresses
 
    To avoid abuse by bad actors, reporting addresses generally have to
    be inside the domains about which reports are requested.  In order to
@@ -2306,6 +2346,13 @@ Internet-Draft                  DMARCbis                   November 2021
    that cannot actually receive mail, Section 3 of
    [DMARC-Aggregate-Reporting] describes a DNS-based mechanism for
    verifying approved external reporting.
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 42]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    The obvious consideration here is an increased DNS load against
    domains that are claimed as external recipients.  Negative caching
@@ -2325,7 +2372,7 @@ Internet-Draft                  DMARCbis                   November 2021
    routed fraudulently to an attacker's systems may be an attractive
    prospect.  Deployment of [RFC4033] is advisable if this is a concern.
 
-10.6.  Secure Protocols
+9.6.  Secure Protocols
 
    This document encourages use of secure transport mechanisms to
    prevent loss of private data to third parties that may be able to
@@ -2336,23 +2383,12 @@ Internet-Draft                  DMARCbis                   November 2021
    secured might appear in a report that is not sent securely, which
    could reveal private information.
 
-11.  Normative References
+10.  Normative References
 
    [DMARC-Aggregate-Reporting]
               Brotman, A., Ed., "DMARC Aggregate Reporting", February
               2021, <https://datatracker.ietf.org/doc/draft-ietf-dmarc-
               aggregate-reporting/>.
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 42]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    [DMARC-Failure-Reporting]
               Jones, S.M., Ed. and A. Vesely, Ed., "DMARC Failure
@@ -2363,6 +2399,16 @@ Internet-Draft                  DMARCbis                   November 2021
    [RFC1035]  Mockapetris, P., "Domain names - implementation and
               specification", STD 13, RFC 1035, DOI 10.17487/RFC1035,
               November 1987, <https://www.rfc-editor.org/info/rfc1035>.
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 43]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
@@ -2402,14 +2448,6 @@ Internet-Draft                  DMARCbis                   November 2021
               RFC 6376, DOI 10.17487/RFC6376, September 2011,
               <https://www.rfc-editor.org/info/rfc6376>.
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 43]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    [RFC6591]  Fontana, H., "Authentication Failure Reporting Using the
               Abuse Reporting Format", RFC 6591, DOI 10.17487/RFC6591,
               April 2012, <https://www.rfc-editor.org/info/rfc6591>.
@@ -2418,6 +2456,15 @@ Internet-Draft                  DMARCbis                   November 2021
               (DKIM) for Failure Reporting", RFC 6651,
               DOI 10.17487/RFC6651, June 2012,
               <https://www.rfc-editor.org/info/rfc6651>.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 44]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    [RFC6652]  Kitterman, S., "Sender Policy Framework (SPF)
               Authentication Failure Reporting Using the Abuse Reporting
@@ -2445,7 +2492,7 @@ Internet-Draft                  DMARCbis                   November 2021
               DOI 10.17487/RFC9091, July 2021,
               <https://www.rfc-editor.org/info/rfc9091>.
 
-12.  Informative References
+11.  Informative References
 
    [Best-Guess-SPF]
               Kitterman, S., "Sender Policy Framework: Best guess record
@@ -2456,16 +2503,6 @@ Internet-Draft                  DMARCbis                   November 2021
               Functions", RFC 2142, DOI 10.17487/RFC2142, May 1997,
               <https://www.rfc-editor.org/info/rfc2142>.
 
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 44]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    [RFC3464]  Moore, K. and G. Vaudreuil, "An Extensible Message Format
               for Delivery Status Notifications", RFC 3464,
               DOI 10.17487/RFC3464, January 2003,
@@ -2475,6 +2512,15 @@ Internet-Draft                  DMARCbis                   November 2021
               Rose, "DNS Security Introduction and Requirements",
               RFC 4033, DOI 10.17487/RFC4033, March 2005,
               <https://www.rfc-editor.org/info/rfc4033>.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 45]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    [RFC5598]  Crocker, D., "Internet Mail Architecture", RFC 5598,
               DOI 10.17487/RFC5598, July 2009,
@@ -2511,17 +2557,6 @@ Internet-Draft                  DMARCbis                   November 2021
               (DoH)", RFC 8484, DOI 10.17487/RFC8484, October 2018,
               <https://www.rfc-editor.org/info/rfc8484>.
 
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 45]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    [RFC8601]  Kucherawy, M., "Message Header Field for Indicating
               Message Authentication Status", RFC 8601,
               DOI 10.17487/RFC8601, May 2019,
@@ -2534,6 +2569,14 @@ Appendix A.  Technology Considerations
    suggestions that were considered but not included in the design.
    This text is included to explain why they were considered and not
    included in this version.
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 46]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 A.1.  S/MIME
 
@@ -2571,13 +2614,6 @@ A.2.  Method Exclusion
    Owner could tell Message Receivers not to attempt verification by one
    of the supported methods (e.g., "check DKIM, but not SPF").
 
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 46]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    Specifically, consider a Domain Owner that has deployed one of the
    technologies, and that technology fails for some messages, but such
    failures don't cause enforcement action.  Deploying DMARC would cause
@@ -2590,6 +2626,13 @@ Internet-Draft                  DMARCbis                   November 2021
    target audience for DMARC does not appear to have concerns about the
    failure modes of one or the other being a barrier to DMARC's
    adoption.
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 47]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    In the scenario described above, the Domain Owner has a few options:
 
@@ -2626,14 +2669,6 @@ A.3.  Sender Header Field
        is for, its use in this way is also unreliable, making it a poor
        candidate for inclusion in the DMARC evaluation algorithm.
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 47]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    3.  Allowing multiple ways to discover policy introduces unacceptable
        ambiguity into the DMARC evaluation algorithm in terms of which
        policy is to be applied and when.
@@ -2646,6 +2681,14 @@ A.4.  Domain Existence Test
    MX, A, or AAAA resource records for the name being evaluated and
    assuming that the domain is nonexistent if it could be determined
    that no such records were published for that domain name.
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 48]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    The original pre-standardization version of this protocol included a
    mandatory check of this nature.  It was ultimately removed, as the
@@ -2683,13 +2726,6 @@ A.5.  Issues with ADSP in Operation
    4.  ADSP has no support for using SPF as an auxiliary mechanism to
        DKIM.
 
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 48]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    5.  ADSP has no support for a slow rollout, i.e., no way to configure
        a percentage of email on which the receiver should apply the
        policy.  This is important for large-volume senders.
@@ -2700,6 +2736,15 @@ Internet-Draft                  DMARCbis                   November 2021
 
    7.  The binding between the "From" header domain and DKIM is too
        tight for ADSP; they must match exactly.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 49]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 A.6.  Organizational Domain Discovery Issues
 
@@ -2730,21 +2775,12 @@ A.6.  Organizational Domain Discovery Issues
    constitutes an amplified denial-of-service attack.
 
    The Organizational Domain mechanism is a necessary component to the
-   goals of DMARC.  The method described in Section 3.4 is far from
+   goals of DMARC.  The method described in Section 4.5 is far from
    perfect but serves this purpose reasonably well without adding undue
    burden or semantics to the DNS.  If a method is created to do so that
    is more reliable and secure than the use of a public suffix list,
    DMARC should be amended to use that method as soon as it is generally
    available.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 49]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 A.6.1.  Public Suffix Lists
 
@@ -2756,6 +2792,15 @@ A.6.1.  Public Suffix Lists
 
    Note that if operators use a variety of public suffix lists,
    interoperability will be difficult or impossible to guarantee.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 50]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 A.7.  Removal of the "pct" Tag
 
@@ -2780,27 +2825,6 @@ A.7.  Removal of the "pct" Tag
    deviate from standard handling of the message, usually by rewriting
    the RFC5322.From header in an effort to avoid DMARC failures
    downstream.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 50]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    These custom actions when the pct= tag was set to "0" proved valuable
    to the email community.  In particular, header rewriting by an
@@ -2827,6 +2851,13 @@ Internet-Draft                  DMARCbis                   November 2021
    application by mailbox providers and intermediaries to the "pct" tag
    values "0" and "100", respectively.
 
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 51]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 Appendix B.  Examples
 
    This section illustrates both the Domain Owner side and the Mail
@@ -2845,18 +2876,6 @@ B.1.1.  SPF
    Alignment cannot exist if SPF does not produce a passing result.
 
    Example 1: SPF in alignment:
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 51]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
         MAIL FROM: <sender@example.com>
 
@@ -2885,6 +2904,16 @@ Internet-Draft                  DMARCbis                   November 2021
 
    Example 3: SPF not in alignment:
 
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 52]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
         MAIL FROM: <sender@example.net>
 
         From: sender@child.example.com
@@ -2902,17 +2931,6 @@ B.1.2.  DKIM
    Alignment cannot exist with a DKIM signature that does not verify.
 
    Example 1: DKIM in alignment:
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 52]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
         DKIM-Signature: v=1; ...; d=example.com; ...
         From: sender@example.com
@@ -2945,6 +2963,13 @@ Internet-Draft                  DMARCbis                   November 2021
         To: receiver@example.org
         Subject: here's a sample
 
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 53]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    In this case, the DKIM signature's "d=" parameter includes a DNS
    domain that is neither the same as, a parent of, nor a child of the
    RFC5322.From domain.  Thus, the identifiers are not in alignment.
@@ -2962,13 +2987,6 @@ B.2.1.  Entire Domain, Monitoring Only
    its messaging infrastructure.  The owner wishes to begin using DMARC
    with a policy that will solicit aggregate feedback from receivers
    without affecting how the messages are processed, in order to:
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 53]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    *  Confirm that its legitimate messages are authenticating correctly
 
@@ -2999,6 +3017,15 @@ Internet-Draft                  DMARCbis                   November 2021
      % dig +short TXT _dmarc.example.com.
      "v=DMARC1; p=none; rua=mailto:dmarc-feedback@example.com"
 
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 54]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    To publish such a record, the DNS administrator for the Domain Owner
    creates an entry like the following in the appropriate zone file
    (following the conventional zone file format):
@@ -3016,15 +3043,6 @@ B.2.2.  Entire Domain, Monitoring Only, Per-Message Reports
    authentication failures.  In order to diagnose these intermittent
    problems, they wish to request per-message failure reports when
    authentication failures occur.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 54]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    Not all Receivers will honor such a request, but the Domain Owner
    feels that any reports it does receive will be helpful enough to
@@ -3056,6 +3074,14 @@ Internet-Draft                  DMARCbis                   November 2021
                        "rua=mailto:dmarc-feedback@example.com; "
                        "ruf=mailto:auth-reports@example.com" )
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 55]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 B.2.3.  Per-Message Failure Reports Directed to Third Party
 
    The Domain Owner from the previous example is maintaining the same
@@ -3071,16 +3097,6 @@ B.2.3.  Per-Message Failure Reports Directed to Third Party
    *  Per-message failure reports should be sent via email to the
       address "auth-reports@thirdparty.example.net" ("ruf=mailto:auth-
       reports@thirdparty.example.net")
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 55]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    The DMARC policy record might look like this when retrieved using a
    common command-line tool (the output shown would appear on a single
@@ -3113,6 +3129,15 @@ Internet-Draft                  DMARCbis                   November 2021
       "example.com._report._dmarc.thirdparty.example.net" with the value
       "v=DMARC1;".
 
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 56]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    The resulting DNS record might look like this when retrieved using a
    common command-line tool (the output shown would appear on a single
    line but is wrapped here for publication):
@@ -3128,15 +3153,6 @@ Internet-Draft                  DMARCbis                   November 2021
      ; Accept DMARC failure reports on behalf of example.com
 
      example.com._report._dmarc   IN   TXT    "v=DMARC1;"
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 56]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    Mediators and other third parties should refer to Section 3 of
    [DMARC-Aggregate-Reporting] for the full details of this mechanism.
@@ -3169,6 +3185,15 @@ B.2.4.  Subdomain, Testing, and Multiple Aggregate Report URIs
    *  Receivers are advised that the Domain Owner considers messages
       that fail to authenticate to be suspicious ("p=quarantine")
 
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 57]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    *  Aggregate feedback reports should be sent via email to the
       addresses "dmarc-feedback@example.com" and "example-tld-
       test@thirdparty.example.net" ("rua=mailto:dmarc-
@@ -3183,16 +3208,6 @@ B.2.4.  Subdomain, Testing, and Multiple Aggregate Report URIs
    The DMARC policy record might look like this when retrieved using a
    common command-line tool (the output shown would appear on a single
    line but is wrapped here for publication):
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 57]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
      % dig +short TXT _dmarc.test.example.com
      "v=DMARC1; p=quarantine; rua=mailto:dmarc-feedback@example.com,
@@ -3226,6 +3241,15 @@ Internet-Draft                  DMARCbis                   November 2021
      "v=DMARC1; p=reject; rua=mailto:dmarc-feedback@example.com,
       mailto:tld-test@thirdparty.example.net"
 
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 58]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    To publish such a record, the DNS administrator for the Domain Owner
    might create an entry like the following in the appropriate zone
    file:
@@ -3242,13 +3266,6 @@ B.3.  Mail Receiver Example
    SPF and DKIM, and possess the ability to collect relevant information
    from various email-processing stages to provide feedback to Domain
    Owners (possibly via Report Receivers).
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 58]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 B.4.  Processing of SMTP Time
 
@@ -3277,6 +3294,18 @@ B.4.  Processing of SMTP Time
    For example, the following sample data is considered to be from a
    piece of email originating from the Domain Owner of "example.com":
 
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 59]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
      Author Domain: example.com
      SPF-authenticated Identifier: mail.example.com
      DKIM-authenticated Identifier: example.com
@@ -3289,22 +3318,6 @@ B.4.  Processing of SMTP Time
    Receiver considers the above email to pass the DMARC check, avoiding
    the "reject" policy that is requested to be applied to email that
    fails to pass the DMARC check.
-
-
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 59]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    If no Authenticated Identifiers align with the Author Domain, then
    the Mail Receiver applies the DMARC-record-specified policy.
@@ -3339,6 +3352,16 @@ Internet-Draft                  DMARCbis                   November 2021
    has not requested aggregate reports, i.e., no "rua" tag was found in
    the policy record.
 
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 60]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 B.5.  Utilization of Aggregate Feedback: Example
 
    Aggregate feedback is consumed by Domain Owners to verify their
@@ -3354,14 +3377,6 @@ B.5.  Utilization of Aggregate Feedback: Example
    checks provides visibility into problems that need to be addressed by
    the Domain Owner.  For example, if either SPF or DKIM fails to pass,
    the Domain Owner is provided with enough information to either
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 60]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    directly correct the problem or understand where authentication-
    breaking changes are being introduced in the email transmission path.
    If authentication-breaking changes due to email transmission path
@@ -3394,6 +3409,15 @@ C.1.1.  Ticket 80 - DMARCbis SHould Have Clear and Concise Defintion of
       ietf-dmarc-dmarcbis/pull/1/files (https://github.com/ietf-wg-
       dmarc/draft-ietf-dmarc-dmarcbis/pull/1/files)
 
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 61]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 C.2.  February 4, 2021
 
 C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208
@@ -3406,17 +3430,6 @@ C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208
    *  Diffs are here - https://github.com/ietf-wg-dmarc/draft-ietf-
       dmarc-dmarcbis/pull/3/files (https://github.com/ietf-wg-dmarc/
       draft-ietf-dmarc-dmarcbis/pull/3/files)
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 61]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 C.3.  February 10, 2021
 
@@ -3453,6 +3466,14 @@ C.5.2.  Ticket 3 - Two tiny nits
       date current text, which appears to have answered the concern
       raised.
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 62]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 C.5.3.  Ticket 4 - Definition of "fo" parameter
 
    *  Changes to wording in section 6.3, to bring clarity to use of
@@ -3465,14 +3486,6 @@ C.5.3.  Ticket 4 - Definition of "fo" parameter
 C.6.  March 16, 2021
 
 C.6.1.  Ticket 7 - ABNF for dmarc-record is slightly wrong
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 62]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    *  New text documented here - https://trac.ietf.org/trac/dmarc/
       ticket/7 (https://trac.ietf.org/trac/dmarc/ticket/7)
@@ -3508,6 +3521,15 @@ C.7.2.  Ticket 72 - Remove absolute requirement for p= tag in DMARC
       ticket/72#comment:3 (https://trac.ietf.org/trac/dmarc/
       ticket/72#comment:3)
 
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 63]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 C.8.  March 29, 2021
 
 C.8.1.  Ticket 54 - Remove or expand limits on number of recipients per
@@ -3518,17 +3540,6 @@ C.8.1.  Ticket 54 - Remove or expand limits on number of recipients per
    *  Diffs documented here - https://trac.ietf.org/trac/dmarc/
       ticket/54#comment:5 (https://trac.ietf.org/trac/dmarc/
       ticket/54#comment:5)
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 63]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 C.9.  April 12, 2021
 
@@ -3567,6 +3578,14 @@ C.10.1.  Ticket 53 - Remove reporting message size chunking
 
 C.10.2.  Ticket 52 - Remove strict alignment (and adkim and aspf tags)
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 64]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    *  Proposed text to remove all references to strict alignment
 
    *  Data demonstrating lack of use of feature entered into ticket -
@@ -3576,15 +3595,6 @@ C.10.2.  Ticket 52 - Remove strict alignment (and adkim and aspf tags)
 C.10.3.  Ticket 47 - Remove pct= tag
 
    *  Proposed text to remove all references to pct and message sampling
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 64]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    *  Data demonstrating lack of use of feature entered into ticket -
       https://trac.ietf.org/trac/dmarc/ticket/47#comment:4
@@ -3624,6 +3634,14 @@ C.12.1.  Ticket 86 - A-R results for DMARC
    *  Proposed text to add for polrec.p and polrec.domain methods for
       registry update.
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 65]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    *  Did not include polrec.pct due to proposal to remove pct tag
       (Ticket 47)
 
@@ -3633,14 +3651,6 @@ C.12.2.  Ticket 62 - Make aggregate reporting a normative MUST
       titled "Send Aggregate Reports"
 
 C.13.  April 19, 2021
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 65]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 C.13.1.  Ticket 109 - Sanity Check DMARCbis Document
 
@@ -3680,23 +3690,20 @@ C.17.  August 12, 2021
 
 C.17.1.  Publication of draft-ietf-dmarc-dmarcbis-03
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 66]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    *  Removal of "pct" tag
 
    *  Addition of "t" tag
 
    *  Rearranging of some text and formatting for better readability and
       consistency.
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 66]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 Acknowledgements
 
@@ -3742,11 +3749,4 @@ Authors' Addresses
 
 
 
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 22 May 2022                 [Page 67]
+Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 67]

--- a/draft-ietf-dmarc-dmarcbis-04.txt
+++ b/draft-ietf-dmarc-dmarcbis-04.txt
@@ -6,7 +6,7 @@ DMARC                                                       T. Herr (ed)
 Internet-Draft                                                  Valimail
 Obsoletes: 7489 (if approved)                             J. Levine (ed)
 Intended status: Standards Track                           Standcore LLC
-Expires: 26 May 2022                                    22 November 2021
+Expires: 27 May 2022                                    23 November 2021
 
 
 Domain-based Message Authentication, Reporting, and Conformance (DMARC)
@@ -41,7 +41,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 26 May 2022.
+   This Internet-Draft will expire on 27 May 2022.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 1]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 1]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -91,43 +91,44 @@ Table of Contents
        3.2.11. PSO Controlled Domain Names . . . . . . . . . . . . .  10
        3.2.12. Report Receiver . . . . . . . . . . . . . . . . . . .  11
    4.  Overview and Key Concepts . . . . . . . . . . . . . . . . . .  11
-     4.1.  Use of RFC5322.From . . . . . . . . . . . . . . . . . . .  12
-     4.2.  Authentication Mechanisms . . . . . . . . . . . . . . . .  13
-     4.3.  Flow Diagram  . . . . . . . . . . . . . . . . . . . . . .  13
-     4.4.  Identifier Alignment Explained  . . . . . . . . . . . . .  15
-       4.4.1.  DKIM-Authenticated Identifiers  . . . . . . . . . . .  15
-       4.4.2.  SPF-Authenticated Identifiers . . . . . . . . . . . .  16
-       4.4.3.  Alignment and Extension Technologies  . . . . . . . .  16
-     4.5.  Determining The Organizational Domain . . . . . . . . . .  17
-   5.  Policy  . . . . . . . . . . . . . . . . . . . . . . . . . . .  18
-     5.1.  DMARC Policy Record . . . . . . . . . . . . . . . . . . .  19
-     5.2.  DMARC URIs  . . . . . . . . . . . . . . . . . . . . . . .  19
-     5.3.  General Record Format . . . . . . . . . . . . . . . . . .  19
-     5.4.  Formal Definition . . . . . . . . . . . . . . . . . . . .  24
-     5.5.  Domain Owner Actions  . . . . . . . . . . . . . . . . . .  25
-       5.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  25
+     4.1.  DMARC Basics  . . . . . . . . . . . . . . . . . . . . . .  11
+     4.2.  Use of RFC5322.From . . . . . . . . . . . . . . . . . . .  12
+     4.3.  Authentication Mechanisms . . . . . . . . . . . . . . . .  13
+     4.4.  Flow Diagram  . . . . . . . . . . . . . . . . . . . . . .  13
+     4.5.  DNS Tree Walk . . . . . . . . . . . . . . . . . . . . . .  15
+     4.6.  Determining the Organizational Domain . . . . . . . . . .  16
+     4.7.  Identifier Alignment Explained  . . . . . . . . . . . . .  17
+       4.7.1.  DKIM-Authenticated Identifiers  . . . . . . . . . . .  17
+       4.7.2.  SPF-Authenticated Identifiers . . . . . . . . . . . .  18
+       4.7.3.  Alignment and Extension Technologies  . . . . . . . .  19
+   5.  Policy  . . . . . . . . . . . . . . . . . . . . . . . . . . .  19
+     5.1.  DMARC Policy Record . . . . . . . . . . . . . . . . . . .  20
+     5.2.  DMARC URIs  . . . . . . . . . . . . . . . . . . . . . . .  20
+     5.3.  General Record Format . . . . . . . . . . . . . . . . . .  20
+     5.4.  Formal Definition . . . . . . . . . . . . . . . . . . . .  25
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 2]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 2]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
+     5.5.  Domain Owner Actions  . . . . . . . . . . . . . . . . . .  26
+       5.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  26
        5.5.2.  Configure Sending System for DKIM Signing Using an
-               Aligned Domain  . . . . . . . . . . . . . . . . . . .  25
-       5.5.3.  Setup a Mailbox to Receive Aggregate Reports  . . . .  25
-       5.5.4.  Publish a DMARC Policy for the Author Domain  . . . .  26
+               Aligned Domain  . . . . . . . . . . . . . . . . . . .  26
+       5.5.3.  Setup a Mailbox to Receive Aggregate Reports  . . . .  27
+       5.5.4.  Publish a DMARC Policy for the Author Domain  . . . .  27
        5.5.5.  Collect and Analyze Reports and Adjust
-               Authentication  . . . . . . . . . . . . . . . . . . .  26
-       5.5.6.  Decide If and When to Update DMARC Policy . . . . . .  26
-     5.6.  PSO Actions . . . . . . . . . . . . . . . . . . . . . . .  26
-     5.7.  Mail Receiver Actions . . . . . . . . . . . . . . . . . .  27
-       5.7.1.  Extract Author Domain . . . . . . . . . . . . . . . .  27
-       5.7.2.  Determine Handling Policy . . . . . . . . . . . . . .  27
-       5.7.3.  Policy Discovery  . . . . . . . . . . . . . . . . . .  29
-       5.7.4.  Store Results of DMARC Processing . . . . . . . . . .  31
-       5.7.5.  Send Aggregate Reports  . . . . . . . . . . . . . . .  31
+               Authentication  . . . . . . . . . . . . . . . . . . .  27
+       5.5.6.  Decide If and When to Update DMARC Policy . . . . . .  28
+     5.6.  PSO Actions . . . . . . . . . . . . . . . . . . . . . . .  28
+     5.7.  Mail Receiver Actions . . . . . . . . . . . . . . . . . .  28
+       5.7.1.  Extract Author Domain . . . . . . . . . . . . . . . .  28
+       5.7.2.  Determine Handling Policy . . . . . . . . . . . . . .  29
+       5.7.3.  Store Results of DMARC Processing . . . . . . . . . .  31
+       5.7.4.  Send Aggregate Reports  . . . . . . . . . . . . . . .  31
      5.8.  Policy Enforcement Considerations . . . . . . . . . . . .  31
    6.  DMARC Feedback  . . . . . . . . . . . . . . . . . . . . . . .  32
    7.  Other Topics  . . . . . . . . . . . . . . . . . . . . . . . .  33
@@ -161,15 +162,15 @@ Internet-Draft                  DMARCbis                   November 2021
      A.5.  Issues with ADSP in Operation . . . . . . . . . . . . . .  49
      A.6.  Organizational Domain Discovery Issues  . . . . . . . . .  50
        A.6.1.  Public Suffix Lists . . . . . . . . . . . . . . . . .  50
-     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  51
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 3]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 3]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
+     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  51
    Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  52
      B.1.  Identifier Alignment Examples . . . . . . . . . . . . . .  52
        B.1.1.  SPF . . . . . . . . . . . . . . . . . . . . . . . . .  52
@@ -216,16 +217,17 @@ Internet-Draft                  DMARCbis                   November 2021
                DMARC . . . . . . . . . . . . . . . . . . . . . . . .  64
        C.9.3.  Ticket 96 - Tweaks to Abstract and Introduction . . .  64
      C.10. April 13, 2021  . . . . . . . . . . . . . . . . . . . . .  64
-       C.10.1.  Ticket 53 - Remove reporting message size
-               chunking  . . . . . . . . . . . . . . . . . . . . . .  64
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 4]
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 4]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
+       C.10.1.  Ticket 53 - Remove reporting message size
+               chunking  . . . . . . . . . . . . . . . . . . . . . .  64
        C.10.2.  Ticket 52 - Remove strict alignment (and adkim and
                aspf tags)  . . . . . . . . . . . . . . . . . . . . .  64
        C.10.3.  Ticket 47 - Remove pct= tag  . . . . . . . . . . . .  65
@@ -275,9 +277,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 5]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 5]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -333,7 +333,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 6]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 6]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -389,7 +389,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 7]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 7]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -445,7 +445,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 8]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 8]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -476,7 +476,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    Domain-level identifiers that are verified using authentication
    technologies are referred to as "Authenticated Identifiers".  See
-   Section 4.2 for details about the supported mechanisms.
+   Section 4.3 for details about the supported mechanisms.
 
 3.2.2.  Author Domain
 
@@ -501,7 +501,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                  [Page 9]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 9]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -509,8 +509,8 @@ Internet-Draft                  DMARCbis                   November 2021
 3.2.4.  Identifier Alignment
 
    When the domain in the address in the From: header field has the same
-   Organizational Domain as a domain verified by SPF or DKIM (or both),
-   it has Identifier Alignment. (see below)
+   Organizational Domain as a domain verified by an authenticated
+   identifier, it has Identifier Alignment. (see below)
 
 3.2.5.  Longest PSD
 
@@ -534,7 +534,7 @@ Internet-Draft                  DMARCbis                   November 2021
    with a domain name registrar.  More formally, it is any Public Suffix
    Domain plus one label.  The Organizational Domain for the domain in
    the RFC5322.From domain is determined by applying the algorithm found
-   in Section 4.5.
+   in Section 4.6.
 
 3.2.9.  Public Suffix Domain (PSD)
 
@@ -557,7 +557,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 10]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 10]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -578,6 +578,8 @@ Internet-Draft                  DMARCbis                   November 2021
    This section provides a general overview of the design and operation
    of the DMARC environment.
 
+4.1.  DMARC Basics
+
    DMARC permits a Domain Owner or PSO to enable verification of a
    domain's use in an email message, to indicate the Domain Owner's or
    PSO's message handling preference regarding failed verification, and
@@ -587,7 +589,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    DMARC's verification function is based on whether the RFC5322.From
    domain is aligned with a domain name used in a supported
-   authentication mechanism.  Section 4.2 When a DMARC policy exists for
+   authentication mechanism.  Section 4.3 When a DMARC policy exists for
    the domain name found in the RFC5322.From header field, and that
    domain name is not verified through an aligned supported
    authentication mechanism, the handling of that message can be
@@ -600,7 +602,7 @@ Internet-Draft                  DMARCbis                   November 2021
    1.  produces a "pass" result, and
 
    2.  produces that result based on an identifier that is in alignment,
-       as described in Section 4.4.
+       as described in Section 4.7.
 
    It is important to note that the authentication mechanisms employed
    by DMARC authenticate only a DNS domain and do not authenticate the
@@ -611,9 +613,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 11]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 11]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -633,7 +633,7 @@ Internet-Draft                  DMARCbis                   November 2021
    DMARC but defined in other referenced material such as [RFC6591] and
    [DMARC-Failure-Reporting]
 
-4.1.  Use of RFC5322.From
+4.2.  Use of RFC5322.From
 
    One of the most obvious points of security scrutiny for DMARC is the
    choice to focus on an identifier, namely the RFC5322.From address,
@@ -669,7 +669,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 12]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 12]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -679,7 +679,7 @@ Internet-Draft                  DMARCbis                   November 2021
    operate under a slightly restricted profile of RFC5322 with respect
    to the expected syntax of this field.  See Section 5.7 for details.
 
-4.2.  Authentication Mechanisms
+4.3.  Authentication Mechanisms
 
    The following mechanisms for determining Authenticated Identifiers
    are supported in this version of DMARC:
@@ -695,7 +695,7 @@ Internet-Draft                  DMARCbis                   November 2021
       describes MAIL FROM processing for cases in which the MAIL command
       has a null path.
 
-4.3.  Flow Diagram
+4.4.  Flow Diagram
 
 
 
@@ -725,7 +725,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 13]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 13]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -781,12 +781,124 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 14]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 14]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-4.4.  Identifier Alignment Explained
+4.5.  DNS Tree Walk
+
+   While the DMARC protocol defines a method for communicating
+   information through publishing records in DNS, it is not necessarily
+   true that a DMARC policy record for a given domain will be found in
+   DNS at the same level as the name label for the domain in question.
+   Instead, some domains will inherit their DNS policy records from
+   parent domains one level or more above them in the DNS hierarchy, and
+   these records can only be discovered through a technique described
+   here, one known colloquially as a "DNS Tree Walk".
+
+   The process for a DNS Tree Walk will always start at the point in the
+   DNS hierarchy that matches the domain in the RFC5322.From header of
+   the message, and will always end at the Public Suffix Domain that
+   terminates the RFC5322.From domain.  To prevent possible abuse of the
+   DNS, a shortcut is built into the process so that RFC5322.From
+   domains that have more than five labels do not result in more than
+   five DNS queries.
+
+   The generic steps for a DNS Tree Walk are as follows:
+
+   1.  Query the DNS for a DMARC TXT record at the DNS domain matching
+       the one found in the RFC5322.From domain in the message.  A
+       possibly empty set of records is returned.
+
+   2.  Records that do not start with a "v=" tag that identifies the
+       current version of DMARC are discarded.
+
+   3.  If the set is now empty, or the set contains one valid DMARC
+       record that does not contain the information sought, then
+       determine the target for additional queries, using steps 4
+       through 8 below.
+
+   4.  Break the subject DNS domain name into a set of "n" ordered
+       labels.  Number these labels from right to left; e.g., for
+       "a.mail.example.com", "com" would be label 1, "example" would be
+       label 2, "mail.example.com" would be label 3, and so forth.
+
+   5.  Count the number of labels found in the subject DNS domain.  Let
+       that number be "x".  If x < 5, remove the left-most (highest-
+       numbered) label from the subject domain.  If x >= 5, remove the
+       left-most (highest-numbered) labels from the subject domain until
+       4 labels remain.  The resulting DNS domain name is the new target
+       for subsequent lookups.
+
+   6.  Query the DNS for a DMARC TXT record at the DNS domain matching
+       this new target in place of the RFC5322.From domain in the
+       message.  A possibly empty set of records is returned.
+
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 15]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+   7.  Records that do not start with a "v=" tag that identifies the
+       current version of DMARC are discarded.
+
+   8.  If the set is now empty, or the set contains one valid DMARC
+       record that does not contain the information sought, then
+       determine the target for additional queries by removing a single
+       label from the target domain as described in step 5 and repeating
+       steps 6 and 7 until there are no more labels remaining or a valid
+       DMARC record containing the information sought has been
+       retrieved.
+
+   To illustrate, for a message with the arbitrary RFC5322.From domain
+   of "a.b.c.d.e.mail.example.com", a full DNS Tree Walk would require
+   the following five queries, in order:
+
+   *  _dmarc.a.b.c.d.e.mail.example.com
+
+   *  _dmarc.e.mail.example.com
+
+   *  _dmarc.mail.example.com
+
+   *  _dmarc.example.com
+
+   *  _dmarc.com
+
+4.6.  Determining the Organizational Domain
+
+   The DMARC protocol defines a method for a Public Suffix Domain to
+   identify itself as such using a tag in its published DMARC policy
+   record.  An Organizational Domain is any subdomain of a PSD that
+   includes exactly one more label than the PSD in its name.
+
+   For any email message, the Organizational Domain of the RFC5322.From
+   domain is determined by performing a DNS Tree Walk as described in
+   Section 4.5.  The target of the search is a valid DMARC record that
+   contains a psd tag with a value of 'y'.  Once such a record has been
+   found, the Organizational Domain for the DNS domain matching the one
+   found in the RFC5322.From domain can be declared to be the target
+   domain queried for in the step just prior to the query that found the
+   PSD domain.
+
+   For example, given the RFC5322.From domain "a.mail.example.com", a
+   series of DNS queries for DMARC records would be executed starting
+   with "_dmarc.a.mail.example.com" and finishing with "_dmarc.com".
+   The "_dmarc.com" record would contain a psd tag with a value of 'y',
+   and so the Organizational Domain for this RFC5322.From domain would
+   be determined to be "example.com", the domain of the DMARC query
+   executed prior to the query for "_dmarc.com".
+
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 16]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+4.7.  Identifier Alignment Explained
 
    Email authentication technologies authenticate various (and
    disparate) aspects of an individual message.  For example, DKIM
@@ -797,9 +909,13 @@ Internet-Draft                  DMARCbis                   November 2021
    These may be different domains, and they are typically not visible to
    the end user.
 
-   DMARC authenticates use of the RFC5322.From domain by requiring that
-   it have the same Organizational Domain as (i.e., be aligned with) an
-   Authenticated Identifier.  Domain names in this context are to be
+   DMARC authenticates use of the RFC5322.From domain by requiring
+   either that it have the same Organizational Domain as an
+   Authenticated Identifier (a condition known as "relaxed alignment")
+   or that it be identical to the domain of the Authenticated Identifier
+   (a condition known as "strict alignment").  The choice of relaxed or
+   strict alignment is left to the domain owner and is expressed in the
+   domain's DMARC policy record.  Domain names in this context are to be
    compared in a case-insensitive manner, per [RFC4343].
 
    It is important to note that Identifier Alignment cannot occur with a
@@ -816,7 +932,7 @@ Internet-Draft                  DMARCbis                   November 2021
    as input yields authenticated domains as their outputs when they
    succeed.
 
-4.4.1.  DKIM-Authenticated Identifiers
+4.7.1.  DKIM-Authenticated Identifiers
 
    DMARC requires Identifier Alignment based on the result of a DKIM
    authentication because a message can bear a valid signature from any
@@ -828,19 +944,22 @@ Internet-Draft                  DMARCbis                   November 2021
    authentication to be strict or relaxed.  (Note that these terms are
    not related to DKIM's "simple" and "relaxed" canonicalization modes.)
 
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 17]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    In relaxed mode, the Organizational Domains of both the DKIM-
    authenticated signing domain (taken from the value of the d= tag in
    the signature) and that of the RFC5322.From domain must be equal if
    the identifiers are to be considered to be aligned.  In strict mode,
    only an exact match between both Fully Qualified Domain Names (FQDNs)
    is considered to produce Identifier Alignment.
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 15]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    To illustrate, in relaxed mode, if a verified DKIM signature
    successfully verifies with a "d=" domain of "example.com", and the
@@ -858,7 +977,7 @@ Internet-Draft                  DMARCbis                   November 2021
    is considered to produce a DMARC "pass" result if any DKIM signature
    is aligned and verifies.
 
-4.4.2.  SPF-Authenticated Identifiers
+4.7.2.  SPF-Authenticated Identifiers
 
    DMARC permits Identifier Alignment based on the result of an SPF
    authentication.  As with DKIM, Identifier Alignement can be either
@@ -883,90 +1002,20 @@ Internet-Draft                  DMARCbis                   November 2021
    [RFC7208], which recommends that SPF checks be done on not only the
    "MAIL FROM" but also on a separate check of the "HELO" identity.
 
-4.4.3.  Alignment and Extension Technologies
+
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 18]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
+4.7.3.  Alignment and Extension Technologies
 
    If in the future DMARC is extended to include the use of other
    authentication mechanisms, the extensions will need to allow for
    domain identifier extraction so that alignment with the RFC5322.From
    domain can be verified.
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 16]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-4.5.  Determining The Organizational Domain
-
-   The DMARC protocol defines a method for a Public Suffix Domain to
-   identify itself as such using a tag in its published DMARC policy
-   record.  An Organizational Domain is any subdomain of a PSD that
-   includes exactly one more label than the PSD in its name.
-
-   For any email message, the Organizational Domain of the RFC5322.From
-   domain is determined using the following algorithm, similar to the
-   one described in Section 5.7.3
-
-   1.  Query the DNS for a DMARC TXT record at the DNS domain matching
-       the one found in the RFC5322.From domain in the message.  A
-       possibly empty set of records is returned.
-
-   2.  Records that do not start with a "v=" tag that identifies the
-       current version of DMARC are discarded.
-
-   3.  If the set is now empty, or the set contains one valid DMARC
-       record that does not include a psd tag with a value of 'y', then
-       determine the target for additional queries, using steps 4
-       through 8 below.
-
-   4.  Break the subject DNS domain name into a set of "n" ordered
-       labels.  Number these labels from right to left; e.g., for
-       "a.mail.example.com", "com" would be label 1 and "example" would
-       be label 2 and so forth.
-
-   5.  Count the number of labels found in the subject DNS domain.  Let
-       that number be "x".  If x < 5, remove the left-most (highest-
-       numbered) label from the subject domain.  If x >= 5, remove the
-       left-most (highest-numbered) labels from the subject domain until
-       4 labels remain.  The resulting DNS domain name is the new target
-       for subsequent lookups.
-
-   6.  Query the DNS for a DMARC TXT record at the DNS domain matching
-       this new target in place of the RFC5322.From domain in the
-       message.  A possibly empty set of records is returned.
-
-   7.  Records that do not start with a "v=" tag that identifies the
-       current version of DMARC are discarded.
-
-   8.  If the set is now empty, or the set contains one valid DMARC
-       record that does not include a psd tag with the value of 'y',
-       then determine the target for additional queries by removing a
-       single label from the target domain as described in step 5 and
-       repeating steps 6 and 7 until there are no more labels remaining
-       or a record containing a psd tag with a value of 'y' is found.
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 17]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-   9.  Once a valid DMARC record containing a psd tag with a value of
-       'y' has been found, the Organizational Domain for the DNS domain
-       matching the one found in the RFC5322.From domain can be declared
-       to be the target domain queried for in the step prior to the
-       query that found the PSD domain.
-
-   For example, given the RFC5322.From domain "a.mail.example.com", a
-   series of DNS queries for DMARC records would be executed starting
-   with "_dmarc.a.mail.example.com" and finishing with "_dmarc.com".
-   The "_dmarc.com" record would contain a psd tag with a value of 'y',
-   and so the Organizational Domain for this RFC5322.From domain would
-   be determined to be "example.com", the domain of the DMARC query
-   executed prior to the query for "_dmarc.com".
 
 5.  Policy
 
@@ -994,10 +1043,9 @@ Internet-Draft                  DMARCbis                   November 2021
    A Mail Receiver implementing the DMARC mechanism SHOULD make a best-
    effort attempt to adhere to the Domain Owner's or PSO's published
    DMARC Domain Owner Assessment Policy when a message fails the DMARC
-   test.
-   Since email streams can be complicated (due to forwarding, existing
-   RFC5322.From domain-spoofing services, etc.), Mail Receivers MAY
-   deviate from a published Domain Owner Assessment Policy during
+   test.  Since email streams can be complicated (due to forwarding,
+   existing RFC5322.From domain-spoofing services, etc.), Mail Receivers
+   MAY deviate from a published Domain Owner Assessment Policy during
    message processing and SHOULD make available the fact of and reason
    for the deviation to the Domain Owner via feedback reporting,
    specifically using the "PolicyOverride" feature of the aggregate
@@ -1005,7 +1053,15 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 18]
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 19]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1061,7 +1117,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 19]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 20]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1075,7 +1131,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    adkim:  (plain-text; OPTIONAL; default is "r".)  Indicates whether
       strict or relaxed DKIM Identifier Alignment mode is required by
-      the Domain Owner.  See Section 4.4.1 for details.  Valid values
+      the Domain Owner.  See Section 4.7.1 for details.  Valid values
       are as follows:
 
       r:  relaxed mode
@@ -1084,7 +1140,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    aspf:  (plain-text; OPTIONAL; default is "r".)  Indicates whether
       strict or relaxed SPF Identifier Alignment mode is required by the
-      Domain Owner.  See Section 4.4.2 for details.  Valid values are as
+      Domain Owner.  See Section 4.7.2 for details.  Valid values are as
       follows:
 
       r:  relaxed mode
@@ -1117,7 +1173,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 20]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 21]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1154,7 +1210,7 @@ Internet-Draft                  DMARCbis                   November 2021
       present, MUST be applied for non-existent subdomains.  Note that
       "np" will be ignored for DMARC records published on subdomains of
       Organizational Domains and PSDs due to the effect of the DMARC
-      policy discovery mechanism described in Section 5.7.3.
+      policy discovery mechanism described in Section 5.7.2.1.
 
    p:  Domain Owner Assessment Policy (plain-text; RECOMMENDED for
       policy records).  Indicates the message handling preference the
@@ -1166,14 +1222,14 @@ Internet-Draft                  DMARCbis                   November 2021
       [DMARC-Aggregate-Reporting] and [DMARC-Failure-Reporting])
       Possible values are as follows:
 
-      none:  The Domain Owner offers no expression of concern.
+      none:  The Domain Owner offers no expression of preference.
 
       quarantine:  The Domain Owner considers such mail to be
          suspicious.  It is possible the mail is valid, although the
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 21]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 22]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1198,7 +1254,7 @@ Internet-Draft                  DMARCbis                   November 2021
          published for a domain that is not a PSD.
 
    rua:  Addresses to which aggregate feedback is to be sent (comma-
-      separated plain-text list of DMARC URIs; OPTIONAL).  Section 3 of
+      separated plain-text list of DMARC URIs; OPTIONAL).
       [DMARC-Aggregate-Reporting] discusses considerations that apply
       when the domain name of a URI differs from that of the domain
       advertising the policy.  See Section 9.5 for additional
@@ -1216,20 +1272,20 @@ Internet-Draft                  DMARCbis                   November 2021
       Receivers to send detailed failure reports about messages that
       fail the DMARC evaluation in specific ways (see the "fo" tag
       above).  The format of the message to be generated MUST follow the
-      format specified for the "rf" tag.  Section 3 of
-      [DMARC-Aggregate-Reporting] discusses considerations that apply
-      when the domain name of a URI differs from that of the domain
-      advertising the policy.  A Mail Receiver MUST implement support
-      for a "mailto:" URI, i.e., the ability to send a DMARC report via
-      electronic mail.  If not provided, Mail Receivers MUST NOT
-      generate failure reports.  See Section 9.5 for additional
-      considerations.
+      format specified for the "rf" tag.  [DMARC-Aggregate-Reporting]
+      discusses considerations that apply when the domain name of a URI
+      differs from that of the domain advertising the policy.  A Mail
+      Receiver MUST implement support for a "mailto:" URI, i.e., the
+      ability to send a DMARC report via electronic mail.  If not
+      provided, Mail Receivers MUST NOT generate failure reports.  See
+      Section 9.5 for additional considerations.
 
 
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 22]
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 23]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1245,7 +1301,7 @@ Internet-Draft                  DMARCbis                   November 2021
       be applied for subdomains.  Note that "sp" will be ignored for
       DMARC records published on subdomains of Organizational Domains
       due to the effect of the DMARC policy discovery mechanism
-      described in Section 5.7.3.
+      described in Section 5.7.2.1.
 
    t:  DMARC policy test mode (plain-text; OPTIONAL; default is 'n').
       For the RFC5322.From domain to which the DMARC record applies, the
@@ -1285,7 +1341,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 23]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 24]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1304,6 +1360,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
      dmarc-tag       = dmarc-request /
                        dmarc-test /
+                       dmarc-psd /
                        dmarc-srequest /
                        dmarc-nprequest /
                        dmarc-adkim /
@@ -1324,6 +1381,8 @@ Internet-Draft                  DMARCbis                   November 2021
 
      dmarc-test      = "t" *WSP "=" ( "y" / "n" )
 
+     dmarc-psd       = "psd" *WSP "=" ( "y" / "n" )
+
      dmarc-srequest  = "sp" *WSP "=" *WSP
                        ( "none" / "quarantine" / "reject" )
 
@@ -1335,17 +1394,17 @@ Internet-Draft                  DMARCbis                   November 2021
      dmarc-aspf      = "aspf" *WSP "=" *WSP ( "r" / "s" )
 
      dmarc-auri      = "rua" *WSP "=" *WSP
-                       dmarc-uri *(*WSP "," *WSP dmarc-uri)
-
-     dmarc-furi      = "ruf" *WSP "=" *WSP
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 24]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 25]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
+                       dmarc-uri *(*WSP "," *WSP dmarc-uri)
+
+     dmarc-furi      = "ruf" *WSP "=" *WSP
                        dmarc-uri *(*WSP "," *WSP dmarc-uri)
 
      dmarc-fo        = "fo" *WSP "=" *WSP
@@ -1382,6 +1441,23 @@ Internet-Draft                  DMARCbis                   November 2021
    that aligns with the Author Domain and configure its system to sign
    using that domain.
 
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 26]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 5.5.3.  Setup a Mailbox to Receive Aggregate Reports
 
    Proper consumption and analysis of DMARC aggregate reports is the key
@@ -1392,15 +1468,6 @@ Internet-Draft                  DMARCbis                   November 2021
    how mature the Domain Owner's DMARC rollout is, some of these sources
    could be legitimate ones that were overlooked during the intial
    deployment of SPF and/or DKIM.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 25]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    Because the aggregate reports are XML documents, it is strongly
    advised that they be machine-parsed, so setting up a mailbox involves
@@ -1430,6 +1497,23 @@ Internet-Draft                  DMARCbis                   November 2021
    reports, the Domain Owner can adjust the SPF record and/or configure
    DKIM signing for those systems.
 
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 27]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 5.5.6.  Decide If and When to Update DMARC Policy
 
    Once the Domain Owner is satisfied that it is properly authenticating
@@ -1448,15 +1532,6 @@ Internet-Draft                  DMARCbis                   November 2021
    availablle to Mail Receivers.  [RFC9091] is an experimental method
    for doing so, and the experiment is described in Appendix B of that
    document.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 26]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 5.7.  Mail Receiver Actions
 
@@ -1484,8 +1559,16 @@ Internet-Draft                  DMARCbis                   November 2021
    header field.  Multi-valued RFC5322.From header fields with multiple
    domains MUST be exempt from DMARC checking.
 
-   Note that domain names that appear on a public suffix list are not
-   exempt from DMARC policy application and reporting.
+   Note that Public Suffix Domains are not exempt from DMARC policy
+   application and reporting.
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 28]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 5.7.2.  Determine Handling Policy
 
@@ -1500,19 +1583,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    2.  Query the DNS for a DMARC policy record.  Continue if one is
        found, or terminate DMARC evaluation otherwise.  See
-       Section 5.7.3 for details.
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 27]
-
-Internet-Draft                  DMARCbis                   November 2021
-
+       Section 5.7.2.1 for details.
 
    3.  Perform DKIM signature verification checks.  A single email could
        contain multiple DKIM signatures.  The results of this step are
@@ -1536,16 +1607,24 @@ Internet-Draft                  DMARCbis                   November 2021
        failures, identifier mismatches) are considered to be DMARC
        mechanism check failures.
 
-   6.  Apply policy.  Emails that fail the DMARC mechanism check are
-       handled in accordance with the discovered DMARC policy of the
-       Domain Owner and any local policy rules enforced by the Mail
-       Receiver.  See Section 5.3 for details.
+   6.  Apply policy, if appropriate.  Emails that fail the DMARC
+       mechanism check are handled in accordance with the discovered
+       DMARC policy of the Domain Owner and any local policy rules
+       enforced by the Mail Receiver.  See Section 5.3 for details.
 
    Heuristics applied in the absence of use by a Domain Owner of either
    SPF or DKIM (e.g., [Best-Guess-SPF]) SHOULD NOT be used, as it may be
    the case that the Domain Owner wishes a Message Receiver not to
    consider the results of that underlying authentication protocol at
    all.
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 29]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    DMARC evaluation can only yield a "pass" result after one of the
    underlying authentication mechanisms passes for an aligned
@@ -1559,89 +1638,29 @@ Internet-Draft                  DMARCbis                   November 2021
    Handling of messages for which SPF and/or DKIM evaluation encounter a
    permanent DNS error is left to the discretion of the Mail Receiver.
 
+5.7.2.1.  DMARC Policy Discovery
 
+   Discovery of the applicable DMARC policy for any domain is
+   accomplished via a DNS Tree Walk as described in Section 4.5.  The
+   target of this tree walk is a valid DMARC policy record, and the
+   following rules should be applied to records that are found in this
+   manner:
 
+   1.  If the tree walk ends in the discovery of multiple records or no
+       records, DMARC processing is not applied to this message.
 
+   2.  If a retrieved policy record does not contain a valid "p" tag, or
+       contains an "sp" tag that is not valid, then:
 
+       *  If a "rua" tag is present and contains at least one
+          syntactically valid reporting URI, the Mail Receiver SHOULD
+          act as if a record containing a valid "v" tag and "p=none" was
+          retrieved, and continue processing;
 
+       *  Otherwise, the Mail Receiver applies no DMARC processing to
+          this message.
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 28]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-5.7.3.  Policy Discovery
-
-   As stated above, the DMARC mechanism uses DNS TXT records to
-   advertise policy.  Policy discovery is accomplished via a method
-   similar to the method used for SPF records.  This method, and the
-   important differences between DMARC and SPF mechanisms, are discussed
-   below.
-
-   To balance the conflicting requirements of supporting wildcarding and
-   allowing subdomain policy overrides, the following DNS lookup scheme
-   is employed:
-
-   1.   Mail Receivers MUST query the DNS for a DMARC TXT record at the
-        DNS domain matching the one found in the RFC5322.From domain in
-        the message.  A possibly empty set of records is returned.
-
-   2.   Records that do not start with a "v=" tag that identifies the
-        current version of DMARC are discarded.
-
-   3.   If the set is now empty, the Mail Receiver determines the target
-        for additional queries, using steps 4 through 8 below.
-
-   4.   Break the subject DNS domain name into a set of "n" ordered
-        labels.  Number these lables from right to left; e.g., for
-        "example.com", "com" would be label 1 and "example" would be
-        label 2.
-
-   5.   Count the number of labels found in the subject DNS domain.  Let
-        that number be "x".  If x < 5, remove the left-most (highest-
-        numbered) label from the subject domain.  If x >= 5, remove the
-        left-most (highest-numbered) labels from the subject domain
-        until 4 labels remain.  The resulting DNS domain name is the new
-        target for subsequent lookups.
-
-   6.   The Mail Receiver MUST query the DNS for a DMARC TXT record at
-        the DNS domain matching this new target in place of the
-        RFC5322.From domain in the message.  This record can contain
-        policy to be asserted for subdomains of the target.  A possibly
-        empty set of records is returned.
-
-   7.   Records that do not start with a "v=" tag that identifies the
-        current version of DMARC are discarded.
-
-   8.   If the set is now empty, the Mail Receiver determines the target
-        for additional queries by removing a single label from the
-        target domain as described in step 5 and repeating steps 6 and 7
-        until there are no more labels remaining.
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 29]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-   9.   If the remaining set contains multiple records or no records,
-        policy discovery terminates and DMARC processing is not applied
-        to this message.
-
-   10.  If a retrieved policy record does not contain a valid "p" tag,
-        or contains an "sp" tag that is not valid, then:
-
-        1.  if a "rua" tag is present and contains at least one
-            syntactically valid reporting URI, the Mail Receiver SHOULD
-            act as if a record containing a valid "v" tag and "p=none"
-            was retrieved, and continue processing;
-
-        2.  otherwise, the Mail Receiver applies no DMARC processing to
-            this message.
-
-   If the set produced by the mechanism above contains no DMARC policy
+   If the set produced by the DNS Tree Walk contains no DMARC policy
    record (i.e., any indication that there is no such record as opposed
    to a transient DNS error), Mail Receivers SHOULD NOT apply the DMARC
    mechanism to the message.
@@ -1655,14 +1674,13 @@ Internet-Draft                  DMARCbis                   November 2021
    cleared, allowing a definite DMARC conclusion to be reached ("fail
    closed").
 
-5.7.3.1.  Longest PSD Example
 
-   As an example of step 5 above, for a message with the Organizational
-   Domain of "example.compute.cloudcompany.com.example", the query for
-   PSD DMARC would use "compute.cloudcompany.com.example" as the longest
-   PSD.  The receiver would check to see if that PSD is listed in the
-   DMARC PSD Registry, and if so, perform the policy lookup at
-   "_dmarc.compute.cloudcompany.com.example".
+
+
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 30]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    Note: Because the PSD policy query comes after the Organizational
    Domain policy query, PSD policy is not used for Organizational
@@ -1670,26 +1688,14 @@ Internet-Draft                  DMARCbis                   November 2021
    not a mechanism to provide feedback addresses (RUA/RUF) when an
    Organizational Domain has declined to do so.
 
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 30]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-5.7.4.  Store Results of DMARC Processing
+5.7.3.  Store Results of DMARC Processing
 
    The results of Mail Receiver-based DMARC processing should be stored
    for eventual presentation back to the Domain Owner in the form of
    aggregate feedback reports.  Section 5.3 and
    [DMARC-Aggregate-Reporting] discuss aggregate feedback.
 
-5.7.5.  Send Aggregate Reports
+5.7.4.  Send Aggregate Reports
 
    For a Domain Owner, DMARC aggregate reports provide data about all
    mailstreams making use of its domain in email, to include not only
@@ -1705,7 +1711,7 @@ Internet-Draft                  DMARCbis                   November 2021
    'none' cannot.
 
    In order to ensure maximum usefulness for DMARC across the email
-   ecosystem, then, Mail Receivers MUST generate and send aggregate
+   ecosystem, then, Mail Receivers SHOULD generate and send aggregate
    reports with a frequency of at least once every 24 hours.
 
 5.8.  Policy Enforcement Considerations
@@ -1724,19 +1730,17 @@ Internet-Draft                  DMARCbis                   November 2021
    increase the likelihood of accepting abusive mail if they choose not
    to honor the published Domain Owner Assessment Policy.  At a minimum,
    addition of the Authentication-Results header field (see [RFC8601])
-   is RECOMMENDED when delivery of failing mail is done.  When this is
-   done, the DNS domain name thus recorded MUST be encoded as an
-   A-label.
 
 
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 31]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 31]
 
 Internet-Draft                  DMARCbis                   November 2021
 
+
+   is RECOMMENDED when delivery of failing mail is done.  When this is
+   done, the DNS domain name thus recorded MUST be encoded as an
+   A-label.
 
    Mail Receivers are only obligated to report reject or quarantine
    policy actions in aggregate feedback reports that are due to
@@ -1785,11 +1789,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 32]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 32]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1845,7 +1845,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 33]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 33]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1886,13 +1886,14 @@ Internet-Draft                  DMARCbis                   November 2021
    In the latter case, when doing an SMTP rejection, providing a clear
    hint can be useful in resolving issues.  A receiver might indicate in
    plain text the reason for the rejection by using the word "DMARC"
-   somewhere in the reply text.  Many systems are able to scan the SMTP
-   reply text to determine the nature of the rejection.  Thus, providing
-   a machine-detectable reason for rejection allows the problems causing
-   rejections to be properly addressed by automated systems.  For
-   example:
+   somewhere in the reply text.  For example:
 
    550 5.7.1 Email rejected per DMARC policy for example.com
+
+   Many systems are able to scan the SMTP reply text to determine the
+   nature of the rejection.  Thus, providing a machine-detectable reason
+   for rejection allows the problems causing rejections to be properly
+   addressed by automated systems.
 
    If a Mail Receiver elects to defer delivery due to inability to
    retrieve or apply DMARC policy, this is best done with a 4xy SMTP
@@ -1900,8 +1901,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 34]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 34]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -1957,7 +1957,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 35]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 35]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2013,7 +2013,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 36]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 36]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2069,7 +2069,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 37]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 37]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2125,44 +2125,53 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 38]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 38]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-   +----------+-----------+----------+------------------------------+
-   | Tag Name | Reference | Status   | Description                  |
-   +==========+===========+==========+==============================+
-   | adkim    | RFC 7489  | current  | DKIM alignment mode          |
-   +----------+-----------+----------+------------------------------+
-   | aspf     | RFC 7489  | current  | SPF alignment mode           |
-   +----------+-----------+----------+------------------------------+
-   | fo       | RFC 7489  | current  | Failure reporting options    |
-   +----------+-----------+----------+------------------------------+
-   | p        | RFC 7489  | current  | Requested handling policy    |
-   +----------+-----------+----------+------------------------------+
-   | pct      | RFC 7489  | historic | Sampling rate                |
-   +----------+-----------+----------+------------------------------+
-   | rf       | RFC 7489  | historic | Failure reporting format(s)  |
-   +----------+-----------+----------+------------------------------+
-   | ri       | RFC 7489  | historic | Aggregate Reporting interval |
-   +----------+-----------+----------+------------------------------+
-   | rua      | RFC 7489  | current  | Reporting URI(s) for         |
-   |          |           |          | aggregate data               |
-   +----------+-----------+----------+------------------------------+
-   | ruf      | RFC 7489  | current  | Reporting URI(s) for failure |
-   |          |           |          | data                         |
-   +----------+-----------+----------+------------------------------+
-   | sp       | RFC 7489  | current  | Requested handling policy    |
-   |          |           |          | for subdomains               |
-   +----------+-----------+----------+------------------------------+
-   | t        | RFC 7489  | current  | Test mode for the specified  |
-   |          |           |          | policy                       |
-   +----------+-----------+----------+------------------------------+
-   | v        | RFC 7489  | current  | Specification version        |
-   +----------+-----------+----------+------------------------------+
+   +-------+-----------+----------+-----------------------------+
+   | Tag   | Reference | Status   | Description                 |
+   | Name  |           |          |                             |
+   +=======+===========+==========+=============================+
+   | adkim | RFC 7489  | current  | DKIM alignment mode         |
+   +-------+-----------+----------+-----------------------------+
+   | aspf  | RFC 7489  | current  | SPF alignment mode          |
+   +-------+-----------+----------+-----------------------------+
+   | fo    | RFC 7489  | current  | Failure reporting options   |
+   +-------+-----------+----------+-----------------------------+
+   | np    | RFC 7489  | current  | Requested handling policy   |
+   |       |           |          | for non-existent subdomains |
+   +-------+-----------+----------+-----------------------------+
+   | p     | RFC 7489  | current  | Requested handling policy   |
+   +-------+-----------+----------+-----------------------------+
+   | pct   | RFC 7489  | historic | Sampling rate               |
+   +-------+-----------+----------+-----------------------------+
+   | psd   | RFC 7489  | current  | Indicates whether policy    |
+   |       |           |          | record is published by a    |
+   |       |           |          | Public Suffix Domain        |
+   +-------+-----------+----------+-----------------------------+
+   | rf    | RFC 7489  | historic | Failure reporting format(s) |
+   +-------+-----------+----------+-----------------------------+
+   | ri    | RFC 7489  | historic | Aggregate Reporting         |
+   |       |           |          | interval                    |
+   +-------+-----------+----------+-----------------------------+
+   | rua   | RFC 7489  | current  | Reporting URI(s) for        |
+   |       |           |          | aggregate data              |
+   +-------+-----------+----------+-----------------------------+
+   | ruf   | RFC 7489  | current  | Reporting URI(s) for        |
+   |       |           |          | failure data                |
+   +-------+-----------+----------+-----------------------------+
+   | sp    | RFC 7489  | current  | Requested handling policy   |
+   |       |           |          | for subdomains              |
+   +-------+-----------+----------+-----------------------------+
+   | t     | RFC 7489  | current  | Test mode for the specified |
+   |       |           |          | policy                      |
+   +-------+-----------+----------+-----------------------------+
+   | v     | RFC 7489  | current  | Specification version       |
+   +-------+-----------+----------+-----------------------------+
 
-                     Table 3: "DMARC Tag Registry"
+                   Table 3: "DMARC Tag Registry"
 
 8.5.  DMARC Report Format Registry
 
@@ -2172,16 +2181,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 39]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 39]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2237,7 +2237,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 40]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 40]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2293,7 +2293,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 41]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 41]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2349,7 +2349,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 42]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 42]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2405,7 +2405,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 43]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 43]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2461,7 +2461,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 44]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 44]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2517,7 +2517,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 45]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 45]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2573,7 +2573,7 @@ Appendix A.  Technology Considerations
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 46]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 46]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2629,7 +2629,7 @@ A.2.  Method Exclusion
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 47]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 47]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2685,7 +2685,7 @@ A.4.  Domain Existence Test
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 48]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 48]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2741,7 +2741,7 @@ A.5.  Issues with ADSP in Operation
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 49]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 49]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2775,7 +2775,7 @@ A.6.  Organizational Domain Discovery Issues
    constitutes an amplified denial-of-service attack.
 
    The Organizational Domain mechanism is a necessary component to the
-   goals of DMARC.  The method described in Section 4.5 is far from
+   goals of DMARC.  The method described in Section 4.6 is far from
    perfect but serves this purpose reasonably well without adding undue
    burden or semantics to the DNS.  If a method is created to do so that
    is more reliable and secure than the use of a public suffix list,
@@ -2797,7 +2797,7 @@ A.6.1.  Public Suffix Lists
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 50]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 50]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2853,7 +2853,7 @@ A.7.  Removal of the "pct" Tag
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 51]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 51]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2909,7 +2909,7 @@ B.1.1.  SPF
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 52]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 52]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2965,7 +2965,7 @@ B.1.2.  DKIM
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 53]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 53]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3021,7 +3021,7 @@ B.2.1.  Entire Domain, Monitoring Only
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 54]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 54]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3077,7 +3077,7 @@ B.2.2.  Entire Domain, Monitoring Only, Per-Message Reports
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 55]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 55]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3133,7 +3133,7 @@ B.2.3.  Per-Message Failure Reports Directed to Third Party
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 56]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 56]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3189,7 +3189,7 @@ B.2.4.  Subdomain, Testing, and Multiple Aggregate Report URIs
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 57]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 57]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3245,7 +3245,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 58]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 58]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3301,7 +3301,7 @@ B.4.  Processing of SMTP Time
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 59]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 59]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3357,7 +3357,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 60]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 60]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3413,7 +3413,7 @@ C.1.1.  Ticket 80 - DMARCbis SHould Have Clear and Concise Defintion of
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 61]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 61]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3469,7 +3469,7 @@ C.5.2.  Ticket 3 - Two tiny nits
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 62]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 62]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3525,7 +3525,7 @@ C.7.2.  Ticket 72 - Remove absolute requirement for p= tag in DMARC
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 63]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 63]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3581,7 +3581,7 @@ C.10.2.  Ticket 52 - Remove strict alignment (and adkim and aspf tags)
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 64]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 64]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3637,7 +3637,7 @@ C.12.1.  Ticket 86 - A-R results for DMARC
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 65]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 65]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3693,7 +3693,7 @@ C.17.1.  Publication of draft-ietf-dmarc-dmarcbis-03
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 66]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 66]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3749,4 +3749,4 @@ Authors' Addresses
 
 
 
-Herr (ed) & Levine (ed)    Expires 26 May 2022                 [Page 67]
+Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 67]

--- a/draft-ietf-dmarc-dmarcbis-04.txt
+++ b/draft-ietf-dmarc-dmarcbis-04.txt
@@ -6,7 +6,7 @@ DMARC                                                       T. Herr (ed)
 Internet-Draft                                                  Valimail
 Obsoletes: 7489 (if approved)                             J. Levine (ed)
 Intended status: Standards Track                           Standcore LLC
-Expires: 27 May 2022                                    23 November 2021
+Expires: 3 June 2022                                    30 November 2021
 
 
 Domain-based Message Authentication, Reporting, and Conformance (DMARC)
@@ -41,7 +41,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 27 May 2022.
+   This Internet-Draft will expire on 3 June 2022.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 1]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                  [Page 1]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -69,192 +69,123 @@ Internet-Draft                  DMARCbis                   November 2021
 
 Table of Contents
 
-   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   5
-   2.  Requirements  . . . . . . . . . . . . . . . . . . . . . . . .   7
-     2.1.  High-Level Goals  . . . . . . . . . . . . . . . . . . . .   7
-     2.2.  Out of Scope  . . . . . . . . . . . . . . . . . . . . . .   7
-     2.3.  Scalability . . . . . . . . . . . . . . . . . . . . . . .   8
-     2.4.  Anti-Phishing . . . . . . . . . . . . . . . . . . . . . .   8
-   3.  Terminology and Definitions . . . . . . . . . . . . . . . . .   8
-     3.1.  Conventions Used in This Document . . . . . . . . . . . .   9
-     3.2.  Defintions  . . . . . . . . . . . . . . . . . . . . . . .   9
-       3.2.1.  Authenticated Identifiers . . . . . . . . . . . . . .   9
-       3.2.2.  Author Domain . . . . . . . . . . . . . . . . . . . .   9
-       3.2.3.  Domain Owner  . . . . . . . . . . . . . . . . . . . .   9
-       3.2.4.  Identifier Alignment  . . . . . . . . . . . . . . . .  10
-       3.2.5.  Longest PSD . . . . . . . . . . . . . . . . . . . . .  10
-       3.2.6.  Mail Receiver . . . . . . . . . . . . . . . . . . . .  10
-       3.2.7.  Non-existent Domains  . . . . . . . . . . . . . . . .  10
-       3.2.8.  Organizational Domain . . . . . . . . . . . . . . . .  10
-       3.2.9.  Public Suffix Domain (PSD)  . . . . . . . . . . . . .  10
-       3.2.10. Public Suffix Operator (PSO)  . . . . . . . . . . . .  10
-       3.2.11. PSO Controlled Domain Names . . . . . . . . . . . . .  10
-       3.2.12. Report Receiver . . . . . . . . . . . . . . . . . . .  11
-   4.  Overview and Key Concepts . . . . . . . . . . . . . . . . . .  11
-     4.1.  DMARC Basics  . . . . . . . . . . . . . . . . . . . . . .  11
-     4.2.  Use of RFC5322.From . . . . . . . . . . . . . . . . . . .  12
-     4.3.  Authentication Mechanisms . . . . . . . . . . . . . . . .  13
-     4.4.  Flow Diagram  . . . . . . . . . . . . . . . . . . . . . .  13
-     4.5.  DNS Tree Walk . . . . . . . . . . . . . . . . . . . . . .  15
-     4.6.  Determining the Organizational Domain . . . . . . . . . .  16
-     4.7.  Identifier Alignment Explained  . . . . . . . . . . . . .  17
-       4.7.1.  DKIM-Authenticated Identifiers  . . . . . . . . . . .  17
-       4.7.2.  SPF-Authenticated Identifiers . . . . . . . . . . . .  18
-       4.7.3.  Alignment and Extension Technologies  . . . . . . . .  19
-   5.  Policy  . . . . . . . . . . . . . . . . . . . . . . . . . . .  19
-     5.1.  DMARC Policy Record . . . . . . . . . . . . . . . . . . .  20
-     5.2.  DMARC URIs  . . . . . . . . . . . . . . . . . . . . . . .  20
-     5.3.  General Record Format . . . . . . . . . . . . . . . . . .  20
-     5.4.  Formal Definition . . . . . . . . . . . . . . . . . . . .  25
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   4
+   2.  Requirements  . . . . . . . . . . . . . . . . . . . . . . . .   5
+     2.1.  High-Level Goals  . . . . . . . . . . . . . . . . . . . .   6
+     2.2.  Anti-Phishing . . . . . . . . . . . . . . . . . . . . . .   6
+     2.3.  Scalability . . . . . . . . . . . . . . . . . . . . . . .   6
+     2.4.  Out of Scope  . . . . . . . . . . . . . . . . . . . . . .   7
+   3.  Terminology and Definitions . . . . . . . . . . . . . . . . .   7
+     3.1.  Conventions Used in This Document . . . . . . . . . . . .   7
+     3.2.  Defintions  . . . . . . . . . . . . . . . . . . . . . . .   8
+       3.2.1.  Authenticated Identifiers . . . . . . . . . . . . . .   8
+       3.2.2.  Author Domain . . . . . . . . . . . . . . . . . . . .   8
+       3.2.3.  Domain Owner  . . . . . . . . . . . . . . . . . . . .   8
+       3.2.4.  Identifier Alignment  . . . . . . . . . . . . . . . .   8
+       3.2.5.  Mail Receiver . . . . . . . . . . . . . . . . . . . .   8
+       3.2.6.  Non-existent Domains  . . . . . . . . . . . . . . . .   9
+       3.2.7.  Organizational Domain . . . . . . . . . . . . . . . .   9
+       3.2.8.  Public Suffix Domain (PSD)  . . . . . . . . . . . . .   9
+       3.2.9.  Public Suffix Operator (PSO)  . . . . . . . . . . . .   9
+       3.2.10. PSO Controlled Domain Names . . . . . . . . . . . . .   9
+       3.2.11. Report Receiver . . . . . . . . . . . . . . . . . . .   9
+   4.  Overview and Key Concepts . . . . . . . . . . . . . . . . . .   9
+     4.1.  DMARC Basics  . . . . . . . . . . . . . . . . . . . . . .  10
+     4.2.  Use of RFC5322.From . . . . . . . . . . . . . . . . . . .  11
+     4.3.  Authentication Mechanisms . . . . . . . . . . . . . . . .  11
+     4.4.  Flow Diagram  . . . . . . . . . . . . . . . . . . . . . .  12
+     4.5.  DNS Tree Walk . . . . . . . . . . . . . . . . . . . . . .  13
+     4.6.  Determining the Organizational Domain . . . . . . . . . .  14
+     4.7.  Identifier Alignment Explained  . . . . . . . . . . . . .  15
+       4.7.1.  DKIM-Authenticated Identifiers  . . . . . . . . . . .  16
+       4.7.2.  SPF-Authenticated Identifiers . . . . . . . . . . . .  16
+       4.7.3.  Alignment and Extension Technologies  . . . . . . . .  17
+   5.  Policy  . . . . . . . . . . . . . . . . . . . . . . . . . . .  17
+     5.1.  DMARC Policy Record . . . . . . . . . . . . . . . . . . .  18
+     5.2.  DMARC URIs  . . . . . . . . . . . . . . . . . . . . . . .  18
+     5.3.  General Record Format . . . . . . . . . . . . . . . . . .  19
+     5.4.  Formal Definition . . . . . . . . . . . . . . . . . . . .  22
+     5.5.  Domain Owner Actions  . . . . . . . . . . . . . . . . . .  24
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 2]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                  [Page 2]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-     5.5.  Domain Owner Actions  . . . . . . . . . . . . . . . . . .  26
-       5.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  26
+       5.5.1.  Publish an SPF Policy for an Aligned Domain . . . . .  24
        5.5.2.  Configure Sending System for DKIM Signing Using an
-               Aligned Domain  . . . . . . . . . . . . . . . . . . .  26
-       5.5.3.  Setup a Mailbox to Receive Aggregate Reports  . . . .  27
-       5.5.4.  Publish a DMARC Policy for the Author Domain  . . . .  27
+               Aligned Domain  . . . . . . . . . . . . . . . . . . .  24
+       5.5.3.  Setup a Mailbox to Receive Aggregate Reports  . . . .  24
+       5.5.4.  Publish a DMARC Policy for the Author Domain  . . . .  25
        5.5.5.  Collect and Analyze Reports and Adjust
-               Authentication  . . . . . . . . . . . . . . . . . . .  27
-       5.5.6.  Decide If and When to Update DMARC Policy . . . . . .  28
-     5.6.  PSO Actions . . . . . . . . . . . . . . . . . . . . . . .  28
-     5.7.  Mail Receiver Actions . . . . . . . . . . . . . . . . . .  28
-       5.7.1.  Extract Author Domain . . . . . . . . . . . . . . . .  28
-       5.7.2.  Determine Handling Policy . . . . . . . . . . . . . .  29
-       5.7.3.  Store Results of DMARC Processing . . . . . . . . . .  31
-       5.7.4.  Send Aggregate Reports  . . . . . . . . . . . . . . .  31
-     5.8.  Policy Enforcement Considerations . . . . . . . . . . . .  31
-   6.  DMARC Feedback  . . . . . . . . . . . . . . . . . . . . . . .  32
-   7.  Other Topics  . . . . . . . . . . . . . . . . . . . . . . . .  33
-     7.1.  Issues Specific to SPF  . . . . . . . . . . . . . . . . .  33
-     7.2.  DNS Load and Caching  . . . . . . . . . . . . . . . . . .  33
-     7.3.  Rejecting Messages  . . . . . . . . . . . . . . . . . . .  34
-     7.4.  Identifier Alignment Considerations . . . . . . . . . . .  35
-     7.5.  Interoperability Issues . . . . . . . . . . . . . . . . .  35
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  35
-     8.1.  Authentication-Results Method Registry Update . . . . . .  35
-     8.2.  Authentication-Results Result Registry Update . . . . . .  36
-     8.3.  Feedback Report Header Fields Registry Update . . . . . .  37
-     8.4.  DMARC Tag Registry  . . . . . . . . . . . . . . . . . . .  38
-     8.5.  DMARC Report Format Registry  . . . . . . . . . . . . . .  39
+               Authentication  . . . . . . . . . . . . . . . . . . .  25
+       5.5.6.  Decide If and When to Update DMARC Policy . . . . . .  25
+     5.6.  PSO Actions . . . . . . . . . . . . . . . . . . . . . . .  25
+     5.7.  Mail Receiver Actions . . . . . . . . . . . . . . . . . .  25
+       5.7.1.  Extract Author Domain . . . . . . . . . . . . . . . .  25
+       5.7.2.  Determine Handling Policy . . . . . . . . . . . . . .  26
+       5.7.3.  Store Results of DMARC Processing . . . . . . . . . .  28
+       5.7.4.  Send Aggregate Reports  . . . . . . . . . . . . . . .  29
+     5.8.  Policy Enforcement Considerations . . . . . . . . . . . .  29
+   6.  DMARC Feedback  . . . . . . . . . . . . . . . . . . . . . . .  30
+   7.  Other Topics  . . . . . . . . . . . . . . . . . . . . . . . .  30
+     7.1.  Issues Specific to SPF  . . . . . . . . . . . . . . . . .  31
+     7.2.  DNS Load and Caching  . . . . . . . . . . . . . . . . . .  31
+     7.3.  Rejecting Messages  . . . . . . . . . . . . . . . . . . .  31
+     7.4.  Identifier Alignment Considerations . . . . . . . . . . .  32
+     7.5.  Interoperability Issues . . . . . . . . . . . . . . . . .  33
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  33
+     8.1.  Authentication-Results Method Registry Update . . . . . .  33
+     8.2.  Authentication-Results Result Registry Update . . . . . .  34
+     8.3.  Feedback Report Header Fields Registry Update . . . . . .  35
+     8.4.  DMARC Tag Registry  . . . . . . . . . . . . . . . . . . .  36
+     8.5.  DMARC Report Format Registry  . . . . . . . . . . . . . .  37
      8.6.  Underscored and Globally Scoped DNS Node Names
-           Registry  . . . . . . . . . . . . . . . . . . . . . . . .  40
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  40
-     9.1.  Authentication Methods  . . . . . . . . . . . . . . . . .  40
-     9.2.  Attacks on Reporting URIs . . . . . . . . . . . . . . . .  41
-     9.3.  DNS Security  . . . . . . . . . . . . . . . . . . . . . .  41
-     9.4.  Display Name Attacks  . . . . . . . . . . . . . . . . . .  42
-     9.5.  External Reporting Addresses  . . . . . . . . . . . . . .  42
-     9.6.  Secure Protocols  . . . . . . . . . . . . . . . . . . . .  43
-   10. Normative References  . . . . . . . . . . . . . . . . . . . .  43
-   11. Informative References  . . . . . . . . . . . . . . . . . . .  45
-   Appendix A.  Technology Considerations  . . . . . . . . . . . . .  46
-     A.1.  S/MIME  . . . . . . . . . . . . . . . . . . . . . . . . .  47
-     A.2.  Method Exclusion  . . . . . . . . . . . . . . . . . . . .  47
-     A.3.  Sender Header Field . . . . . . . . . . . . . . . . . . .  48
-     A.4.  Domain Existence Test . . . . . . . . . . . . . . . . . .  48
-     A.5.  Issues with ADSP in Operation . . . . . . . . . . . . . .  49
-     A.6.  Organizational Domain Discovery Issues  . . . . . . . . .  50
-       A.6.1.  Public Suffix Lists . . . . . . . . . . . . . . . . .  50
+           Registry  . . . . . . . . . . . . . . . . . . . . . . . .  38
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  38
+     9.1.  Authentication Methods  . . . . . . . . . . . . . . . . .  38
+     9.2.  Attacks on Reporting URIs . . . . . . . . . . . . . . . .  39
+     9.3.  DNS Security  . . . . . . . . . . . . . . . . . . . . . .  39
+     9.4.  Display Name Attacks  . . . . . . . . . . . . . . . . . .  40
+     9.5.  External Reporting Addresses  . . . . . . . . . . . . . .  40
+     9.6.  Secure Protocols  . . . . . . . . . . . . . . . . . . . .  41
+   10. Normative References  . . . . . . . . . . . . . . . . . . . .  41
+   11. Informative References  . . . . . . . . . . . . . . . . . . .  43
+   Appendix A.  Technology Considerations  . . . . . . . . . . . . .  44
+     A.1.  S/MIME  . . . . . . . . . . . . . . . . . . . . . . . . .  45
+     A.2.  Method Exclusion  . . . . . . . . . . . . . . . . . . . .  45
+     A.3.  Sender Header Field . . . . . . . . . . . . . . . . . . .  46
+     A.4.  Domain Existence Test . . . . . . . . . . . . . . . . . .  46
+     A.5.  Issues with ADSP in Operation . . . . . . . . . . . . . .  47
+     A.6.  Organizational Domain Discovery Issues  . . . . . . . . .  48
+     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  49
+   Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  50
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 3]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                  [Page 3]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-     A.7.  Removal of the "pct" Tag  . . . . . . . . . . . . . . . .  51
-   Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  52
-     B.1.  Identifier Alignment Examples . . . . . . . . . . . . . .  52
-       B.1.1.  SPF . . . . . . . . . . . . . . . . . . . . . . . . .  52
-       B.1.2.  DKIM  . . . . . . . . . . . . . . . . . . . . . . . .  53
-     B.2.  Domain Owner Example  . . . . . . . . . . . . . . . . . .  54
-       B.2.1.  Entire Domain, Monitoring Only  . . . . . . . . . . .  54
+     B.1.  Identifier Alignment Examples . . . . . . . . . . . . . .  50
+       B.1.1.  SPF . . . . . . . . . . . . . . . . . . . . . . . . .  50
+       B.1.2.  DKIM  . . . . . . . . . . . . . . . . . . . . . . . .  51
+     B.2.  Domain Owner Example  . . . . . . . . . . . . . . . . . .  52
+       B.2.1.  Entire Domain, Monitoring Only  . . . . . . . . . . .  52
        B.2.2.  Entire Domain, Monitoring Only, Per-Message
-               Reports . . . . . . . . . . . . . . . . . . . . . . .  55
+               Reports . . . . . . . . . . . . . . . . . . . . . . .  53
        B.2.3.  Per-Message Failure Reports Directed to Third
-               Party . . . . . . . . . . . . . . . . . . . . . . . .  56
+               Party . . . . . . . . . . . . . . . . . . . . . . . .  54
        B.2.4.  Subdomain, Testing, and Multiple Aggregate Report
-               URIs  . . . . . . . . . . . . . . . . . . . . . . . .  57
-     B.3.  Mail Receiver Example . . . . . . . . . . . . . . . . . .  59
-     B.4.  Processing of SMTP Time . . . . . . . . . . . . . . . . .  59
-     B.5.  Utilization of Aggregate Feedback: Example  . . . . . . .  61
-   Appendix C.  Change Log . . . . . . . . . . . . . . . . . . . . .  61
-     C.1.  January 5, 2021 . . . . . . . . . . . . . . . . . . . . .  61
-       C.1.1.  Ticket 80 - DMARCbis SHould Have Clear and Concise
-               Defintion of DMARC  . . . . . . . . . . . . . . . . .  61
-     C.2.  February 4, 2021  . . . . . . . . . . . . . . . . . . . .  62
-       C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208 . . . . . . . . . . .  62
-     C.3.  February 10, 2021 . . . . . . . . . . . . . . . . . . . .  62
-       C.3.1.  Ticket 84 - Remove Erroneous References to RFC3986  .  62
-     C.4.  March 1, 2021 . . . . . . . . . . . . . . . . . . . . . .  62
-       C.4.1.  Design Team Work Begins . . . . . . . . . . . . . . .  62
-     C.5.  March 8, 2021 . . . . . . . . . . . . . . . . . . . . . .  62
-       C.5.1.  Removed E.  Gustafsson as editor  . . . . . . . . . .  62
-       C.5.2.  Ticket 3 - Two tiny nits  . . . . . . . . . . . . . .  62
-       C.5.3.  Ticket 4 - Definition of "fo" parameter . . . . . . .  63
-     C.6.  March 16, 2021  . . . . . . . . . . . . . . . . . . . . .  63
-       C.6.1.  Ticket 7 - ABNF for dmarc-record is slightly wrong  .  63
-       C.6.2.  Ticket 26 - ABNF for pct allows "999" . . . . . . . .  63
-     C.7.  March 23, 2021  . . . . . . . . . . . . . . . . . . . . .  63
-       C.7.1.  Ticket 75 - Using wording alternatives to
-               'disposition', 'dispose', and the like  . . . . . . .  63
-       C.7.2.  Ticket 72 - Remove absolute requirement for p= tag in
-               DMARC record  . . . . . . . . . . . . . . . . . . . .  63
-     C.8.  March 29, 2021  . . . . . . . . . . . . . . . . . . . . .  64
-       C.8.1.  Ticket 54 - Remove or expand limits on number of
-               recipients per report . . . . . . . . . . . . . . . .  64
-     C.9.  April 12, 2021  . . . . . . . . . . . . . . . . . . . . .  64
-       C.9.1.  Ticket 50 - Remove ri= tag  . . . . . . . . . . . . .  64
-       C.9.2.  Ticket 66 - Define what it means to have implemented
-               DMARC . . . . . . . . . . . . . . . . . . . . . . . .  64
-       C.9.3.  Ticket 96 - Tweaks to Abstract and Introduction . . .  64
-     C.10. April 13, 2021  . . . . . . . . . . . . . . . . . . . . .  64
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 4]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-       C.10.1.  Ticket 53 - Remove reporting message size
-               chunking  . . . . . . . . . . . . . . . . . . . . . .  64
-       C.10.2.  Ticket 52 - Remove strict alignment (and adkim and
-               aspf tags)  . . . . . . . . . . . . . . . . . . . . .  64
-       C.10.3.  Ticket 47 - Remove pct= tag  . . . . . . . . . . . .  65
-       C.10.4.  Ticket 2 - Flow of operations text in dmarc-base . .  65
-     C.11. April 14, 2021  . . . . . . . . . . . . . . . . . . . . .  65
-       C.11.1.  Ticket 107 - DMARCbis should take a stand on
-               multi-valued From fields  . . . . . . . . . . . . . .  65
-       C.11.2.  Ticket 82 - Deprecate rf= and maybe fo= tag  . . . .  65
-       C.11.3.  Ticket 85 - Proposed change to wording describing 'p'
-               tag and values  . . . . . . . . . . . . . . . . . . .  65
-     C.12. April 15, 2021  . . . . . . . . . . . . . . . . . . . . .  65
-       C.12.1.  Ticket 86 - A-R results for DMARC  . . . . . . . . .  65
-       C.12.2.  Ticket 62 - Make aggregate reporting a normative
-               MUST  . . . . . . . . . . . . . . . . . . . . . . . .  66
-     C.13. April 19, 2021  . . . . . . . . . . . . . . . . . . . . .  66
-       C.13.1.  Ticket 109 - Sanity Check DMARCbis Document  . . . .  66
-     C.14. April 20, 2021  . . . . . . . . . . . . . . . . . . . . .  66
-       C.14.1.  Ticket 108 - Changes to DMARCbis for PSD . . . . . .  66
-     C.15. April 22, 2021  . . . . . . . . . . . . . . . . . . . . .  66
-       C.15.1.  Ticket 104 - Update the Security Considerations
-               section 11.3 on DNS . . . . . . . . . . . . . . . . .  66
-     C.16. June 16, 2021 . . . . . . . . . . . . . . . . . . . . . .  66
-       C.16.1.  Publication of draft-ietf-dmarc-dmarcbis-02  . . . .  66
-     C.17. August 12, 2021 . . . . . . . . . . . . . . . . . . . . .  66
-       C.17.1.  Publication of draft-ietf-dmarc-dmarcbis-03  . . . .  66
-   Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . .  67
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  67
+               URIs  . . . . . . . . . . . . . . . . . . . . . . . .  55
+     B.3.  Mail Receiver Example . . . . . . . . . . . . . . . . . .  57
+       B.3.1.  SMTP Session Example  . . . . . . . . . . . . . . . .  57
+     B.4.  Utilization of Aggregate Feedback: Example  . . . . . . .  59
+   Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . .  59
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  60
 
 1.  Introduction
 
@@ -269,18 +200,11 @@ Internet-Draft                  DMARCbis                   November 2021
    trusted by - the recipient.  The Sender Policy Framework (SPF)
    [RFC7208] and DomainKeys Identified Mail (DKIM) [RFC6376] protocols
    provide domain-level authentication but are not directly associated
-   with the RFC5322.From domain.  DMARC leverages them, and provides a
-   method for Domain Owners to publish a DNS record describing the email
-   authentication policies for the RFC5322.From domain and to request a
-   specific handling for messages using that domain that fail
-   authentication checks.
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 5]
-
-Internet-Draft                  DMARCbis                   November 2021
-
+   with the RFC5322.From domain.  DMARC leverages these two protocols,
+   providing a method for Domain Owners to publish a DNS record
+   describing the email authentication policies for the RFC5322.From
+   domain and to request specific handling for messages using that
+   domain that fail authentication checks.
 
    As with SPF and DKIM, DMARC classes results as "pass" or "fail".  In
    order to get a DMARC result of "pass", a pass from either SPF or DKIM
@@ -292,6 +216,15 @@ Internet-Draft                  DMARCbis                   November 2021
    hierarchy for the RFC5322.From domain while having the same
    administrative authority as the RFC5322.From domain.  Domains are "in
    strict alignment" if and only if they are identical.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                  [Page 4]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    A DMARC pass indicates only that the RFC5322.From domain has been
    authenticated for that message.  Authentication does not carry an
@@ -327,16 +260,8 @@ Internet-Draft                  DMARCbis                   November 2021
    authentication practices.  However, as with honoring the Domain
    Owner's stated mail handling preference, a mail-receiving
    organization supporting DMARC is under no obligation to send
-   requested reports.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 6]
-
-Internet-Draft                  DMARCbis                   November 2021
-
+   requested reports, although it is recommended that they do send
+   aggregate reports.
 
    Use of DMARC creates some interoperability challenges that require
    due consideration before deployment, particularly with configurations
@@ -348,6 +273,14 @@ Internet-Draft                  DMARCbis                   November 2021
    Specification of DMARC is guided by the following high-level goals,
    security dependencies, detailed requirements, and items that are
    documented as out of scope.
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                  [Page 5]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 2.1.  High-Level Goals
 
@@ -368,54 +301,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
    *  Work at Internet scale.
 
-2.2.  Out of Scope
-
-   Several topics and issues are specifically out of scope for this
-   work.  These include the following:
-
-   *  Different treatment of messages that are not authenticated versus
-      those that fail authentication;
-
-   *  Evaluation of anything other than RFC5322.From header field;
-
-   *  Multiple reporting formats;
-
-   *  Publishing policy other than via the DNS;
-
-   *  Reporting or otherwise evaluating other than the last-hop IP
-      address;
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 7]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-   *  Attacks in the From: header field, also known as "display name"
-      attacks;
-
-   *  Authentication of entities other than domains, since DMARC is
-      built upon SPF and DKIM, which authenticate domains; and
-
-   *  Content analysis.
-
-2.3.  Scalability
-
-   Scalability is a major issue for systems that need to operate in a
-   system as widely deployed as current SMTP email.  For this reason,
-   DMARC seeks to avoid the need for third parties or pre-sending
-   agreements between senders and receivers.  This preserves the
-   positive aspects of the current email infrastructure.
-
-   Although DMARC does not introduce third-party senders (namely
-   external agents authorized to send on behalf of an operator) to the
-   email-handling flow, it also does not preclude them.  Such third
-   parties are free to provide services in conjunction with DMARC.
-
-2.4.  Anti-Phishing
+2.2.  Anti-Phishing
 
    DMARC is designed to prevent bad actors from sending mail that claims
    to come from legitimate senders, particularly senders of
@@ -435,20 +321,56 @@ Internet-Draft                  DMARCbis                   November 2021
    use of visually similar domain names ("cousin domains") or abuse of
    the RFC5322.From human-readable <display-name>.
 
-3.  Terminology and Definitions
+2.3.  Scalability
 
-   This section defines terms used in the rest of the document.
+   Scalability is a major issue for systems that need to operate in a
+   system as widely deployed as current SMTP email.  For this reason,
+   DMARC seeks to avoid the need for third parties or pre-sending
+   agreements between senders and receivers.  This preserves the
+   positive aspects of the current email infrastructure.
 
 
 
 
 
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 8]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                  [Page 6]
 
 Internet-Draft                  DMARCbis                   November 2021
 
+
+   Although DMARC does not introduce third-party senders (namely
+   external agents authorized to send on behalf of an operator) to the
+   email-handling flow, it also does not preclude them.  Such third
+   parties are free to provide services in conjunction with DMARC.
+
+2.4.  Out of Scope
+
+   Several topics and issues are specifically out of scope for this
+   work.  These include the following:
+
+   *  Different treatment of messages that are not authenticated versus
+      those that fail authentication;
+
+   *  Evaluation of anything other than RFC5322.From header field;
+
+   *  Multiple reporting formats;
+
+   *  Publishing policy other than via the DNS;
+
+   *  Reporting or otherwise evaluating other than the last-hop IP
+      address;
+
+   *  Attacks in the RFC5322.From header field, also known as "display
+      name" attacks;
+
+   *  Authentication of entities other than domains, since DMARC is
+      built upon SPF and DKIM, which authenticate domains; and
+
+   *  Content analysis.
+
+3.  Terminology and Definitions
+
+   This section defines terms used in the rest of the document.
 
 3.1.  Conventions Used in This Document
 
@@ -464,6 +386,14 @@ Internet-Draft                  DMARCbis                   November 2021
    contexts.  For example, a Domain Owner could, via the messaging
    security mechanisms on which DMARC is based, delegate the ability to
    send mail as the Domain Owner to a third party with another role.
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                  [Page 7]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    This document does not address the distinctions among such roles; the
    reader is encouraged to become familiar with that material before
    continuing.
@@ -480,8 +410,8 @@ Internet-Draft                  DMARCbis                   November 2021
 
 3.2.2.  Author Domain
 
-   The domain name of the apparent author, as extracted from the From:
-   header field.
+   The domain name of the apparent author, as extracted from the
+   RFC5322.From header field.
 
 3.2.3.  Domain Owner
 
@@ -496,39 +426,37 @@ Internet-Draft                  DMARCbis                   November 2021
    Receivers, when those are outside of their immediate management
    domain.
 
+3.2.4.  Identifier Alignment
+
+   When the domain in the address in the RFC5322.From header field has
+   the same Organizational Domain as a domain verified by an
+   authenticated identifier, it has Identifier Alignment. (see
+   Section 3.2.7)
+
+3.2.5.  Mail Receiver
+
+   The entity or organization that receives and processes email.  Mail
+   Receivers operate one or more Internet-facing Mail Transport Agents
+   (MTAs).
 
 
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                  [Page 9]
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                  [Page 8]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-3.2.4.  Identifier Alignment
-
-   When the domain in the address in the From: header field has the same
-   Organizational Domain as a domain verified by an authenticated
-   identifier, it has Identifier Alignment. (see below)
-
-3.2.5.  Longest PSD
-
-   The term Longest PSD is defined in [RFC9091].
-
-3.2.6.  Mail Receiver
-
-   The entity or organization that receives and processes email.
-   Mail Receivers operate one or more Internet-facing Mail Transport
-   Agents (MTAs).
-
-3.2.7.  Non-existent Domains
+3.2.6.  Non-existent Domains
 
    For DMARC purposes, a non-existent domain is a domain for which there
    is an NXDOMAIN or NODATA response for A, AAAA, and MX records.  This
    is a broader definition than that in [RFC8020].
 
-3.2.8.  Organizational Domain
+3.2.7.  Organizational Domain
 
    The Organizational Domain is typically a domain that was registered
    with a domain name registrar.  More formally, it is any Public Suffix
@@ -536,33 +464,19 @@ Internet-Draft                  DMARCbis                   November 2021
    the RFC5322.From domain is determined by applying the algorithm found
    in Section 4.6.
 
-3.2.9.  Public Suffix Domain (PSD)
+3.2.8.  Public Suffix Domain (PSD)
 
    The term Public Suffix Domain is defined in [RFC9091].
 
-3.2.10.  Public Suffix Operator (PSO)
+3.2.9.  Public Suffix Operator (PSO)
 
    The term Public Suffix Operator is defined in [RFC9091].
 
-3.2.11.  PSO Controlled Domain Names
+3.2.10.  PSO Controlled Domain Names
 
    The term PSO Controlled Domain Names is defined in [RFC9091].
 
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 10]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-3.2.12.  Report Receiver
+3.2.11.  Report Receiver
 
    An operator that receives reports from another operator implementing
    the reporting mechanisms described in this document and/or the
@@ -578,6 +492,20 @@ Internet-Draft                  DMARCbis                   November 2021
    This section provides a general overview of the design and operation
    of the DMARC environment.
 
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                  [Page 9]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 4.1.  DMARC Basics
 
    DMARC permits a Domain Owner or PSO to enable verification of a
@@ -589,12 +517,12 @@ Internet-Draft                  DMARCbis                   November 2021
 
    DMARC's verification function is based on whether the RFC5322.From
    domain is aligned with a domain name used in a supported
-   authentication mechanism.  Section 4.3 When a DMARC policy exists for
-   the domain name found in the RFC5322.From header field, and that
-   domain name is not verified through an aligned supported
-   authentication mechanism, the handling of that message can be
-   affected based on the DMARC policy when delivered to a participating
-   receiver.
+   authentication mechanism, as described in Section 4.3.  When a DMARC
+   policy exists for the domain name found in the RFC5322.From header
+   field, and that domain name is not verified through an aligned
+   supported authentication mechanism, the handling of that message can
+   be affected based on the DMARC policy when delivered to a
+   participating receiver.
 
    A message satisfies the DMARC checks if at least one of the supported
    authentication mechanisms:
@@ -608,15 +536,6 @@ Internet-Draft                  DMARCbis                   November 2021
    by DMARC authenticate only a DNS domain and do not authenticate the
    local-part of any email address identifier found in a message, nor do
    they validate the legitimacy of message content.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 11]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    DMARC's feedback component involves the collection of information
    about received messages claiming to be from the Author Domain for
@@ -632,6 +551,16 @@ Internet-Draft                  DMARCbis                   November 2021
    analyzing attacks.  The capability for such services is enabled by
    DMARC but defined in other referenced material such as [RFC6591] and
    [DMARC-Failure-Reporting]
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 10]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 4.2.  Use of RFC5322.From
 
@@ -661,18 +590,9 @@ Internet-Draft                  DMARCbis                   November 2021
       with that mailbox, if the end user knows that these various
       protections have been provided.
 
-   The absence of a single, properly formed RFC5322.From header field
-   renders the message invalid.  Handling of such a message is outside
-   of the scope of this specification.
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 12]
-
-Internet-Draft                  DMARCbis                   November 2021
-
+   *  The absence of a single, properly formed RFC5322.From header field
+      renders the message invalid.  Handling of such a message is
+      outside of the scope of this specification.
 
    Since the sorts of mail typically protected by DMARC participants
    tend to only have single Authors, DMARC participants generally
@@ -688,47 +608,22 @@ Internet-Draft                  DMARCbis                   November 2021
       content of the "d=" tag of a verified DKIM-Signature header field.
 
    *  SPF, [RFC7208], which can authenticate both the domain found in an
-      [RFC5321] HELO/EHLO command (the HELO identity) and the domain
-      found in an SMTP MAIL command (the MAIL FROM identity).  As noted
-      earlier, however, DMARC relies solely on SPF authentication of the
-      domain found in SMTP MAIL FROM command.  Section 2.4 of [RFC7208]
-      describes MAIL FROM processing for cases in which the MAIL command
-      has a null path.
-
-4.4.  Flow Diagram
+      SMTP [RFC5321] HELO/EHLO command (the HELO identity) and the
+      domain found in an SMTP MAIL command (the MAIL FROM identity).  As
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 13]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 11]
 
 Internet-Draft                  DMARCbis                   November 2021
 
+
+      noted earlier, however, DMARC relies solely on SPF authentication
+      of the domain found in SMTP MAIL FROM command.  Section 2.4 of
+      [RFC7208] describes MAIL FROM processing for cases in which the
+      MAIL command has a null path.
+
+4.4.  Flow Diagram
 
     +---------------+                             +--------------------+
     | Author Domain |< . . . . . . . . . . . .    | Return-Path Domain |
@@ -767,6 +662,18 @@ Internet-Draft                  DMARCbis                   November 2021
    authentication modules.  "sMTA" is the sending MTA, and "rMTA" is the
    receiving MTA.
 
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 12]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    Put simply, when a message reaches a DMARC-aware rMTA, a DNS query
    will be initiated to determine if a DMARC policy exists that applies
    to the author domain.  If a policy is found, the rMTA will use the
@@ -777,25 +684,17 @@ Internet-Draft                  DMARCbis                   November 2021
    More details on specific actions for the parties involved can be
    found in Section 5.5 and Section 5.7.
 
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 14]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
 4.5.  DNS Tree Walk
 
    While the DMARC protocol defines a method for communicating
-   information through publishing records in DNS, it is not necessarily
-   true that a DMARC policy record for a given domain will be found in
-   DNS at the same level as the name label for the domain in question.
-   Instead, some domains will inherit their DNS policy records from
-   parent domains one level or more above them in the DNS hierarchy, and
-   these records can only be discovered through a technique described
-   here, one known colloquially as a "DNS Tree Walk".
+   information through the publishing of records in DNS, it is not
+   necessarily true that a DMARC policy record for a given domain will
+   be found in DNS at the same level as the name label for the domain in
+   question.  Instead, some domains will inherit their DNS policy
+   records from parent domains one level or more above them in the DNS
+   hierarchy, and these records can only be discovered through a
+   technique described here, one known colloquially as a "DNS Tree
+   Walk".
 
    The process for a DNS Tree Walk will always start at the point in the
    DNS hierarchy that matches the domain in the RFC5322.From header of
@@ -824,6 +723,13 @@ Internet-Draft                  DMARCbis                   November 2021
        "a.mail.example.com", "com" would be label 1, "example" would be
        label 2, "mail.example.com" would be label 3, and so forth.
 
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 13]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    5.  Count the number of labels found in the subject DNS domain.  Let
        that number be "x".  If x < 5, remove the left-most (highest-
        numbered) label from the subject domain.  If x >= 5, remove the
@@ -834,13 +740,6 @@ Internet-Draft                  DMARCbis                   November 2021
    6.  Query the DNS for a DMARC TXT record at the DNS domain matching
        this new target in place of the RFC5322.From domain in the
        message.  A possibly empty set of records is returned.
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 15]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    7.  Records that do not start with a "v=" tag that identifies the
        current version of DMARC are discarded.
@@ -879,6 +778,14 @@ Internet-Draft                  DMARCbis                   November 2021
    Section 4.5.  The target of the search is a valid DMARC record that
    contains a psd tag with a value of 'y'.  Once such a record has been
    found, the Organizational Domain for the DNS domain matching the one
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 14]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    found in the RFC5322.From domain can be declared to be the target
    domain queried for in the step just prior to the query that found the
    PSD domain.
@@ -890,13 +797,6 @@ Internet-Draft                  DMARCbis                   November 2021
    and so the Organizational Domain for this RFC5322.From domain would
    be determined to be "example.com", the domain of the DMARC query
    executed prior to the query for "_dmarc.com".
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 16]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 4.7.  Identifier Alignment Explained
 
@@ -914,7 +814,7 @@ Internet-Draft                  DMARCbis                   November 2021
    Authenticated Identifier (a condition known as "relaxed alignment")
    or that it be identical to the domain of the Authenticated Identifier
    (a condition known as "strict alignment").  The choice of relaxed or
-   strict alignment is left to the domain owner and is expressed in the
+   strict alignment is left to the Domain Owner and is expressed in the
    domain's DMARC policy record.  Domain names in this context are to be
    compared in a case-insensitive manner, per [RFC4343].
 
@@ -932,6 +832,16 @@ Internet-Draft                  DMARCbis                   November 2021
    as input yields authenticated domains as their outputs when they
    succeed.
 
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 15]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 4.7.1.  DKIM-Authenticated Identifiers
 
    DMARC requires Identifier Alignment based on the result of a DKIM
@@ -943,16 +853,6 @@ Internet-Draft                  DMARCbis                   November 2021
    DMARC permits Identifier Alignment based on the result of a DKIM
    authentication to be strict or relaxed.  (Note that these terms are
    not related to DKIM's "simple" and "relaxed" canonicalization modes.)
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 17]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    In relaxed mode, the Organizational Domains of both the DKIM-
    authenticated signing domain (taken from the value of the d= tag in
@@ -988,6 +888,16 @@ Internet-Draft                  DMARCbis                   November 2021
    to be considered to be aligned.  In strict mode, the two FQDNs must
    match exactly in order from them to be considered to be aligned.
 
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 16]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    For example, in relaxed mode, if a message passes an SPF check with
    an RFC5321.MailFrom domain of "cbg.bounces.example.com", and the
    address portion of the RFC5322.From header field contains
@@ -1002,14 +912,6 @@ Internet-Draft                  DMARCbis                   November 2021
    [RFC7208], which recommends that SPF checks be done on not only the
    "MAIL FROM" but also on a separate check of the "HELO" identity.
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 18]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
 4.7.3.  Alignment and Extension Technologies
 
    If in the future DMARC is extended to include the use of other
@@ -1019,21 +921,21 @@ Internet-Draft                  DMARCbis                   November 2021
 
 5.  Policy
 
-   DMARC policies are published by Domain Owners and PSOs and can be
-   used by Mail Receivers to inform their message handling decisions.
-
    A Domain Owner or PSO advertises DMARC participation of one or more
    of its domains by adding a DNS TXT record (described in Section 5.1)
    to those domains.  In doing so, Domain Owners and PSOs indicate their
    handling preference regarding failed authentication for email
    messages making use of their domain in the RFC5322.From header field
-   as well as the provision of feedback about those messages.  Mail
+   as well as their desire for feedback about those messages.  Mail
    Receivers in turn can take into account the Domain Owner's stated
    preference when making handling decisions about email messages that
    fail DMARC authentication checks.
 
    A Domain Owner or PSO may choose not to participate in DMARC
-   evaluation by Mail Receivers.  In this case, the Domain Owner simply
+   evaluation by Mail Receivers simply by not publishing an appropriate
+   DNS TXT record for its domain(s).  A Domain Owner can also choose to
+   not have some underlying authentication technologies apply to DMARC
+   evaluation of its domain(s).  In this case, the Domain Owner simply
    declines to advertise participation in those schemes.  For example,
    if the results of path authorization checks ought not be considered
    as part of the overall DMARC result for a given Author Domain, then
@@ -1044,27 +946,20 @@ Internet-Draft                  DMARCbis                   November 2021
    effort attempt to adhere to the Domain Owner's or PSO's published
    DMARC Domain Owner Assessment Policy when a message fails the DMARC
    test.  Since email streams can be complicated (due to forwarding,
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 17]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    existing RFC5322.From domain-spoofing services, etc.), Mail Receivers
    MAY deviate from a published Domain Owner Assessment Policy during
    message processing and SHOULD make available the fact of and reason
    for the deviation to the Domain Owner via feedback reporting,
    specifically using the "PolicyOverride" feature of the aggregate
    report defined in [DMARC-Aggregate-Reporting]
-
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 19]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 5.1.  DMARC Policy Record
 
@@ -1106,21 +1001,19 @@ Internet-Draft                  DMARCbis                   November 2021
 
    A formal definition is provided in Section 5.4.
 
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 18]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 5.3.  General Record Format
 
    DMARC records follow the extensible "tag-value" syntax for DNS-based
    key records defined in DKIM [RFC6376].
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 20]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    Section 8 creates a registry for known DMARC tags and registers the
    initial set defined in this document.  Only tags defined in this
@@ -1153,50 +1046,32 @@ Internet-Draft                  DMARCbis                   November 2021
       This tag's content MUST be ignored if a "ruf" tag (below) is not
       also specified.  Failure reporting options are shown below.  The
       value of this tag is either "0", "1", or a colon-separated list of
-      the options represented by alphabetic characters.
+      the options represented by alphabetic characters.  The valid
+      values and their meanings are:
 
-   The valid values and their meanings are:
+      0:  Generate a DMARC failure report if all underlying
+         authentication mechanisms fail to produce an aligned "pass"
+         result.
 
+      1:  Generate a DMARC failure report if any underlying
+         authentication mechanism produced something other than an
+         aligned "pass" result.
 
-
-
-
-
-
-
-
-
-
+      d:  Generate a DKIM failure report if the message had a signature
 
 
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 21]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 19]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-   0:
-   :  Generate a DMARC failure report if all underlying
-      authentication mechanisms fail to produce an aligned "pass"
-      result.
+         that failed evaluation, regardless of its alignment.  DKIM-
+         specific reporting is described in [RFC6651].
 
-   1:
-   :  Generate a DMARC failure report if any underlying
-      authentication mechanism produced something other than an
-      aligned "pass" result.
-
-   d:
-   :  Generate a DKIM failure report if the message had a signature
-      that failed evaluation, regardless of its alignment.  DKIM-
-      specific reporting is described in [@!RFC6651].
-
-   s:
-   :  Generate an SPF failure report if the message failed SPF
-      evaluation, regardless of its alignment.  SPF-specific
-      reporting is described in [@!RFC6652].
+      s:  Generate an SPF failure report if the message failed SPF
+         evaluation, regardless of its alignment.  SPF-specific
+         reporting is described in [RFC6652].
 
    np:  Domain Owner Assessment Policy for non-existent subdomains
       (plain-text; OPTIONAL).  Indicates the message handling preference
@@ -1226,14 +1101,6 @@ Internet-Draft                  DMARCbis                   November 2021
 
       quarantine:  The Domain Owner considers such mail to be
          suspicious.  It is possible the mail is valid, although the
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 22]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
          failure creates a significant concern.
 
       reject:  The Domain Owner considers all such failures to be a
@@ -1247,6 +1114,14 @@ Internet-Draft                  DMARCbis                   November 2021
       y:  Domains on the PSL that publish DMARC policy records SHOULD
          include this tag with a value of 'y' to indicate that the
          domain is a PSD.  This information will be used during policy
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 20]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
          discovery to determine how to apply any DMARC policy records
          that are discovered during the tree walk.
 
@@ -1258,12 +1133,12 @@ Internet-Draft                  DMARCbis                   November 2021
       [DMARC-Aggregate-Reporting] discusses considerations that apply
       when the domain name of a URI differs from that of the domain
       advertising the policy.  See Section 9.5 for additional
-      considerations.  Any valid URI can be specified.
-         A Mail Receiver MUST implement support for a "mailto:" URI,
-      i.e., the ability to send a DMARC report via electronic mail.  If
-      not provided, Mail Receivers MUST NOT generate aggregate feedback
-      reports.  URIs not supported by Mail Receivers MUST be ignored.
-      The aggregate feedback report format is described in
+      considerations.  Any valid URI can be specified.  A Mail Receiver
+      MUST implement support for a "mailto:" URI, i.e., the ability to
+      send a DMARC report via electronic mail.  If the tag is not
+      provided, Mail Receivers MUST NOT generate aggregate feedback
+      reports for the domain.  URIs not supported by Mail Receivers MUST
+      be ignored.  The aggregate feedback report format is described in
       [DMARC-Aggregate-Reporting]
 
    ruf:  Addresses to which message-specific failure information is to
@@ -1276,19 +1151,9 @@ Internet-Draft                  DMARCbis                   November 2021
       discusses considerations that apply when the domain name of a URI
       differs from that of the domain advertising the policy.  A Mail
       Receiver MUST implement support for a "mailto:" URI, i.e., the
-      ability to send a DMARC report via electronic mail.  If not
-      provided, Mail Receivers MUST NOT generate failure reports.  See
-      Section 9.5 for additional considerations.
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 23]
-
-Internet-Draft                  DMARCbis                   November 2021
-
+      ability to send a DMARC report via electronic mail.  If the tag is
+      not provided, Mail Receivers MUST NOT generate failure reports for
+      the domain.  See Section 9.5 for additional considerations.
 
    sp:  Domain Owner Assessment Policy for all subdomains (plain-text;
       OPTIONAL).  Indicates the message handling preference the Domain
@@ -1302,6 +1167,16 @@ Internet-Draft                  DMARCbis                   November 2021
       DMARC records published on subdomains of Organizational Domains
       due to the effect of the DMARC policy discovery mechanism
       described in Section 5.7.2.1.
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 21]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    t:  DMARC policy test mode (plain-text; OPTIONAL; default is 'n').
       For the RFC5322.From domain to which the DMARC record applies, the
@@ -1338,14 +1213,6 @@ Internet-Draft                  DMARCbis                   November 2021
    the "v" tag's value), but a change to any existing tags does require
    a new version of DMARC.
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 24]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
 5.4.  Formal Definition
 
    The formal definition of the DMARC format, using [RFC5234], is as
@@ -1359,9 +1226,17 @@ Internet-Draft                  DMARCbis                   November 2021
      dmarc-record    = dmarc-version dmarc-sep *(dmarc-tag dmarc-sep)
 
      dmarc-tag       = dmarc-request /
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 22]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
                        dmarc-test /
                        dmarc-psd /
-                       dmarc-srequest /
+                       dmarc-sprequest /
                        dmarc-nprequest /
                        dmarc-adkim /
                        dmarc-aspf /
@@ -1383,7 +1258,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
      dmarc-psd       = "psd" *WSP "=" ( "y" / "n" )
 
-     dmarc-srequest  = "sp" *WSP "=" *WSP
+     dmarc-sprequest = "sp" *WSP "=" *WSP
                        ( "none" / "quarantine" / "reject" )
 
      dmarc-nprequest  = "np" *WSP "=" *WSP
@@ -1394,14 +1269,6 @@ Internet-Draft                  DMARCbis                   November 2021
      dmarc-aspf      = "aspf" *WSP "=" *WSP ( "r" / "s" )
 
      dmarc-auri      = "rua" *WSP "=" *WSP
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 25]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
                        dmarc-uri *(*WSP "," *WSP dmarc-uri)
 
      dmarc-furi      = "ruf" *WSP "=" *WSP
@@ -1415,6 +1282,14 @@ Internet-Draft                  DMARCbis                   November 2021
 
    "Keyword" is imported from Section 4.1.2 of [RFC5321].
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 23]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
 5.5.  Domain Owner Actions
 
    This section describes Domain Owner actions to fully implement the
@@ -1424,11 +1299,13 @@ Internet-Draft                  DMARCbis                   November 2021
 
    Because DMARC relies on SPF [RFC7208] and DKIM [RFC6376], in order to
    take full advantage of DMARC, a Domain Owner SHOULD first ensure that
-   SPF and DKIM authentication are properly configured.  The easiest
-   first step here is to choose a domain to use as the RFC5321.From
-   domain (i.e., the Return-Path domain) for its mail, one that aligns
-   with the Author Domain, and then publish an SPF policy in DNS for
-   that domain.
+   SPF and DKIM authentication are properly configured.  As a first step
+   the Domain Owner SHOULD choose a domain to use as the
+   RFC5321.MailFrom domain (i.e., the Return-Path domain) for its mail,
+   one that aligns with the Author Domain, and then publish an SPF
+   policy in DNS for that domain.  The SPF record SHOULD be constructed
+   at a minimum to ensure an SPF pass verdict for all known sources of
+   mail for the RFC5321.MailFrom domain.
 
 5.5.2.  Configure Sending System for DKIM Signing Using an Aligned
         Domain
@@ -1439,24 +1316,8 @@ Internet-Draft                  DMARCbis                   November 2021
    failure of just one of them.  The Domain Owner SHOULD choose a DKIM-
    Signing domain (i.e., the d= domain in the DKIM-Signature header)
    that aligns with the Author Domain and configure its system to sign
-   using that domain.
-
-
-
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 26]
-
-Internet-Draft                  DMARCbis                   November 2021
-
+   using that domain, to include publishing a corresponding DKIM public
+   key in DNS.
 
 5.5.3.  Setup a Mailbox to Receive Aggregate Reports
 
@@ -1469,21 +1330,28 @@ Internet-Draft                  DMARCbis                   November 2021
    could be legitimate ones that were overlooked during the intial
    deployment of SPF and/or DKIM.
 
-   Because the aggregate reports are XML documents, it is strongly
-   advised that they be machine-parsed, so setting up a mailbox involves
-   more than just the physical creation of the mailbox.  Many third-
-   party services exist that will process DMARC aggregate reports, or
-   the Domain Owner can create its own set of tools.  No matter which
-   method is chosen, the ability to parse these reports and consume the
-   data contained in them will go a long way to ensuring a successful
+   Because the aggregate reports are XML documents, it is recommended
+   that they be machine-parsed, so setting up a mailbox involves more
+   than just the physical creation of that mailbox.  Many third-party
+   services exist that will process DMARC aggregate reports, or the
+   Domain Owner can create its own set of tools.  No matter which method
+   is chosen, the ability to parse these reports and consume the data
+   contained in them will go a long way to ensuring a successful
    deployment.
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 24]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 5.5.4.  Publish a DMARC Policy for the Author Domain
 
    Once SPF, DKIM, and the aggregate reports mailbox are all in place,
    it's time to publish a DMARC record.  For best results, Domain Owners
-   SHOULD start with "p=none", with the rua tag containg the mailbox
-   created in the previous step.
+   SHOULD start with "p=none", with the rua tag containg a URI that
+   references the mailbox created in the previous step.
 
 5.5.5.  Collect and Analyze Reports and Adjust Authentication
 
@@ -1496,23 +1364,6 @@ Internet-Draft                  DMARCbis                   November 2021
    its own mail streams.  Should any overlooked systems be found in the
    reports, the Domain Owner can adjust the SPF record and/or configure
    DKIM signing for those systems.
-
-
-
-
-
-
-
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 27]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 5.5.6.  Decide If and When to Update DMARC Policy
 
@@ -1544,6 +1395,13 @@ Internet-Draft                  DMARCbis                   November 2021
    8, the domain name must be converted to an A-label, as described in
    Section 2.3 of [RFC5890], for further processing.
 
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 25]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    In order to be processed by DMARC, a message typically needs to
    contain exactly one RFC5322.From domain (a single From: field with a
    single domain in it).  Not all messages meet this requirement, and
@@ -1561,14 +1419,6 @@ Internet-Draft                  DMARCbis                   November 2021
 
    Note that Public Suffix Domains are not exempt from DMARC policy
    application and reporting.
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 28]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 5.7.2.  Determine Handling Policy
 
@@ -1598,14 +1448,24 @@ Internet-Draft                  DMARCbis                   November 2021
        reasons for failure.  The results MUST further include the domain
        name used to complete the SPF check.
 
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 26]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    5.  Conduct Identifier Alignment checks.  With authentication checks
        and policy discovery performed, the Mail Receiver checks to see
        if Authenticated Identifiers fall into alignment as described in
-       Section 3.  If one or more of the Authenticated Identifiers align
-       with the RFC5322.From domain, the message is considered to pass
-       the DMARC mechanism check.  All other conditions (authentication
-       failures, identifier mismatches) are considered to be DMARC
-       mechanism check failures.
+       Section 4.7.  If one or more of the Authenticated Identifiers
+       align with the RFC5322.From domain, the message is considered to
+       pass the DMARC mechanism check.  All other conditions
+       (authentication failures, identifier mismatches) are considered
+       to be DMARC mechanism check failures.
 
    6.  Apply policy, if appropriate.  Emails that fail the DMARC
        mechanism check are handled in accordance with the discovered
@@ -1617,14 +1477,6 @@ Internet-Draft                  DMARCbis                   November 2021
    the case that the Domain Owner wishes a Message Receiver not to
    consider the results of that underlying authentication protocol at
    all.
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 29]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    DMARC evaluation can only yield a "pass" result after one of the
    underlying authentication mechanisms passes for an aligned
@@ -1652,6 +1504,16 @@ Internet-Draft                  DMARCbis                   November 2021
    2.  If a retrieved policy record does not contain a valid "p" tag, or
        contains an "sp" tag that is not valid, then:
 
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 27]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
        *  If a "rua" tag is present and contains at least one
           syntactically valid reporting URI, the Mail Receiver SHOULD
           act as if a record containing a valid "v" tag and "p=none" was
@@ -1674,18 +1536,10 @@ Internet-Draft                  DMARCbis                   November 2021
    cleared, allowing a definite DMARC conclusion to be reached ("fail
    closed").
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 30]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    Note: Because the PSD policy query comes after the Organizational
    Domain policy query, PSD policy is not used for Organizational
    domains that have published a DMARC policy.  Specifically, this is
-   not a mechanism to provide feedback addresses (RUA/RUF) when an
+   not a mechanism to provide feedback addresses (rua/ruf) when an
    Organizational Domain has declined to do so.
 
 5.7.3.  Store Results of DMARC Processing
@@ -1694,6 +1548,27 @@ Internet-Draft                  DMARCbis                   November 2021
    for eventual presentation back to the Domain Owner in the form of
    aggregate feedback reports.  Section 5.3 and
    [DMARC-Aggregate-Reporting] discuss aggregate feedback.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 28]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 5.7.4.  Send Aggregate Reports
 
@@ -1710,9 +1585,9 @@ Internet-Draft                  DMARCbis                   November 2021
    with handling decisions for a message in ways that p= tag values of
    'none' cannot.
 
-   In order to ensure maximum usefulness for DMARC across the email
-   ecosystem, then, Mail Receivers SHOULD generate and send aggregate
-   reports with a frequency of at least once every 24 hours.
+   Given the above, in order to ensure maximum usefulness for DMARC
+   across the email ecosystem, Mail Receivers SHOULD generate and send
+   aggregate reports with a frequency of at least once every 24 hours.
 
 5.8.  Policy Enforcement Considerations
 
@@ -1730,14 +1605,6 @@ Internet-Draft                  DMARCbis                   November 2021
    increase the likelihood of accepting abusive mail if they choose not
    to honor the published Domain Owner Assessment Policy.  At a minimum,
    addition of the Authentication-Results header field (see [RFC8601])
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 31]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    is RECOMMENDED when delivery of failing mail is done.  When this is
    done, the DNS domain name thus recorded MUST be encoded as an
    A-label.
@@ -1749,6 +1616,15 @@ Internet-Draft                  DMARCbis                   November 2021
    of local policy.  If local policy information is exposed, abusers can
    gain insight into the effectiveness and delivery rates of spam
    campaigns.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 29]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    Final handling of a message is always a matter of local policy.  An
    operator that wishes to favor DMARC policy over SPF policy, for
@@ -1787,13 +1663,6 @@ Internet-Draft                  DMARCbis                   November 2021
    The details of this feedback are described in
    [DMARC-Aggregate-Reporting]
 
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 32]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
    Operational note for PSD DMARC: For PSOs, feedback for non-existent
    domains is desirable and useful, just as it is for org-level DMARC
    operators.  See Section 4 of [RFC9091] for discussion of Privacy
@@ -1803,6 +1672,15 @@ Internet-Draft                  DMARCbis                   November 2021
 
    This section discusses some topics regarding choices made in the
    development of DMARC, largely to commit the history to record.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 30]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
 7.1.  Issues Specific to SPF
 
@@ -1842,24 +1720,23 @@ Internet-Draft                  DMARCbis                   November 2021
    responsiveness of DMARC preference changes while preserving the
    benefits of DNS caching.
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 33]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
 7.3.  Rejecting Messages
 
    This protocol calls for rejection of a message during the SMTP
    session under certain circumstances.  This is preferable to
-   generation of a Delivery Status Notification ([RFC3464]), since
+   generation of a Delivery Status Notification [RFC3464], since
    fraudulent messages caught and rejected using DMARC would then result
    in annoying generation of such failure reports that go back to the
    RFC5321.MailFrom address.
 
    This synchronous rejection is typically done in one of two ways:
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 31]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    *  Full rejection, wherein the SMTP server issues a 5xy reply code as
       an indication to the SMTP client that the transaction failed; the
@@ -1899,13 +1776,6 @@ Internet-Draft                  DMARCbis                   November 2021
    retrieve or apply DMARC policy, this is best done with a 4xy SMTP
    reply code.
 
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 34]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
 7.4.  Identifier Alignment Considerations
 
    The DMARC mechanism allows both DKIM and SPF-authenticated
@@ -1914,6 +1784,15 @@ Internet-Draft                  DMARCbis                   November 2021
    users can gain control of the SPF record or DKIM selector records for
    a subdomain, the subdomain can be used to generate DMARC-passing
    email on behalf of the Organizational Domain.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 32]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    For example, an attacker who controls the SPF record for
    "evil.example.com" can send mail with an RFC5322.From header field
@@ -1957,7 +1836,16 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 35]
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 33]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2013,7 +1901,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 36]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 34]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2069,7 +1957,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 37]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 35]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2125,7 +2013,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 38]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 36]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2181,7 +2069,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 39]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 37]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2237,7 +2125,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 40]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 38]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2269,8 +2157,10 @@ Internet-Draft                  DMARCbis                   November 2021
 
    The DMARC mechanism and its underlying technologies (SPF, DKIM)
    depend on the security of the DNS.  Examples of how hostile parties
-   can have an adverse impact on DNS traffic include: * If they can
-   snoop on DNS traffic, they can get an idea of who is sending mail.
+   can have an adverse impact on DNS traffic include:
+
+   *  If they can snoop on DNS traffic, they can get an idea of who is
+      sending mail.
 
    *  If they can block outgoing or reply DNS messages, they can prevent
       systems from discovering senders' DMARC policies, causing
@@ -2291,9 +2181,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 41]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 39]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2349,7 +2237,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 42]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 40]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2405,7 +2293,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 43]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 41]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2461,7 +2349,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 44]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 42]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2517,7 +2405,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 45]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 43]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2565,15 +2453,15 @@ Internet-Draft                  DMARCbis                   November 2021
 Appendix A.  Technology Considerations
 
    This section documents some design decisions that were made in the
-   development of DMARC.  Specifically, addressed here are some
-   suggestions that were considered but not included in the design.
-   This text is included to explain why they were considered and not
-   included in this version.
+   development of DMARC.  Specifically addressed here are some
+   suggestions that were considered but not included in the design, with
+   explanatory text regarding the decision.
 
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 46]
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 44]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2629,7 +2517,7 @@ A.2.  Method Exclusion
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 47]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 45]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2685,7 +2573,7 @@ A.4.  Domain Existence Test
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 48]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 46]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -2741,66 +2629,77 @@ A.5.  Issues with ADSP in Operation
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 49]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 47]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
 A.6.  Organizational Domain Discovery Issues
 
-   Although protocols like ADSP are useful for "protecting" a specific
-   domain name, they are not helpful at protecting subdomains.  If one
-   wished to protect "example.com" by requiring via ADSP that all mail
-   bearing an RFC5322.From domain of "example.com" be signed, this would
-   "protect" that domain; however, one could then craft an email whose
-   RFC5322.From domain is "security.example.com", and ADSP would not
-   provide any protection.  One could use a DNS wildcard, but this can
-   undesirably interfere with other DNS activity; one could add ADSP
-   records as fraudulent domains are discovered, but this solution does
-   not scale and is a purely reactive measure against abuse.
+   An earlier informational version of the DMARC protocol [RFC7489]
+   noted that the DNS does not provide a method by which the "domain of
+   record", or the domain that was actually registered with a domain
+   registrar, can be determined given an arbitrary domain name.  That
+   version further mentioned suggestions that have been made that
+   attempt to glean such information from SOA or NS resource records,
+   but these too are not fully reliable, as the partitioning of the DNS
+   is not always done at administrative boundaries.
 
-   The DNS does not provide a method by which the "domain of record", or
-   the domain that was actually registered with a domain registrar, can
-   be determined given an arbitrary domain name.  Suggestions have been
-   made that attempt to glean such information from SOA or NS resource
-   records, but these too are not fully reliable, as the partitioning of
-   the DNS is not always done at administrative boundaries.
+   That previous version posited that one could "climb the tree" to find
+   the Organizational Domain, but expressed concern that an attacker
+   could exploit this for a denial-of-service attack through sending a
+   high number of messages each with a relatively large number of
+   nonsense labels, causing a Mail Receiver to perform a large number of
+   DNS queries in search of a policy record.  This version defines a
+   method for performing a DNS Tree Walk, described in Section 4.5, and
+   further mitigates the risk of the denial-of-service attack by
+   expressly limiting the number of DNS queries to execute regardless of
+   the number of labels in the domain name.
 
-   When seeking domain-specific policy based on an arbitrary domain
-   name, one could "climb the tree", dropping labels off the left end of
-   the name until the root is reached or a policy is discovered, but
-   then one could craft a name that has a large number of nonsense
-   labels; this would cause a Mail Receiver to attempt a large number of
-   queries in search of a policy record.  Sending many such messages
-   constitutes an amplified denial-of-service attack.
+   As a matter of historical record, the method for finding the
+   Organizational Domain described in [RFC7489] is preserved here:
 
-   The Organizational Domain mechanism is a necessary component to the
-   goals of DMARC.  The method described in Section 4.6 is far from
-   perfect but serves this purpose reasonably well without adding undue
-   burden or semantics to the DNS.  If a method is created to do so that
-   is more reliable and secure than the use of a public suffix list,
-   DMARC should be amended to use that method as soon as it is generally
-   available.
+   1.  Acquire a "public suffix" list (PSL), i.e., a list of DNS domain
+       names reserved for registrations.  Some country Top-Level Domains
+       (TLDs) make specific registration requirements, e.g., the United
+       Kingdom places company registrations under ".co.uk"; other TLDs
+       such as ".com" appear in the IANA registry of top-level DNS
+       domains.  A PSL is the union of all of these.
 
-A.6.1.  Public Suffix Lists
+       A PSL can be obtained from various sources.  The most common one
+       is maintained by the Mozilla Foundation and made public at
+       http://publicsuffix.org (http://publicsuffix.org).  License terms
+       governing the use of that list are available at that URI.
 
-   A public suffix list for the purposes of determining the
-   Organizational Domain can be obtained from various sources.  The most
-   common one is maintained by the Mozilla Foundation and made public at
-   http://publicsuffix.org (http://publicsuffix.org).  License terms
-   governing the use of that list are available at that URI.
+       Note that if operators use a variety of public suffix lists,
+       interoperability will be difficult or impossible to guarantee.
 
-   Note that if operators use a variety of public suffix lists,
-   interoperability will be difficult or impossible to guarantee.
+   2.  Break the subject DNS domain name into a set of "n" ordered
+       labels.  Number these labels from right to left; e.g., for
+       "example.com", "com" would be label 1 and "example" would be
+       label 2.
 
-
+   3.  Search the public suffix list for the name that matches the
+       largest number of labels found in the subject DNS domain.  Let
+       that number be "x".
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 50]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 48]
 
 Internet-Draft                  DMARCbis                   November 2021
 
+
+   4.  Construct a new DNS domain name using the name that matched from
+       the public suffix list and prefixing to it the "x+1"th label from
+       the subject domain.  This new name is the Organizational Domain.
+
+   Thus, since "com" is an IANA-registered TLD, a subject domain of
+   "a.b.c.d.example.com" would have an Organizational Domain of
+   "example.com".
+
+   The process of determining a suffix is currently a heuristic one.  No
+   list is guaranteed to be accurate or current.
 
 A.7.  Removal of the "pct" Tag
 
@@ -2813,18 +2712,16 @@ A.7.  Removal of the "pct" Tag
    for just a percentage of messages that produced DMARC results of
    "fail".
 
-   Operational experience and mathematics (specifically the Probability
-   Mass Function as applied to Binomial Distributions) showed that the
-   pct tag was usually not accurately applied, unless the value
-   specified was either "0" or "100" (the default), and the inaccuracies
-   with other values varied widely from implementation to
-   implementation.  The default value was easily implemented, as it
-   required no special processing on the part of the message receiver,
-   while the value of "0" took on unintended significance as a value
-   used by some intermediaries and mailbox providers as an indicator to
-   deviate from standard handling of the message, usually by rewriting
-   the RFC5322.From header in an effort to avoid DMARC failures
-   downstream.
+   Operational experience showed that the pct tag was usually not
+   accurately applied, unless the value specified was either "0" or
+   "100" (the default), and the inaccuracies with other values varied
+   widely from implementation to implementation.  The default value was
+   easily implemented, as it required no special processing on the part
+   of the message receiver, while the value of "0" took on unintended
+   significance as a value used by some intermediaries and mailbox
+   providers as an indicator to deviate from standard handling of the
+   message, usually by rewriting the RFC5322.From header in an effort to
+   avoid DMARC failures downstream.
 
    These custom actions when the pct= tag was set to "0" proved valuable
    to the email community.  In particular, header rewriting by an
@@ -2842,6 +2739,13 @@ A.7.  Removal of the "pct" Tag
    informed decision regarding subjecting its mail traffic to possible
    DMARC failures based on the Domain Owner's tolerance for such things.
 
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 49]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    Because of the value provided by "pct=0" to Domain Owners, it was
    logical to keep this functionality in the protocol; at the same time
    it didn't make sense to support a tag named "pct" that had only two
@@ -2850,13 +2754,6 @@ A.7.  Removal of the "pct" Tag
    values of "y" and "n", which are meant to be analogous in their
    application by mailbox providers and intermediaries to the "pct" tag
    values "0" and "100", respectively.
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 51]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
 Appendix B.  Examples
 
@@ -2897,22 +2794,20 @@ B.1.1.  SPF
         To: receiver@example.org
         Subject: here's a sample
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 50]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    In this case, the RFC5322.From header parameter includes a DNS domain
    that is a parent of the RFC5321.MailFrom domain.  Thus, the
    identifiers are in relaxed alignment, because they both have the same
    Organizational Domain (example.com).
 
    Example 3: SPF not in alignment:
-
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 52]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
         MAIL FROM: <sender@example.net>
 
@@ -2955,6 +2850,14 @@ B.1.2.  DKIM
    identifiers are in relaxed alignment, as they have the same
    Organizational Domain (example.com).
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 51]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    Example 3: DKIM not in alignment:
 
         DKIM-Signature: v=1; ...; d=sample.net; ...
@@ -2962,13 +2865,6 @@ B.1.2.  DKIM
         Date: Fri, Feb 15 2002 16:54:30 -0800
         To: receiver@example.org
         Subject: here's a sample
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 53]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    In this case, the DKIM signature's "d=" parameter includes a DNS
    domain that is neither the same as, a parent of, nor a child of the
@@ -3011,20 +2907,18 @@ B.2.1.  Entire Domain, Monitoring Only
    *  All messages from this Organizational Domain are subject to this
       policy (no "t" tag present, so the default of "n" applies).
 
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 52]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    The DMARC policy record might look like this when retrieved using a
    common command-line tool:
 
      % dig +short TXT _dmarc.example.com.
      "v=DMARC1; p=none; rua=mailto:dmarc-feedback@example.com"
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 54]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    To publish such a record, the DNS administrator for the Domain Owner
    creates an entry like the following in the appropriate zone file
@@ -3044,13 +2938,13 @@ B.2.2.  Entire Domain, Monitoring Only, Per-Message Reports
    problems, they wish to request per-message failure reports when
    authentication failures occur.
 
-   Not all Receivers will honor such a request, but the Domain Owner
-   feels that any reports it does receive will be helpful enough to
-   justify publishing this record.  The default per-message report
+   Not all Mail Receivers will honor such a request, but the Domain
+   Owner feels that any reports it does receive will be helpful enough
+   to justify publishing this record.  The default per-message report
    format ([RFC6591]) meets the Domain Owner's needs in this scenario.
 
    The Domain Owner accomplishes this by adding the following to its
-   policy record from Appendix B.2:
+   policy record from Appendix B.2.1:
 
    *  Per-message failure reports should be sent via email to the
       address "auth-reports@example.com" ("ruf=mailto:auth-
@@ -3068,28 +2962,28 @@ B.2.2.  Entire Domain, Monitoring Only, Per-Message Reports
    might create an entry like the following in the appropriate zone file
    (following the conventional zone file format):
 
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 53]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
      ; DMARC record for the domain example.com
 
      _dmarc  IN TXT ( "v=DMARC1; p=none; "
                        "rua=mailto:dmarc-feedback@example.com; "
                        "ruf=mailto:auth-reports@example.com" )
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 55]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
 B.2.3.  Per-Message Failure Reports Directed to Third Party
 
    The Domain Owner from the previous example is maintaining the same
    policy but now wishes to have a third party receive and process the
-   per-message failure reports.  Again, not all Receivers will honor
-   this request, but those that do may implement additional checks to
-   verify that the third party wishes to receive the failure reports for
-   this domain.
+   per-message failure reports.  Again, not all Mail Receivers will
+   honor this request, but those that do may implement additional checks
+   to verify that the third party wishes to receive the failure reports
+   for this domain.
 
    The Domain Owner needs to alter its policy record from Appendix B.2.2
    as follows:
@@ -3118,25 +3012,25 @@ B.2.3.  Per-Message Failure Reports Directed to Third Party
 
    Because the address used in the "ruf" tag is outside the
    Organizational Domain in which this record is published, conforming
-   Receivers will implement additional checks as described in Section 3
-   of [DMARC-Aggregate-Reporting].  In order to pass these additional
-   checks, the third party will need to publish an additional DNS record
-   as follows:
+   Mail Receivers will implement additional checks as described in
+   Section 3 of [DMARC-Aggregate-Reporting].  In order to pass these
+   additional checks, the third party will need to publish an additional
+   DNS record as follows:
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 54]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    *  Given the DMARC record published by the Domain Owner at
       "_dmarc.example.com", the DNS administrator for the third party
       will need to publish a TXT resource record at
       "example.com._report._dmarc.thirdparty.example.net" with the value
       "v=DMARC1;".
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 56]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    The resulting DNS record might look like this when retrieved using a
    common command-line tool (the output shown would appear on a single
@@ -3179,20 +3073,20 @@ B.2.4.  Subdomain, Testing, and Multiple Aggregate Report URIs
 
    *  The version of DMARC being used is "DMARC1" ("v=DMARC1;")
 
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 55]
+
+Internet-Draft                  DMARCbis                   November 2021
+
+
    *  It is applied only to this subdomain (record is published at
       "_dmarc.test.example.com" and not "_dmarc.example.com")
 
    *  Receivers are advised that the Domain Owner considers messages
       that fail to authenticate to be suspicious ("p=quarantine")
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 57]
-
-Internet-Draft                  DMARCbis                   November 2021
-
 
    *  Aggregate feedback reports should be sent via email to the
       addresses "dmarc-feedback@example.com" and "example-tld-
@@ -3211,7 +3105,7 @@ Internet-Draft                  DMARCbis                   November 2021
 
      % dig +short TXT _dmarc.test.example.com
      "v=DMARC1; p=quarantine; rua=mailto:dmarc-feedback@example.com,
-      mailto:tld-test@thirdparty.example.net t=y"
+      mailto:tld-test@thirdparty.example.net; t=y"
 
    To publish such a record, the DNS administrator for the Domain Owner
    might create an entry like the following in the appropriate zone
@@ -3231,24 +3125,22 @@ Internet-Draft                  DMARCbis                   November 2021
    it considers authentication failures to be a clear indication that
    use of the subdomain is not valid.  It would do this by altering the
    DNS record to advise receivers of its position on such messages
-   ("p=reject").
+   ("p=reject") and removing the testing flag ("t=y").
 
    After alteration, the DMARC policy record might look like this when
    retrieved using a common command-line tool (the output shown would
    appear on a single line but is wrapped here for publication):
 
-     % dig +short TXT _dmarc.test.example.com
-     "v=DMARC1; p=reject; rua=mailto:dmarc-feedback@example.com,
-      mailto:tld-test@thirdparty.example.net"
 
 
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 58]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 56]
 
 Internet-Draft                  DMARCbis                   November 2021
 
+
+     % dig +short TXT _dmarc.test.example.com
+     "v=DMARC1; p=reject; rua=mailto:dmarc-feedback@example.com,
+      mailto:tld-test@thirdparty.example.net"
 
    To publish such a record, the DNS administrator for the Domain Owner
    might create an entry like the following in the appropriate zone
@@ -3267,7 +3159,7 @@ B.3.  Mail Receiver Example
    from various email-processing stages to provide feedback to Domain
    Owners (possibly via Report Receivers).
 
-B.4.  Processing of SMTP Time
+B.3.1.  SMTP Session Example
 
    An optimal DMARC-enabled Mail Receiver performs authentication and
    Identifier Alignment checking during the SMTP [RFC5321] conversation.
@@ -3297,11 +3189,7 @@ B.4.  Processing of SMTP Time
 
 
 
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 59]
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 57]
 
 Internet-Draft                  DMARCbis                   November 2021
 
@@ -3323,11 +3211,10 @@ Internet-Draft                  DMARCbis                   November 2021
    the Mail Receiver applies the DMARC-record-specified policy.
    However, before this action is taken, the Mail Receiver can consult
    external information to override the Domain Owner's Assessment
-   Policy.
-   For example, if the Mail Receiver knows that this particular email
-   came from a known and trusted forwarder (that happens to break both
-   SPF and DKIM), then the Mail Receiver may choose to ignore the Domain
-   Owner's policy.
+   Policy.  For example, if the Mail Receiver knows that this particular
+   email came from a known and trusted forwarder (that happens to break
+   both SPF and DKIM), then the Mail Receiver may choose to ignore the
+   Domain Owner's policy.
 
    The Mail Receiver is now ready to reply to the DATA command.  If the
    DMARC check yields that the message is to be rejected, then the Mail
@@ -3357,12 +3244,13 @@ Internet-Draft                  DMARCbis                   November 2021
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 60]
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 58]
 
 Internet-Draft                  DMARCbis                   November 2021
 
 
-B.5.  Utilization of Aggregate Feedback: Example
+B.4.  Utilization of Aggregate Feedback: Example
 
    Aggregate feedback is consumed by Domain Owners to verify their
    understanding of how a given domain is being processed by the Mail
@@ -3393,318 +3281,6 @@ B.5.  Utilization of Aggregate Feedback: Example
    regarding failing authentication checks can also allow the Domain
    Owner to come to an understanding of how its domain is being misused.
 
-   (Aggregate report example should be moved to
-   [DMARC-Aggregate-Reporting])
-
-Appendix C.  Change Log
-
-C.1.  January 5, 2021
-
-C.1.1.  Ticket 80 - DMARCbis SHould Have Clear and Concise Defintion of
-        DMARC
-
-   *  Updated text for Abstract and Introduction sections.
-
-   *  Diffs are recorded here - https://github.com/ietf-wg-dmarc/draft-
-      ietf-dmarc-dmarcbis/pull/1/files (https://github.com/ietf-wg-
-      dmarc/draft-ietf-dmarc-dmarcbis/pull/1/files)
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 61]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-C.2.  February 4, 2021
-
-C.2.1.  Ticket 1 - SPF RFC 4408 vs 7208
-
-   *  Some rearranging of text in the "SPF-Authenticated Identifiers"
-      section
-
-   *  Clarification of the term "in alignment" in that same section
-
-   *  Diffs are here - https://github.com/ietf-wg-dmarc/draft-ietf-
-      dmarc-dmarcbis/pull/3/files (https://github.com/ietf-wg-dmarc/
-      draft-ietf-dmarc-dmarcbis/pull/3/files)
-
-C.3.  February 10, 2021
-
-C.3.1.  Ticket 84 - Remove Erroneous References to RFC3986
-
-   *  Several references to RFC3986 changed to RFC7208
-
-   *  Diffs are here - https://github.com/ietf-wg-dmarc/draft-ietf-
-      dmarc-dmarcbis/pull/4/files (https://github.com/ietf-wg-dmarc/
-      draft-ietf-dmarc-dmarcbis/pull/4/files)
-
-C.4.  March 1, 2021
-
-C.4.1.  Design Team Work Begins
-
-   *  Added change log section to document
-
-C.5.  March 8, 2021
-
-C.5.1.  Removed E.  Gustafsson as editor
-
-   *  He withdrew as editor after a job change.
-
-C.5.2.  Ticket 3 - Two tiny nits
-
-   *  Changes to wording in section 6.6.2, Determine Handling Policy,
-      steps 3 and 4.
-
-   *  New text documented here - https://trac.ietf.org/trac/dmarc/
-      ticket/3#comment:6 (https://trac.ietf.org/trac/dmarc/
-      ticket/3#comment:6)
-
-   *  No change to section 6.6.3, Policy Discovery; ticket seems to pre-
-      date current text, which appears to have answered the concern
-      raised.
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 62]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-C.5.3.  Ticket 4 - Definition of "fo" parameter
-
-   *  Changes to wording in section 6.3, to bring clarity to use of
-      colon-separated list as possible value to "fo"
-
-   *  New text documented here - https://trac.ietf.org/trac/dmarc/
-      ticket/4#comment:4 (https://trac.ietf.org/trac/dmarc/
-      ticket/4#comment:4)
-
-C.6.  March 16, 2021
-
-C.6.1.  Ticket 7 - ABNF for dmarc-record is slightly wrong
-
-   *  New text documented here - https://trac.ietf.org/trac/dmarc/
-      ticket/7 (https://trac.ietf.org/trac/dmarc/ticket/7)
-
-C.6.2.  Ticket 26 - ABNF for pct allows "999"
-
-   *  Updated ABNF for dmarc-percent
-
-   *  New text documented here - https://trac.ietf.org/trac/dmarc/
-      ticket/26#comment:6 (https://trac.ietf.org/trac/dmarc/
-      ticket/26#comment:6)
-
-   *  Ticket 47, Remove pct= tag, rendered change obsolete
-
-C.7.  March 23, 2021
-
-C.7.1.  Ticket 75 - Using wording alternatives to 'disposition',
-        'dispose', and the like
-
-   *  Changed disposition/dispose to "handling"
-
-   *  Diffs documented here - https://trac.ietf.org/trac/dmarc/
-      ticket/75#comment:3 (https://trac.ietf.org/trac/dmarc/
-      ticket/75#comment:3)
-
-C.7.2.  Ticket 72 - Remove absolute requirement for p= tag in DMARC
-        record
-
-   *  Changed from REQUIRED to RECOMMENDED, noted default with forward
-      reference to discussion
-
-   *  Diffs documented here - https://trac.ietf.org/trac/dmarc/
-      ticket/72#comment:3 (https://trac.ietf.org/trac/dmarc/
-      ticket/72#comment:3)
-
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 63]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-C.8.  March 29, 2021
-
-C.8.1.  Ticket 54 - Remove or expand limits on number of recipients per
-        report
-
-   *  Removed limit
-
-   *  Diffs documented here - https://trac.ietf.org/trac/dmarc/
-      ticket/54#comment:5 (https://trac.ietf.org/trac/dmarc/
-      ticket/54#comment:5)
-
-C.9.  April 12, 2021
-
-C.9.1.  Ticket 50 - Remove ri= tag
-
-   *  Updated text to recommend against its usage, a la the ptr
-      mechanism in RFC 7208
-
-   *  Diffs documented here - https://trac.ietf.org/trac/dmarc/
-      ticket/50#comment:5 (https://trac.ietf.org/trac/dmarc/
-      ticket/50#comment:5)
-
-C.9.2.  Ticket 66 - Define what it means to have implemented DMARC
-
-   *  Proposed new text (taken straight from
-      https://trac.ietf.org/trac/dmarc/ticket/66
-      (https://trac.ietf.org/trac/dmarc/ticket/66) as replacement for
-      current text in "Minimum Implemenatations"
-
-C.9.3.  Ticket 96 - Tweaks to Abstract and Introduction
-
-   *  Changed phrase in Abstract to "an email author's domain name"
-
-   *  Changed phrase in Introduction to "reports about email use of the
-      domain name"
-
-C.10.  April 13, 2021
-
-C.10.1.  Ticket 53 - Remove reporting message size chunking
-
-   *  Proposed text to remove all references to message size chunking
-
-   *  Data demonstrating lack of use of feature entered into ticket -
-      https://trac.ietf.org/trac/dmarc/ticket/53#comment:4
-      (https://trac.ietf.org/trac/dmarc/ticket/53#comment:4)
-
-C.10.2.  Ticket 52 - Remove strict alignment (and adkim and aspf tags)
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 64]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-   *  Proposed text to remove all references to strict alignment
-
-   *  Data demonstrating lack of use of feature entered into ticket -
-      https://trac.ietf.org/trac/dmarc/ticket/52#comment:2
-      (https://trac.ietf.org/trac/dmarc/ticket/52#comment:2)
-
-C.10.3.  Ticket 47 - Remove pct= tag
-
-   *  Proposed text to remove all references to pct and message sampling
-
-   *  Data demonstrating lack of use of feature entered into ticket -
-      https://trac.ietf.org/trac/dmarc/ticket/47#comment:4
-      (https://trac.ietf.org/trac/dmarc/ticket/47#comment:4)
-
-C.10.4.  Ticket 2 - Flow of operations text in dmarc-base
-
-   *  Update ASCII Art
-
-   *  Proposed text to replace description of ASCII Art
-
-   *  Proposed text to update Domain Owner Actions section
-
-C.11.  April 14, 2021
-
-C.11.1.  Ticket 107 - DMARCbis should take a stand on multi-valued From
-         fields
-
-   *  Proposed text that limits processing to only those times when all
-      domains are the same.
-
-C.11.2.  Ticket 82 - Deprecate rf= and maybe fo= tag
-
-   *  Proposed text to deprecate rf= tag, while leaving fo= tag as is
-
-C.11.3.  Ticket 85 - Proposed change to wording describing 'p' tag and
-         values
-
-   *  The language expressing the semantics is proposed to be changed to
-      be, in a sense, egocentric.  How do I, the domain owner feel about
-      (assess) the meaning of a DMARC failure?
-
-C.12.  April 15, 2021
-
-C.12.1.  Ticket 86 - A-R results for DMARC
-
-   *  Proposed text to add for polrec.p and polrec.domain methods for
-      registry update.
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 65]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-   *  Did not include polrec.pct due to proposal to remove pct tag
-      (Ticket 47)
-
-C.12.2.  Ticket 62 - Make aggregate reporting a normative MUST
-
-   *  Proposed text to do just that in Mail Receiver Actions, section
-      titled "Send Aggregate Reports"
-
-C.13.  April 19, 2021
-
-C.13.1.  Ticket 109 - Sanity Check DMARCbis Document
-
-   *  Updated document to remove all "original text"/"proposed text"
-      couplets in favor of one (hopefully coherent) document full of
-      proposed text changes.
-
-   *  Noted which tickets were the cause of whatever rfcdiff output will
-      show in tracker
-
-C.14.  April 20, 2021
-
-C.14.1.  Ticket 108 - Changes to DMARCbis for PSD
-
-   *  Incorporating requests for changes to DMARCbis made in text of
-      "Experimental DMARC Extension for Public Suffix Domains"
-      (https://datatracker.ietf.org/doc/draft-ietf-dmarc-psd/
-      (https://datatracker.ietf.org/doc/draft-ietf-dmarc-psd/))
-
-C.15.  April 22, 2021
-
-C.15.1.  Ticket 104 - Update the Security Considerations section 11.3 on
-         DNS
-
-   *  Updated text.  Diffs are here - https://github.com/ietf-wg-dmarc/
-      draft-ietf-dmarc-dmarcbis/pull/31/files (https://github.com/ietf-
-      wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/31/files)
-
-C.16.  June 16, 2021
-
-C.16.1.  Publication of draft-ietf-dmarc-dmarcbis-02
-
-   *  Includes final resolution for tickets 4, 47, 50, 52, 53, 54, and
-      82
-
-C.17.  August 12, 2021
-
-C.17.1.  Publication of draft-ietf-dmarc-dmarcbis-03
-
-
-
-
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 66]
-
-Internet-Draft                  DMARCbis                   November 2021
-
-
-   *  Removal of "pct" tag
-
-   *  Addition of "t" tag
-
-   *  Rearranging of some text and formatting for better readability and
-      consistency.
-
 Acknowledgements
 
    DMARC and the draft version of this document submitted to the
@@ -3720,6 +3296,15 @@ Acknowledgements
    Draegen, Steve Jones, Franck Martin, Brett McDowell, and Paul Midgen.
    The contributors would also like to recognize the invaluable input
    and guidance that was provided early on by J.D.  Falk.
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 59]
+
+Internet-Draft                  DMARCbis                   November 2021
+
 
    Additional contributions within the IETF context were made by Kurt
    Anderson, Michael Jack Assels, Les Barstow, Anne Bennett, Jim Fenton,
@@ -3749,4 +3334,27 @@ Authors' Addresses
 
 
 
-Herr (ed) & Levine (ed)    Expires 27 May 2022                 [Page 67]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Herr (ed) & Levine (ed)    Expires 3 June 2022                 [Page 60]

--- a/draft-ietf-dmarc-dmarcbis-04.txt
+++ b/draft-ietf-dmarc-dmarcbis-04.txt
@@ -1,4 +1,3 @@
-```
 
 
 
@@ -3695,4 +3694,3 @@ Authors' Addresses
 
 
 Herr (ed) & Levine (ed)   Expires 24 March 2022                [Page 66]
-```

--- a/draft-ietf-dmarc-dmarcbis-04.xml
+++ b/draft-ietf-dmarc-dmarcbis-04.xml
@@ -40,9 +40,9 @@ belongs to an organization expected to be known to - and presumably
 trusted by - the recipient. The Sender Policy Framework (SPF) <xref target="RFC7208"></xref>
 and DomainKeys Identified Mail (DKIM) <xref target="RFC6376"></xref> protocols provide
 domain-level authentication but are not directly associated with the
-RFC5322.From domain. DMARC leverages them, and provides a method for
-Domain Owners to publish a DNS record describing the email authentication
-policies for the RFC5322.From domain and to request a specific handling
+RFC5322.From domain. DMARC leverages these two protocols, providing a method
+for Domain Owners to publish a DNS record describing the email authentication
+policies for the RFC5322.From domain and to request specific handling
 for messages using that domain that fail authentication checks.</t>
 <t>As with SPF and DKIM, DMARC classes results as &quot;pass&quot; or &quot;fail&quot;. In order
 to get a DMARC result of &quot;pass&quot;, a pass from either SPF or DKIM is required.
@@ -80,7 +80,8 @@ Owners can use these reports, especially the aggregate reports, to identify
 not only sources of mail attempting to fraudulently use their domain, but also
 (and perhaps more importantly) gaps in their own authentication practices. However,
 as with honoring the Domain Owner's stated mail handling preference, a mail-receiving
-organization supporting DMARC is under no obligation to send requested reports.</t>
+organization supporting DMARC is under no obligation to send requested reports,
+although it is recommended that they do send aggregate reports.</t>
 <t>Use of DMARC creates some interoperability challenges that require due
 consideration before deployment, particularly with configurations that
 can cause mail to be rejected.  These are discussed in <xref target="other-topics"></xref>.</t>
@@ -112,6 +113,36 @@ messages.</t>
 </ul>
 </section>
 
+<section anchor="anti-phishing"><name>Anti-Phishing</name>
+<t>DMARC is designed to prevent bad actors from sending mail that claims
+to come from legitimate senders, particularly senders of transactional
+email (official mail that is about business transactions).  One of the
+primary uses of this kind of spoofed mail is phishing (enticing users
+to provide information by pretending to be the legitimate service
+requesting the information).  Thus, DMARC is significantly informed
+by ongoing efforts to enact large-scale, Internet-wide anti-phishing
+measures.</t>
+<t>Although DMARC can only be used to combat specific forms of
+exact-domain spoofing directly, the DMARC mechanism has been found
+to be useful in the creation of reliable and defensible message streams.</t>
+<t>DMARC does not attempt to solve all problems with spoofed or
+otherwise fraudulent email.  In particular, it does not address the
+use of visually similar domain names (&quot;cousin domains&quot;) or abuse of
+the RFC5322.From human-readable &lt;display-name&gt;.</t>
+</section>
+
+<section anchor="scalability"><name>Scalability</name>
+<t>Scalability is a major issue for systems that need to operate in a
+system as widely deployed as current SMTP email.  For this reason,
+DMARC seeks to avoid the need for third parties or pre-sending
+agreements between senders and receivers.  This preserves the
+positive aspects of the current email infrastructure.</t>
+<t>Although DMARC does not introduce third-party senders (namely
+external agents authorized to send on behalf of an operator) to the
+email-handling flow, it also does not preclude them.  Such third
+parties are free to provide services in conjunction with DMARC.</t>
+</section>
+
 <section anchor="out-of-scope"><name>Out of Scope</name>
 <t>Several topics and issues are specifically out of scope for this
 work.  These include the following:</t>
@@ -129,7 +160,7 @@ those that fail authentication;</t>
 <li><t>Reporting or otherwise evaluating other than the last-hop IP
 address;</t>
 </li>
-<li><t>Attacks in the From: header field, also known as &quot;display name&quot;
+<li><t>Attacks in the RFC5322.From header field, also known as &quot;display name&quot;
 attacks;</t>
 </li>
 <li><t>Authentication of entities other than domains, since DMARC is
@@ -138,36 +169,6 @@ built upon SPF and DKIM, which authenticate domains; and</t>
 <li><t>Content analysis.</t>
 </li>
 </ul>
-</section>
-
-<section anchor="scalability"><name>Scalability</name>
-<t>Scalability is a major issue for systems that need to operate in a
-system as widely deployed as current SMTP email.  For this reason,
-DMARC seeks to avoid the need for third parties or pre-sending
-agreements between senders and receivers.  This preserves the
-positive aspects of the current email infrastructure.</t>
-<t>Although DMARC does not introduce third-party senders (namely
-external agents authorized to send on behalf of an operator) to the
-email-handling flow, it also does not preclude them.  Such third
-parties are free to provide services in conjunction with DMARC.</t>
-</section>
-
-<section anchor="anti-phishing"><name>Anti-Phishing</name>
-<t>DMARC is designed to prevent bad actors from sending mail that claims
-to come from legitimate senders, particularly senders of
-transactional email (official mail that is about business
-transactions).  One of the primary uses of this kind of spoofed mail
-is phishing (enticing users to provide information by pretending to
-be the legitimate service requesting the information).  Thus, DMARC
-is significantly informed by ongoing efforts to enact large-scale,
-Internet-wide anti-phishing measures.</t>
-<t>Although DMARC can only be used to combat specific forms of exact-
-domain spoofing directly, the DMARC mechanism has been found to be
-useful in the creation of reliable and defensible message streams.</t>
-<t>DMARC does not attempt to solve all problems with spoofed or
-otherwise fraudulent email.  In particular, it does not address the
-use of visually similar domain names (&quot;cousin domains&quot;) or abuse of
-the RFC5322.From human-readable &lt;display-name&gt;.</t>
 </section>
 </section>
 
@@ -200,7 +201,7 @@ for details about the supported mechanisms.</t>
 </section>
 
 <section anchor="author-domain"><name>Author Domain</name>
-<t>The domain name of the apparent author, as extracted from the From: header field.</t>
+<t>The domain name of the apparent author, as extracted from the RFC5322.From header field.</t>
 </section>
 
 <section anchor="domain-owner"><name>Domain Owner</name>
@@ -217,19 +218,14 @@ their immediate management domain.</t>
 </section>
 
 <section anchor="identifier-alignment"><name>Identifier Alignment</name>
-<t>When the domain in the address in the From: header field has the
+<t>When the domain in the address in the RFC5322.From header field has the
 same Organizational Domain as a domain verified by an authenticated
-identifier, it has Identifier Alignment. (see below)</t>
-</section>
-
-<section anchor="longest-psd"><name>Longest PSD</name>
-<t>The term Longest PSD is defined in <xref target="RFC9091"></xref>.</t>
+identifier, it has Identifier Alignment. (see <xref target="organizational-domain"></xref>)</t>
 </section>
 
 <section anchor="mail-receiver"><name>Mail Receiver</name>
-<t>The entity or organization that receives and processes email.<br />
-Mail Receivers operate one or more Internet-facing Mail Transport
-Agents (MTAs).</t>
+<t>The entity or organization that receives and processes email. Mail
+Receivers operate one or more Internet-facing Mail Transport Agents (MTAs).</t>
 </section>
 
 <section anchor="non-existent-domains"><name>Non-existent Domains</name>
@@ -283,8 +279,8 @@ about use of the domain name.  All information about a Domain Owner's or
 PSO's DMARC policy is published and retrieved via the DNS.</t>
 <t>DMARC's verification function is based on whether the RFC5322.From
 domain is aligned with a domain name used in a supported authentication
-mechanism. <xref target="authentication-mechanisms"></xref> When a DMARC policy exists
-for the domain name found in the RFC5322.From header field, and that
+mechanism, as described in <xref target="authentication-mechanisms"></xref>. When a DMARC policy
+exists for the domain name found in the RFC5322.From header field, and that
 domain name is not verified through an aligned supported authentication
 mechanism, the handling of that message can be affected based on the
 DMARC policy when delivered to a participating receiver.</t>
@@ -344,10 +340,11 @@ evidence that the message was indeed originated by the agent they
 associate with that mailbox, if the end user knows that these
 various protections have been provided.</t>
 </li>
+<li><t>The absence of a single, properly formed RFC5322.From header field
+renders the message invalid. Handling of such a message is outside
+of the scope of this specification.</t>
+</li>
 </ul>
-<t>The absence of a single, properly formed RFC5322.From header field renders
-the message invalid.  Handling of such a message is outside of the
-scope of this specification.</t>
 <t>Since the sorts of mail typically protected by DMARC participants
 tend to only have single Authors, DMARC participants generally
 operate under a slightly restricted profile of RFC5322 with respect
@@ -364,7 +361,7 @@ are supported in this version of DMARC:</t>
 the &quot;d=&quot; tag of a verified DKIM-Signature header field.</t>
 </li>
 <li><t>SPF, <xref target="RFC7208"></xref>, which can authenticate both the domain found in
-an <xref target="RFC5321"></xref> HELO/EHLO command (the HELO identity) and the domain
+an SMTP <xref target="RFC5321"></xref> HELO/EHLO command (the HELO identity) and the domain
 found in an SMTP MAIL command (the MAIL FROM identity). As noted earlier,
 however, DMARC relies solely on SPF authentication of the domain found in
 SMTP MAIL FROM command. Section 2.4 of <xref target="RFC7208"></xref> describes MAIL FROM
@@ -423,7 +420,7 @@ found in <xref target="domain-owner-actions"></xref> and <xref target="mail-rece
 
 <section anchor="dns-tree-walk"><name>DNS Tree Walk</name>
 <t>While the DMARC protocol defines a method for communicating information
-through publishing records in DNS, it is not necessarily true that a
+through the publishing of records in DNS, it is not necessarily true that a
 DMARC policy record for a given domain will be found in DNS at the same
 level as the name label for the domain in question. Instead, some domains
 will inherit their DNS policy records from parent domains one level or more
@@ -520,8 +517,8 @@ are typically not visible to the end user.</t>
 that it have the same Organizational Domain as an Authenticated Identifier
 (a condition known as &quot;relaxed alignment&quot;) or that it be identical to the
 domain of the Authenticated Identifier (a condition known as &quot;strict
-alignment&quot;). The choice of relaxed or strict alignment is left to the domain
-owner and is expressed in the domain's DMARC policy record.  Domain names
+alignment&quot;). The choice of relaxed or strict alignment is left to the Domain
+Owner and is expressed in the domain's DMARC policy record.  Domain names
 in this context are to be compared in a case-insensitive manner, per <xref target="RFC4343"></xref>.</t>
 <t>It is important to note that Identifier Alignment cannot occur with a
 message that is not valid per <xref target="RFC5322"></xref>, particularly one with a
@@ -597,23 +594,23 @@ domain can be verified.</t>
 </section>
 
 <section anchor="policy"><name>Policy</name>
-<t>DMARC policies are published by Domain Owners and PSOs and can be
-used by Mail Receivers to inform their message handling decisions.</t>
 <t>A Domain Owner or PSO advertises DMARC participation of one or more of its
 domains by adding a DNS TXT record (described in <xref target="dmarc-policy-record"></xref>) to
 those domains.  In doing so, Domain Owners and PSOs indicate their handling
 preference regarding failed authentication for email messages making use
-of their domain in the RFC5322.From header field as well as the provision
-of feedback about those messages. Mail Receivers in turn can take into
+of their domain in the RFC5322.From header field as well as their desire
+for feedback about those messages. Mail Receivers in turn can take into
 account the Domain Owner's stated preference when making handling
 decisions about email messages that fail DMARC authentication checks.</t>
 <t>A Domain Owner or PSO may choose not to participate in DMARC evaluation by
-Mail Receivers.  In this case, the Domain Owner simply declines to
-advertise participation in those schemes.  For example, if the
-results of path authorization checks ought not be considered as part
-of the overall DMARC result for a given Author Domain, then the
-Domain Owner does not publish an SPF policy record that can produce
-an SPF pass result.</t>
+Mail Receivers simply by not publishing an appropriate DNS TXT record for
+its domain(s).  A Domain Owner can also choose to not have some underlying
+authentication technologies apply to DMARC evaluation of its domain(s). In
+this case, the Domain Owner simply declines to advertise participation in
+those schemes.  For example, if the results of path authorization checks
+ought not be considered as part of the overall DMARC result for a given
+Author Domain, then the Domain Owner does not publish an SPF policy record
+that can produce an SPF pass result.</t>
 <t>A Mail Receiver implementing the DMARC mechanism SHOULD make a best-effort
 attempt to adhere to the Domain Owner's or PSO's published DMARC Domain
 Owner Assessment Policy when a message fails the DMARC test. Since email
@@ -700,35 +697,27 @@ Report generators MAY choose to adhere to the requested options.
 This tag's content MUST be ignored if a &quot;ruf&quot; tag (below) is not
 also specified.  Failure reporting options are shown below. The value
 of this tag is either &quot;0&quot;, &quot;1&quot;, or a colon-separated list of the
-options represented by alphabetic characters.</t>
-</dd>
-</dl>
-<t>The valid values and their meanings are:</t>
-
-<artwork>0:
-:  Generate a DMARC failure report if all underlying
-   authentication mechanisms fail to produce an aligned &quot;pass&quot;
-   result.
-
-1:
-:  Generate a DMARC failure report if any underlying
-   authentication mechanism produced something other than an
-   aligned &quot;pass&quot; result.
-
-d:
-:  Generate a DKIM failure report if the message had a signature
-   that failed evaluation, regardless of its alignment.  DKIM-
-   specific reporting is described in [@!RFC6651].
-
-s:
-:  Generate an SPF failure report if the message failed SPF
-   evaluation, regardless of its alignment.  SPF-specific
-   reporting is described in [@!RFC6652].
-</artwork>
+options represented by alphabetic characters. The valid values and
+their meanings are:</t>
 
 <dl>
+<dt>0:</dt>
+<dd>Generate a DMARC failure report if all underlying authentication
+mechanisms fail to produce an aligned &quot;pass&quot; result.</dd>
+<dt>1:</dt>
+<dd>Generate a DMARC failure report if any underlying authentication
+mechanism produced something other than an aligned &quot;pass&quot; result.</dd>
+<dt>d:</dt>
+<dd>Generate a DKIM failure report if the message had a signature
+that failed evaluation, regardless of its alignment. DKIM-specific
+reporting is described in <xref target="RFC6651"></xref>.</dd>
+<dt>s:</dt>
+<dd>Generate an SPF failure report if the message failed SPF
+evaluation, regardless of its alignment. SPF-specific
+reporting is described in <xref target="RFC6652"></xref>.</dd>
+</dl></dd>
 <dt>np:</dt>
-<dd>Domain Owner Assessment Policy for non-existent subdomains
+<dd><t>Domain Owner Assessment Policy for non-existent subdomains
 (plain-text; OPTIONAL).  Indicates the message handling preference
 that the Domain Owner or PSO has for mail using non-existent subdomains
 of the domain queried. It applies only to non-existent subdomains of
@@ -740,7 +729,8 @@ policy specified by the &quot;p&quot; tag, if the &quot;sp&quot; tag is not pres
 MUST be applied for non-existent subdomains.  Note that &quot;np&quot; will
 be ignored for DMARC records published on subdomains of Organizational
 Domains and PSDs due to the effect of the DMARC policy discovery
-mechanism described in <xref target="dmarc-policy-discovery"></xref>.</dd>
+mechanism described in <xref target="dmarc-policy-discovery"></xref>.</t>
+</dd>
 <dt>p:</dt>
 <dd><t>Domain Owner Assessment Policy (plain-text; RECOMMENDED for policy
 records). Indicates the message handling preference the Domain Owner or
@@ -755,14 +745,12 @@ Possible values are as follows:</t>
 <dt>none:</dt>
 <dd>The Domain Owner offers no expression of preference.</dd>
 <dt>quarantine:</dt>
-<dd>The Domain Owner considers such mail to be suspicious. It
-is possible the mail is valid, although the failure creates
-a significant concern.</dd>
+<dd>The Domain Owner considers such mail to be suspicious. It is possible
+the mail is valid, although the failure creates a significant concern.</dd>
 <dt>reject:</dt>
-<dd>The Domain Owner considers all such failures to be a clear
-indication that the use of the domain name is not valid. See
-<xref target="rejecting-messages"></xref> for some discussion of SMTP rejection
-methods and their implications.</dd>
+<dd>The Domain Owner considers all such failures to be a clear indication
+that the use of the domain name is not valid. See <xref target="rejecting-messages"></xref>
+for some discussion of SMTP rejection methods and their implications.</dd>
 </dl></dd>
 <dt>psd:</dt>
 <dd><t>A flag indicating whether the domain is a PSD. (plain-text; OPTIONAL;
@@ -775,35 +763,32 @@ this tag with a value of 'y' to indicate that the domain is a PSD. This
 information will be used during policy discovery to determine how to
 apply any DMARC policy records that are discovered during the tree walk.</dd>
 <dt>n:</dt>
-<dd>The default, indicating that the DMARC policy record is published
-for a domain that is not a PSD.</dd>
+<dd>The default, indicating that the DMARC policy record is published for a
+domain that is not a PSD.</dd>
 </dl></dd>
 <dt>rua:</dt>
-<dd><t>Addresses to which aggregate feedback is to be sent (comma-
-separated plain-text list of DMARC URIs; OPTIONAL).  <xref target="DMARC-Aggregate-Reporting"></xref>
-discusses considerations that apply when the domain name of a URI differs
-from that of the domain advertising the policy.  See <xref target="external-report-addresses"></xref>
-for additional considerations.  Any valid URI can be specified.<br />
-A Mail Receiver MUST implement support for a &quot;mailto:&quot; URI, i.e., the
-ability to send a DMARC report via electronic mail.  If not provided,
-Mail Receivers MUST NOT generate aggregate feedback reports.  URIs
-not supported by Mail Receivers MUST be ignored.  The aggregate
-feedback report format is described in <xref target="DMARC-Aggregate-Reporting"></xref></t>
+<dd><t>Addresses to which aggregate feedback is to be sent (comma-separated plain-text
+list of DMARC URIs; OPTIONAL).  <xref target="DMARC-Aggregate-Reporting"></xref> discusses considerations
+that apply when the domain name of a URI differs from that of the domain advertising
+the policy.  See <xref target="external-report-addresses"></xref> for additional considerations. Any
+valid URI can be specified.  A Mail Receiver MUST implement support for a &quot;mailto:&quot;
+URI, i.e., the ability to send a DMARC report via electronic mail.  If the tag is not
+provided, Mail Receivers MUST NOT generate aggregate feedback reports for the domain.
+URIs not supported by Mail Receivers MUST be ignored. The aggregate feedback report
+format is described in <xref target="DMARC-Aggregate-Reporting"></xref></t>
 </dd>
 <dt>ruf:</dt>
-<dd><t>Addresses to which message-specific failure information is to
-be reported (comma-separated plain-text list of DMARC URIs;
-OPTIONAL).  If present, the Domain Owner or PSO is requesting Mail
-Receivers to send detailed failure reports about messages that
-fail the DMARC evaluation in specific ways (see the &quot;fo&quot; tag
-above).  The format of the message to be generated MUST follow the
-format specified for the &quot;rf&quot; tag. <xref target="DMARC-Aggregate-Reporting"></xref> discusses
-considerations that apply when the domain name of a URI differs
-from that of the domain advertising the policy.  A Mail Receiver
-MUST implement support for a &quot;mailto:&quot; URI, i.e., the ability to
-send a DMARC report via electronic mail.  If not provided, Mail
-Receivers MUST NOT generate failure reports.  See <xref target="external-report-addresses"></xref> for
-additional considerations.</t>
+<dd><t>Addresses to which message-specific failure information is to be reported
+(comma-separated plain-text list of DMARC URIs; OPTIONAL).  If present, the Domain
+Owner or PSO is requesting Mail Receivers to send detailed failure reports about
+messages that fail the DMARC evaluation in specific ways (see the &quot;fo&quot; tag above).
+The format of the message to be generated MUST follow the format specified for the
+&quot;rf&quot; tag. <xref target="DMARC-Aggregate-Reporting"></xref> discusses considerations that apply when
+the domain name of a URI differs from that of the domain advertising the policy.
+A Mail Receiver MUST implement support for a &quot;mailto:&quot; URI, i.e., the ability to
+send a DMARC report via electronic mail.  If the tag is not provided, Mail Receivers
+MUST NOT generate failure reports for the domain. See <xref target="external-report-addresses"></xref>
+for additional considerations.</t>
 </dd>
 <dt>sp:</dt>
 <dd><t>Domain Owner Assessment Policy for all subdomains (plain-text;
@@ -871,7 +856,7 @@ follows:</t>
   dmarc-tag       = dmarc-request /
                     dmarc-test /
                     dmarc-psd /
-                    dmarc-srequest /
+                    dmarc-sprequest /
                     dmarc-nprequest /
                     dmarc-adkim /
                     dmarc-aspf /
@@ -893,7 +878,7 @@ follows:</t>
 
   dmarc-psd       = &quot;psd&quot; *WSP &quot;=&quot; ( &quot;y&quot; / &quot;n&quot; )
 
-  dmarc-srequest  = &quot;sp&quot; *WSP &quot;=&quot; *WSP
+  dmarc-sprequest = &quot;sp&quot; *WSP &quot;=&quot; *WSP
                     ( &quot;none&quot; / &quot;quarantine&quot; / &quot;reject&quot; )
 
   dmarc-nprequest  = &quot;np&quot; *WSP &quot;=&quot; *WSP
@@ -927,10 +912,12 @@ DMARC mechanism.</t>
 <t>Because DMARC relies on SPF <xref target="RFC7208"></xref> and DKIM <xref target="RFC6376"></xref>, in
 order to take full advantage of DMARC, a Domain Owner SHOULD first
 ensure that SPF and DKIM authentication are properly configured.
-The easiest first step here is to choose a domain to use as the
-RFC5321.From domain (i.e., the Return-Path domain) for its mail,
+As a first step the Domain Owner SHOULD choose a domain to use as the
+RFC5321.MailFrom domain (i.e., the Return-Path domain) for its mail,
 one that aligns with the Author Domain, and then publish an SPF
-policy in DNS for that domain.</t>
+policy in DNS for that domain. The SPF record SHOULD be constructed
+at a minimum to ensure an SPF pass verdict for all known sources of
+mail for the RFC5321.MailFrom domain.</t>
 </section>
 
 <section anchor="configure-sending-system-for-dkim-signing-using-an-aligned-domain"><name>Configure Sending System for DKIM Signing Using an Aligned Domain</name>
@@ -940,7 +927,8 @@ both authentication mechanisms are in place in order to guard
 against failure of just one of them. The Domain Owner SHOULD choose
 a DKIM-Signing domain (i.e., the d= domain in the DKIM-Signature
 header) that aligns with the Author Domain and configure its system
-to sign using that domain.</t>
+to sign using that domain, to include publishing a corresponding DKIM
+public key in DNS.</t>
 </section>
 
 <section anchor="setup-a-mailbox-to-receive-aggregate-reports"><name>Setup a Mailbox to Receive Aggregate Reports</name>
@@ -952,11 +940,11 @@ Owner, showing sources of mail using the Author Domain. Depending
 on how mature the Domain Owner's DMARC rollout is, some of these
 sources could be legitimate ones that were overlooked during the
 intial deployment of SPF and/or DKIM.</t>
-<t>Because the aggregate reports are XML documents, it is strongly
-advised that they be machine-parsed, so setting up a mailbox
-involves more than just the physical creation of the mailbox. Many
-third-party services exist that will process DMARC aggregate reports,
-or the Domain Owner can create its own set of tools. No matter which
+<t>Because the aggregate reports are XML documents, it is recommended
+that they be machine-parsed, so setting up a mailbox involves more
+than just the physical creation of that mailbox. Many third-party
+services exist that will process DMARC aggregate reports, or the
+Domain Owner can create its own set of tools. No matter which
 method is chosen, the ability to parse these reports and consume
 the data contained in them will go a long way to ensuring a
 successful deployment.</t>
@@ -965,8 +953,8 @@ successful deployment.</t>
 <section anchor="publish-a-dmarc-policy-for-the-author-domain"><name>Publish a DMARC Policy for the Author Domain</name>
 <t>Once SPF, DKIM, and the aggregate reports mailbox are all in place,
 it's time to publish a DMARC record. For best results, Domain Owners
-SHOULD start with &quot;p=none&quot;, with the rua tag containg the mailbox
-created in the previous step.</t>
+SHOULD start with &quot;p=none&quot;, with the rua tag containg a URI that
+references the mailbox created in the previous step.</t>
 </section>
 
 <section anchor="collect-and-analyze-reports-and-adjust-authentication"><name>Collect and Analyze Reports and Adjust Authentication</name>
@@ -1056,11 +1044,11 @@ to complete the SPF check.</t>
 <li><t>Conduct Identifier Alignment checks.  With authentication checks
 and policy discovery performed, the Mail Receiver checks to see
 if Authenticated Identifiers fall into alignment as described in
-<xref target="terminology"></xref>.  If one or more of the Authenticated Identifiers align
-with the RFC5322.From domain, the message is considered to pass
-the DMARC mechanism check.  All other conditions (authentication
-failures, identifier mismatches) are considered to be DMARC
-mechanism check failures.</t>
+<xref target="identifier-alignment-explained"></xref>.  If one or more of the Authenticated
+Identifiers align with the RFC5322.From domain, the message is
+considered to pass the DMARC mechanism check.  All other conditions
+(authentication failures, identifier mismatches) are considered to be
+DMARC mechanism check failures.</t>
 </li>
 <li><t>Apply policy, if appropriate.  Emails that fail the DMARC mechanism
 check are handled in accordance with the discovered DMARC policy of the
@@ -1123,7 +1111,7 @@ closed&quot;).</t>
 <t>Note: Because the PSD policy query comes after the Organizational
 Domain policy query, PSD policy is not used for Organizational
 domains that have published a DMARC policy.  Specifically, this is
-not a mechanism to provide feedback addresses (RUA/RUF) when an
+not a mechanism to provide feedback addresses (rua/ruf) when an
 Organizational Domain has declined to do so.</t>
 </section>
 </section>
@@ -1148,8 +1136,8 @@ records with p= tag values of 'quarantine' or 'reject' are higher
 value signals to Mail Receivers, ones that can assist Mail Receivers
 with handling decisions for a message in ways that p= tag values of
 'none' cannot.</t>
-<t>In order to ensure maximum usefulness for DMARC across the email
-ecosystem, then, Mail Receivers SHOULD generate and send aggregate
+<t>Given the above, in order to ensure maximum usefulness for DMARC across
+the email ecosystem, Mail Receivers SHOULD generate and send aggregate
 reports with a frequency of at least once every 24 hours.</t>
 </section>
 </section>
@@ -1257,7 +1245,7 @@ benefits of DNS caching.</t>
 <section anchor="rejecting-messages"><name>Rejecting Messages</name>
 <t>This protocol calls for rejection of a message during the SMTP
 session under certain circumstances.  This is preferable to
-generation of a Delivery Status Notification (<xref target="RFC3464"></xref>), since
+generation of a Delivery Status Notification <xref target="RFC3464"></xref>, since
 fraudulent messages caught and rejected using DMARC would then result
 in annoying generation of such failure reports that go back to the
 RFC5321.MailFrom address.</t>
@@ -1694,11 +1682,12 @@ false data from compromised but known Mail Receivers.</t>
 <section anchor="dns-security"><name>DNS Security</name>
 <t>The DMARC mechanism and its underlying technologies (SPF, DKIM)
 depend on the security of the DNS. Examples of how hostile parties can
-have an adverse impact on DNS traffic include:
-*  If they can snoop on DNS traffic, they can get an idea of who is
-   sending mail.</t>
+have an adverse impact on DNS traffic include:</t>
 
 <ul>
+<li><t>If they can snoop on DNS traffic, they can get an idea of who is
+sending mail.</t>
+</li>
 <li><t>If they can block outgoing or reply DNS messages, they can prevent
 systems from discovering senders' DMARC policies, causing recipients
 to assume p=none by default.</t>
@@ -1859,10 +1848,9 @@ could reveal private information.</t>
 
 <section anchor="technology-considerations"><name>Technology Considerations</name>
 <t>This section documents some design decisions that were made in the
-development of DMARC.  Specifically, addressed here are some
-suggestions that were considered but not included in the design.
-This text is included to explain why they were considered and not
-included in this version.</t>
+development of DMARC.  Specifically addressed here are some
+suggestions that were considered but not included in the design,
+with explanatory text regarding the decision.</t>
 
 <section anchor="s-mime"><name>S/MIME</name>
 <t>S/MIME, or Secure Multipurpose Internet Mail Extensions, is a
@@ -2008,46 +1996,58 @@ tight for ADSP; they must match exactly.</t>
 </section>
 
 <section anchor="organizational-domain-discovery-issues"><name>Organizational Domain Discovery Issues</name>
-<t>Although protocols like ADSP are useful for &quot;protecting&quot; a specific
-domain name, they are not helpful at protecting subdomains.  If one
-wished to protect &quot;example.com&quot; by requiring via ADSP that all mail
-bearing an RFC5322.From domain of &quot;example.com&quot; be signed, this would
-&quot;protect&quot; that domain; however, one could then craft an email whose
-RFC5322.From domain is &quot;security.example.com&quot;, and ADSP would not
-provide any protection.  One could use a DNS wildcard, but this can
-undesirably interfere with other DNS activity; one could add ADSP
-records as fraudulent domains are discovered, but this solution does
-not scale and is a purely reactive measure against abuse.</t>
-<t>The DNS does not provide a method by which the &quot;domain of record&quot;, or
-the domain that was actually registered with a domain registrar, can
-be determined given an arbitrary domain name.  Suggestions have been
-made that attempt to glean such information from SOA or NS resource
-records, but these too are not fully reliable, as the partitioning of
-the DNS is not always done at administrative boundaries.</t>
-<t>When seeking domain-specific policy based on an arbitrary domain
-name, one could &quot;climb the tree&quot;, dropping labels off the left end of
-the name until the root is reached or a policy is discovered, but
-then one could craft a name that has a large number of nonsense
-labels; this would cause a Mail Receiver to attempt a large number of
-queries in search of a policy record.  Sending many such messages
-constitutes an amplified denial-of-service attack.</t>
-<t>The Organizational Domain mechanism is a necessary component to the
-goals of DMARC.  The method described in <xref target="determining-the-organizational-domain"></xref> is far from
-perfect but serves this purpose reasonably well without adding undue
-burden or semantics to the DNS.  If a method is created to do so that
-is more reliable and secure than the use of a public suffix list,
-DMARC should be amended to use that method as soon as it is generally
-available.</t>
+<t>An earlier informational version of the DMARC protocol <xref target="RFC7489"></xref>
+noted that the DNS does not provide a method by which the &quot;domain of record&quot;,
+or the domain that was actually registered with a domain registrar, can
+be determined given an arbitrary domain name. That version further mentioned
+suggestions that have been made that attempt to glean such information from
+SOA or NS resource records, but these too are not fully reliable, as the
+partitioning of the DNS is not always done at administrative boundaries.</t>
+<t>That previous version posited that one could &quot;climb the tree&quot; to find the
+Organizational Domain, but expressed concern that an attacker could exploit
+this for a denial-of-service attack through sending a high number of messages
+each with a relatively large number of nonsense labels, causing a Mail Receiver
+to perform a large number of DNS queries in search of a policy record. This
+version defines a method for performing a DNS Tree Walk, described in <xref target="dns-tree-walk"></xref>,
+and further mitigates the risk of the denial-of-service attack by expressly limiting
+the number of DNS queries to execute regardless of the number of labels in the domain
+name.</t>
+<t>As a matter of historical record, the method for finding the Organizational
+Domain described in <xref target="RFC7489"></xref> is preserved here:</t>
 
-<section anchor="public-suffix-lists"><name>Public Suffix Lists</name>
-<t>A public suffix list for the purposes of determining the
-Organizational Domain can be obtained from various sources.  The most
-common one is maintained by the Mozilla Foundation and made public at
-<eref target="http://publicsuffix.org">http://publicsuffix.org</eref>.  License terms governing the use of that
-list are available at that URI.</t>
+<ol>
+<li><t>Acquire a &quot;public suffix&quot; list (PSL), i.e., a list of DNS domain
+   names reserved for registrations.  Some country Top-Level Domains
+   (TLDs) make specific registration requirements, e.g., the United
+   Kingdom places company registrations under &quot;.co.uk&quot;; other TLDs
+   such as &quot;.com&quot; appear in the IANA registry of top-level DNS
+   domains.  A PSL is the union of all of these.</t>
+<t>A PSL can be obtained from various sources. The most common one
+   is maintained by the Mozilla Foundation and made public at
+   <eref target="http://publicsuffix.org">http://publicsuffix.org</eref>.  License terms governing the use of that
+   list are available at that URI.</t>
 <t>Note that if operators use a variety of public suffix lists,
-interoperability will be difficult or impossible to guarantee.</t>
-</section>
+   interoperability will be difficult or impossible to guarantee.</t>
+</li>
+<li><t>Break the subject DNS domain name into a set of &quot;n&quot; ordered
+   labels.  Number these labels from right to left; e.g., for
+   &quot;example.com&quot;, &quot;com&quot; would be label 1 and &quot;example&quot; would be
+   label 2.</t>
+</li>
+<li><t>Search the public suffix list for the name that matches the
+   largest number of labels found in the subject DNS domain.  Let
+   that number be &quot;x&quot;.</t>
+</li>
+<li><t>Construct a new DNS domain name using the name that matched from
+   the public suffix list and prefixing to it the &quot;x+1&quot;th label from
+   the subject domain.  This new name is the Organizational Domain.</t>
+</li>
+</ol>
+<t>Thus, since &quot;com&quot; is an IANA-registered TLD, a subject domain of
+   &quot;a.b.c.d.example.com&quot; would have an Organizational Domain of
+   &quot;example.com&quot;.</t>
+<t>The process of determining a suffix is currently a heuristic one.  No
+   list is guaranteed to be accurate or current.</t>
 </section>
 
 <section anchor="removal-of-the-pct-tag"><name>Removal of the &quot;pct&quot; Tag</name>
@@ -2058,16 +2058,15 @@ owners with a method to gradually change their preferred assessment policy
 (the p= tag) from 'none' to 'quarantine' or from 'quarantine' to 'reject'
 by requesting the stricter treatment for just a percentage of messages
 that produced DMARC results of &quot;fail&quot;.</t>
-<t>Operational experience and mathematics (specifically the Probability Mass
-Function as applied to Binomial Distributions) showed that the pct tag
-was usually not accurately applied, unless the value specified was either &quot;0&quot;
-or &quot;100&quot; (the default), and the inaccuracies with other values varied widely
-from implementation to implementation. The default value was easily implemented,
-as it required no special processing on the part of the message receiver, while
-the value of &quot;0&quot; took on unintended significance as a value used by some
-intermediaries and mailbox providers as an indicator to deviate from
-standard handling of the message, usually by rewriting the RFC5322.From
-header in an effort to avoid DMARC failures downstream.</t>
+<t>Operational experience showed that the pct tag was usually not accurately
+applied, unless the value specified was either &quot;0&quot; or &quot;100&quot; (the default),
+and the inaccuracies with other values varied widely from implementation to
+implementation. The default value was easily implemented, as it required no
+special processing on the part of the message receiver, while the value
+of &quot;0&quot; took on unintended significance as a value used by some intermediaries
+and mailbox providers as an indicator to deviate from standard handling of
+the message, usually by rewriting the RFC5322.From header in an effort to
+avoid DMARC failures downstream.</t>
 <t>These custom actions when the pct= tag was set to &quot;0&quot; proved valuable to the
 email community. In particular, header rewriting by an intermediary meant
 that a Domain Owner's aggregate reports could reveal to the Domain Owner
@@ -2246,12 +2245,12 @@ implemented DKIM correctly, but they are still seeing periodic
 authentication failures.  In order to diagnose these intermittent
 problems, they wish to request per-message failure reports when
 authentication failures occur.</t>
-<t>Not all Receivers will honor such a request, but the Domain Owner
+<t>Not all Mail Receivers will honor such a request, but the Domain Owner
 feels that any reports it does receive will be helpful enough to
 justify publishing this record.  The default per-message report
 format (<xref target="RFC6591"></xref>) meets the Domain Owner's needs in this scenario.</t>
 <t>The Domain Owner accomplishes this by adding the following to its
-policy record from <xref target="domain-owner-example"></xref>:</t>
+policy record from <xref target="entire-domain-monitoring-only"></xref>:</t>
 
 <ul>
 <li>Per-message failure reports should be sent via email to the
@@ -2281,7 +2280,7 @@ might create an entry like the following in the appropriate zone file
 <section anchor="per-message-failure-reports-directed-to-third-party"><name>Per-Message Failure Reports Directed to Third Party</name>
 <t>The Domain Owner from the previous example is maintaining the same
 policy but now wishes to have a third party receive and process the
-per-message failure reports.  Again, not all Receivers will honor
+per-message failure reports.  Again, not all Mail Receivers will honor
 this request, but those that do may implement additional checks to
 verify that the third party wishes to receive the failure reports
 for this domain.</t>
@@ -2313,7 +2312,7 @@ might create an entry like the following in the appropriate zone file
 </artwork>
 <t>Because the address used in the &quot;ruf&quot; tag is outside the
 Organizational Domain in which this record is published, conforming
-Receivers will implement additional checks as described in Section 3 of
+Mail Receivers will implement additional checks as described in Section 3 of
 <xref target="DMARC-Aggregate-Reporting"></xref>.  In order to pass these additional
 checks, the third party will need to publish an additional DNS record
 as follows:</t>
@@ -2389,7 +2388,7 @@ line but is wrapped here for publication):</t>
 
 <artwork>  % dig +short TXT _dmarc.test.example.com
   &quot;v=DMARC1; p=quarantine; rua=mailto:dmarc-feedback@example.com,
-   mailto:tld-test@thirdparty.example.net t=y&quot;
+   mailto:tld-test@thirdparty.example.net; t=y&quot;
 </artwork>
 <t>To publish such a record, the DNS administrator for the Domain Owner
 might create an entry like the following in the appropriate zone
@@ -2408,7 +2407,8 @@ the subdomain is properly authenticating and passing DMARC checks, then
 the Domain Owner can update the policy record to indicate that it considers
 authentication failures to be a clear indication that use of the subdomain
 is not valid. It would do this by altering the DNS record to advise
-receivers of its position on such messages (&quot;p=reject&quot;).</t>
+receivers of its position on such messages (&quot;p=reject&quot;) and removing the
+testing flag (&quot;t=y&quot;).</t>
 <t>After alteration, the DMARC policy record might look like this when retrieved
 using a common command-line tool (the output shown would appear on a single
 line but is wrapped here for publication):</t>
@@ -2435,9 +2435,8 @@ file:</t>
 SPF and DKIM, and possess the ability to collect relevant information
 from various email-processing stages to provide feedback to Domain
 Owners (possibly via Report Receivers).</t>
-</section>
 
-<section anchor="processing-of-smtp-time"><name>Processing of SMTP Time</name>
+<section anchor="smtp-session-example"><name>SMTP Session Example</name>
 <t>An optimal DMARC-enabled Mail Receiver performs authentication and
 Identifier Alignment checking during the SMTP <xref target="RFC5321"></xref> conversation.</t>
 <t>Prior to returning a final reply to the DATA command, the Mail
@@ -2475,12 +2474,12 @@ Receiver considers the above email to pass the DMARC check, avoiding
 the &quot;reject&quot; policy that is requested to be applied to email that fails
 to pass the DMARC check.</t>
 <t>If no Authenticated Identifiers align with the Author Domain, then
-the Mail Receiver applies the DMARC-record-specified policy.
-However, before this action is taken, the Mail Receiver can consult
-external information to override the Domain Owner's Assessment Policy.<br />
-For example, if the Mail Receiver knows that this particular email
-came from a known and trusted forwarder (that happens to break both
-SPF and DKIM), then the Mail Receiver may choose to ignore the Domain
+the Mail Receiver applies the DMARC-record-specified policy. However,
+before this action is taken, the Mail Receiver can consult external
+information to override the Domain Owner's Assessment Policy. For
+example, if the Mail Receiver knows that this particular email came
+from a known and trusted forwarder (that happens to break both SPF
+and DKIM), then the Mail Receiver may choose to ignore the Domain
 Owner's policy.</t>
 <t>The Mail Receiver is now ready to reply to the DATA command.  If the
 DMARC check yields that the message is to be rejected, then the Mail
@@ -2502,6 +2501,7 @@ DMARC processing.  Captured information is used to build feedback for
 Domain Owner consumption.  This is not necessary if the Domain Owner
 has not requested aggregate reports, i.e., no &quot;rua&quot; tag was found in
 the policy record.</t>
+</section>
 </section>
 
 <section anchor="utilization-of-aggregate-feedback-example"><name>Utilization of Aggregate Feedback: Example</name>
@@ -2531,304 +2531,6 @@ across uncovered email sources, if the mail that is failing the checks
 was generated by or on behalf of the Domain Owner.  Data regarding
 failing authentication checks can also allow the Domain Owner to
 come to an understanding of how its domain is being misused.</t>
-<t>(Aggregate report example should be moved to <xref target="DMARC-Aggregate-Reporting"></xref>)</t>
-</section>
-</section>
-
-<section anchor="change-log"><name>Change Log</name>
-
-<section anchor="january-5-2021"><name>January 5, 2021</name>
-
-<section anchor="ticket-80-dmarcbis-should-have-clear-and-concise-defintion-of-dmarc"><name>Ticket 80 - DMARCbis SHould Have Clear and Concise Defintion of DMARC</name>
-
-<ul>
-<li>Updated text for Abstract and Introduction sections.</li>
-<li>Diffs are recorded here - <eref target="https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/1/files">https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/1/files</eref></li>
-</ul>
-</section>
-</section>
-
-<section anchor="february-4-2021"><name>February 4, 2021</name>
-
-<section anchor="ticket-1-spf-rfc-4408-vs-7208"><name>Ticket 1 - SPF RFC 4408 vs 7208</name>
-
-<ul>
-<li>Some rearranging of text in the &quot;SPF-Authenticated Identifiers&quot; section</li>
-<li>Clarification of the term &quot;in alignment&quot; in that same section</li>
-<li>Diffs are here - <eref target="https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/3/files">https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/3/files</eref></li>
-</ul>
-</section>
-</section>
-
-<section anchor="february-10-2021"><name>February 10, 2021</name>
-
-<section anchor="ticket-84-remove-erroneous-references-to-rfc3986"><name>Ticket 84 - Remove Erroneous References to RFC3986</name>
-
-<ul>
-<li>Several references to RFC3986 changed to RFC7208</li>
-<li>Diffs are here - <eref target="https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/4/files">https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/4/files</eref></li>
-</ul>
-</section>
-</section>
-
-<section anchor="march-1-2021"><name>March 1, 2021</name>
-
-<section anchor="design-team-work-begins"><name>Design Team Work Begins</name>
-
-<ul>
-<li>Added change log section to document</li>
-</ul>
-</section>
-</section>
-
-<section anchor="march-8-2021"><name>March 8, 2021</name>
-
-<section anchor="removed-e-gustafsson-as-editor"><name>Removed E. Gustafsson as editor</name>
-
-<ul>
-<li>He withdrew as editor after a job change.</li>
-</ul>
-</section>
-
-<section anchor="ticket-3-two-tiny-nits"><name>Ticket 3 - Two tiny nits</name>
-
-<ul>
-<li>Changes to wording in section 6.6.2, Determine Handling Policy, steps
-3 and 4.</li>
-<li>New text documented here - <eref target="https://trac.ietf.org/trac/dmarc/ticket/3#comment:6">https://trac.ietf.org/trac/dmarc/ticket/3#comment:6</eref></li>
-<li>No change to section 6.6.3, Policy Discovery; ticket seems to pre-date
-current text, which appears to have answered the concern raised.</li>
-</ul>
-</section>
-
-<section anchor="ticket-4-definition-of-fo-parameter"><name>Ticket 4 - Definition of &quot;fo&quot; parameter</name>
-
-<ul>
-<li>Changes to wording in section 6.3, to bring clarity to use of colon-separated
-list as possible value to &quot;fo&quot;</li>
-<li>New text documented here - <eref target="https://trac.ietf.org/trac/dmarc/ticket/4#comment:4">https://trac.ietf.org/trac/dmarc/ticket/4#comment:4</eref></li>
-</ul>
-</section>
-</section>
-
-<section anchor="march-16-2021"><name>March 16, 2021</name>
-
-<section anchor="ticket-7-abnf-for-dmarc-record-is-slightly-wrong"><name>Ticket 7 - ABNF for dmarc-record is slightly wrong</name>
-
-<ul>
-<li>New text documented here - <eref target="https://trac.ietf.org/trac/dmarc/ticket/7">https://trac.ietf.org/trac/dmarc/ticket/7</eref></li>
-</ul>
-</section>
-
-<section anchor="ticket-26-abnf-for-pct-allows-999"><name>Ticket 26 - ABNF for pct allows &quot;999&quot;</name>
-
-<ul>
-<li>Updated ABNF for dmarc-percent</li>
-<li>New text documented here - <eref target="https://trac.ietf.org/trac/dmarc/ticket/26#comment:6">https://trac.ietf.org/trac/dmarc/ticket/26#comment:6</eref></li>
-<li>Ticket 47, Remove pct= tag, rendered change obsolete</li>
-</ul>
-</section>
-</section>
-
-<section anchor="march-23-2021"><name>March 23, 2021</name>
-
-<section anchor="ticket-75-using-wording-alternatives-to-disposition-dispose-and-the-like"><name>Ticket 75 - Using wording alternatives to 'disposition', 'dispose', and the like</name>
-
-<ul>
-<li>Changed disposition/dispose to &quot;handling&quot;</li>
-<li>Diffs documented here - <eref target="https://trac.ietf.org/trac/dmarc/ticket/75#comment:3">https://trac.ietf.org/trac/dmarc/ticket/75#comment:3</eref></li>
-</ul>
-</section>
-
-<section anchor="ticket-72-remove-absolute-requirement-for-p-tag-in-dmarc-record"><name>Ticket 72 - Remove absolute requirement for p= tag in DMARC record</name>
-
-<ul>
-<li>Changed from REQUIRED to RECOMMENDED, noted default with forward reference to discussion</li>
-<li>Diffs documented here - <eref target="https://trac.ietf.org/trac/dmarc/ticket/72#comment:3">https://trac.ietf.org/trac/dmarc/ticket/72#comment:3</eref></li>
-</ul>
-</section>
-</section>
-
-<section anchor="march-29-2021"><name>March 29, 2021</name>
-
-<section anchor="ticket-54-remove-or-expand-limits-on-number-of-recipients-per-report"><name>Ticket 54 - Remove or expand limits on number of recipients per report</name>
-
-<ul>
-<li>Removed limit</li>
-<li>Diffs documented here - <eref target="https://trac.ietf.org/trac/dmarc/ticket/54#comment:5">https://trac.ietf.org/trac/dmarc/ticket/54#comment:5</eref></li>
-</ul>
-</section>
-</section>
-
-<section anchor="april-12-2021"><name>April 12, 2021</name>
-
-<section anchor="ticket-50-remove-ri-tag"><name>Ticket 50 - Remove ri= tag</name>
-
-<ul>
-<li>Updated text to recommend against its usage, a la the ptr mechanism in RFC 7208</li>
-<li>Diffs documented here - <eref target="https://trac.ietf.org/trac/dmarc/ticket/50#comment:5">https://trac.ietf.org/trac/dmarc/ticket/50#comment:5</eref></li>
-</ul>
-</section>
-
-<section anchor="ticket-66-define-what-it-means-to-have-implemented-dmarc"><name>Ticket 66 - Define what it means to have implemented DMARC</name>
-
-<ul>
-<li>Proposed new text (taken straight from <eref target="https://trac.ietf.org/trac/dmarc/ticket/66">https://trac.ietf.org/trac/dmarc/ticket/66</eref>
-as replacement for current text in &quot;Minimum Implemenatations&quot;</li>
-</ul>
-</section>
-
-<section anchor="ticket-96-tweaks-to-abstract-and-introduction"><name>Ticket 96 - Tweaks to Abstract and Introduction</name>
-
-<ul>
-<li>Changed phrase in Abstract to &quot;an email author's domain name&quot;</li>
-<li>Changed phrase in Introduction to &quot;reports about email use of the domain name&quot;</li>
-</ul>
-</section>
-</section>
-
-<section anchor="april-13-2021"><name>April 13, 2021</name>
-
-<section anchor="ticket-53-remove-reporting-message-size-chunking"><name>Ticket 53 - Remove reporting message size chunking</name>
-
-<ul>
-<li>Proposed text to remove all references to message size chunking</li>
-<li>Data demonstrating lack of use of feature entered into ticket -
-<eref target="https://trac.ietf.org/trac/dmarc/ticket/53#comment:4">https://trac.ietf.org/trac/dmarc/ticket/53#comment:4</eref></li>
-</ul>
-</section>
-
-<section anchor="ticket-52-remove-strict-alignment-and-adkim-and-aspf-tags"><name>Ticket 52 - Remove strict alignment (and adkim and aspf tags)</name>
-
-<ul>
-<li>Proposed text to remove all references to strict alignment</li>
-<li>Data demonstrating lack of use of feature entered into ticket -
-<eref target="https://trac.ietf.org/trac/dmarc/ticket/52#comment:2">https://trac.ietf.org/trac/dmarc/ticket/52#comment:2</eref></li>
-</ul>
-</section>
-
-<section anchor="ticket-47-remove-pct-tag"><name>Ticket 47 - Remove pct= tag</name>
-
-<ul>
-<li>Proposed text to remove all references to pct and message sampling</li>
-<li>Data demonstrating lack of use of feature entered into ticket -
-<eref target="https://trac.ietf.org/trac/dmarc/ticket/47#comment:4">https://trac.ietf.org/trac/dmarc/ticket/47#comment:4</eref></li>
-</ul>
-</section>
-
-<section anchor="ticket-2-flow-of-operations-text-in-dmarc-base"><name>Ticket 2 - Flow of operations text in dmarc-base</name>
-
-<ul>
-<li>Update ASCII Art</li>
-<li>Proposed text to replace description of ASCII Art</li>
-<li>Proposed text to update Domain Owner Actions section</li>
-</ul>
-</section>
-</section>
-
-<section anchor="april-14-2021"><name>April 14, 2021</name>
-
-<section anchor="ticket-107-dmarcbis-should-take-a-stand-on-multi-valued-from-fields"><name>Ticket 107 - DMARCbis should take a stand on multi-valued From fields</name>
-
-<ul>
-<li>Proposed text that limits processing to only those times when all domains
-are the same.</li>
-</ul>
-</section>
-
-<section anchor="ticket-82-deprecate-rf-and-maybe-fo-tag"><name>Ticket 82 - Deprecate rf= and maybe fo= tag</name>
-
-<ul>
-<li>Proposed text to deprecate rf= tag, while leaving fo= tag as is</li>
-</ul>
-</section>
-
-<section anchor="ticket-85-proposed-change-to-wording-describing-p-tag-and-values"><name>Ticket 85 - Proposed change to wording describing 'p' tag and values</name>
-
-<ul>
-<li>The language expressing the semantics is proposed to be changed to be,
-in a sense, egocentric. How do I, the domain owner feel about (assess)
-the meaning of a DMARC failure?</li>
-</ul>
-</section>
-</section>
-
-<section anchor="april-15-2021"><name>April 15, 2021</name>
-
-<section anchor="ticket-86-a-r-results-for-dmarc"><name>Ticket 86 - A-R results for DMARC</name>
-
-<ul>
-<li>Proposed text to add for polrec.p and polrec.domain methods for registry
-update.</li>
-<li>Did not include polrec.pct due to proposal to remove pct tag (Ticket 47)</li>
-</ul>
-</section>
-
-<section anchor="ticket-62-make-aggregate-reporting-a-normative-must"><name>Ticket 62 - Make aggregate reporting a normative MUST</name>
-
-<ul>
-<li>Proposed text to do just that in Mail Receiver Actions, section
-titled &quot;Send Aggregate Reports&quot;</li>
-</ul>
-</section>
-</section>
-
-<section anchor="april-19-2021"><name>April 19, 2021</name>
-
-<section anchor="ticket-109-sanity-check-dmarcbis-document"><name>Ticket 109 - Sanity Check DMARCbis Document</name>
-
-<ul>
-<li>Updated document to remove all &quot;original text&quot;/&quot;proposed text&quot; couplets
-in favor of one (hopefully coherent) document full of proposed text
-changes.</li>
-<li>Noted which tickets were the cause of whatever rfcdiff output will show
-in tracker</li>
-</ul>
-</section>
-</section>
-
-<section anchor="april-20-2021"><name>April 20, 2021</name>
-
-<section anchor="ticket-108-changes-to-dmarcbis-for-psd"><name>Ticket 108 - Changes to DMARCbis for PSD</name>
-
-<ul>
-<li>Incorporating requests for changes to DMARCbis made in text of
-&quot;Experimental DMARC Extension for Public Suffix Domains&quot;
-(<eref target="https://datatracker.ietf.org/doc/draft-ietf-dmarc-psd/">https://datatracker.ietf.org/doc/draft-ietf-dmarc-psd/</eref>)</li>
-</ul>
-</section>
-</section>
-
-<section anchor="april-22-2021"><name>April 22, 2021</name>
-
-<section anchor="ticket-104-update-the-security-considerations-section-11-3-on-dns"><name>Ticket 104 - Update the Security Considerations section 11.3 on DNS</name>
-
-<ul>
-<li>Updated text. Diffs are here - <eref target="https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/31/files">https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/31/files</eref></li>
-</ul>
-</section>
-</section>
-
-<section anchor="june-16-2021"><name>June 16, 2021</name>
-
-<section anchor="publication-of-draft-ietf-dmarc-dmarcbis-02"><name>Publication of draft-ietf-dmarc-dmarcbis-02</name>
-
-<ul>
-<li>Includes final resolution for tickets 4, 47, 50, 52, 53, 54, and 82</li>
-</ul>
-</section>
-</section>
-
-<section anchor="august-12-2021"><name>August 12, 2021</name>
-
-<section anchor="publication-of-draft-ietf-dmarc-dmarcbis-03"><name>Publication of draft-ietf-dmarc-dmarcbis-03</name>
-
-<ul>
-<li>Removal of &quot;pct&quot; tag</li>
-<li>Addition of &quot;t&quot; tag</li>
-<li>Rearranging of some text and formatting for better readability and consistency.</li>
-</ul>
-</section>
 </section>
 </section>
 

--- a/draft-ietf-dmarc-dmarcbis-04.xml
+++ b/draft-ietf-dmarc-dmarcbis-04.xml
@@ -19,7 +19,7 @@
 Reporting, and Conformance (DMARC) protocol.</t>
 <t>DMARC permits the owner of an email author's domain name to enable
 verification of the domain's use, to indicate the Domain Owner's or
-Public Suffix Operator's severity of concern regarding failed
+Public Suffix Operator's message handling preference regarding failed
 verification, and to request reports about use of the domain name.
 Mail receiving organizations can use this information when evaluating
 handling choices for incoming mail.</t>
@@ -37,36 +37,29 @@ The source for this draft is maintained in GitHub at:
 <t>Abusive email often includes unauthorized and deceptive use of a
 domain name in the RFC5322.From header field. The domain typically
 belongs to an organization expected to be known to - and presumably
-trusted by - the recipient. The Sender Policy Framework (SPF) (<xref target="RFC7208"></xref>)
-and DomainKeys Identified Mail (DKIM) (<xref target="RFC6376"></xref>) protocols provide
+trusted by - the recipient. The Sender Policy Framework (SPF) <xref target="RFC7208"></xref>
+and DomainKeys Identified Mail (DKIM) <xref target="RFC6376"></xref> protocols provide
 domain-level authentication but are not directly associated with the
-RFC5322.From domain. DMARC leverages them, so that Domain Owners
-publish a DNS record indicating their RFC5322.From field:</t>
-
-<ul>
-<li>Email authentication policies</li>
-<li>Level of concern for mail that fails authentication checks</li>
-<li>Desire for reports about email use of the domain name</li>
-</ul>
-<t>DMARC can cover non-existent sub-domains, below the &quot;Organizational
-Domain&quot;, as well as domains at the top of the name hierarchy,
-controlled by Public Suffix Operators (PSOs).</t>
-<t>As with SPF and DKIM, DMARC classes results as &quot;pass&quot; or &quot;fail&quot;. A
-pass from either SPF or DKIM is required. Depending on the stated
-DMARC policy, the passed domain must be &quot;aligned&quot; with the RFC5322.From
-domain in one of two modes - &quot;relaxed&quot; or &quot;strict&quot;.  Domains are said
-to be &quot;in relaxed alignment&quot; if they have the same Organizational Domain,
-which is at the top of the domain hierarchy, while having the same
-administrative authority as the RFC5322.From domain, while domains are
-&quot;in strict alignment&quot; if and only if they are identical.</t>
+RFC5322.From domain. DMARC leverages them, and provides a method for
+Domain Owners to publish a DNS record describing the email authentication
+policies for the RFC5322.From domain and to request a specific handling
+for messages using that domain that fail authentication checks.</t>
+<t>As with SPF and DKIM, DMARC classes results as &quot;pass&quot; or &quot;fail&quot;. In order
+to get a DMARC result of &quot;pass&quot;, a pass from either SPF or DKIM is required.
+In addition, the passed domain must be &quot;aligned&quot; with the RFC5322.From domain
+in one of two modes - &quot;relaxed&quot; or &quot;strict&quot;. The mode is expressed in the
+domain's DMARC policy record. Domains are said to be &quot;in relaxed alignment&quot;
+if they have the same &quot;Organizational Domain&quot;, which is the domain at the
+top of the domain hierarchy for the RFC5322.From domain while having the
+same administrative authority as the RFC5322.From domain. Domains are &quot;in
+strict alignment&quot; if and only if they are identical.</t>
 <t>A DMARC pass indicates only that the RFC5322.From domain has been
-authenticated for that message; authentication does not carry an
+authenticated for that message. Authentication does not carry an
 explicit or implicit value assertion about that message or about
-the Domain Owner. Indeed, a mail-receiving organization that performs
-DMARC verification can choose to follow the Domain Owner's requested
-disposition for authentication failures, and to inform the Domain
-Owner of the mail handling decision for that message. It also might
-choose different actions.</t>
+the Domain Owner. Furthermore, a mail-receiving organization that performs
+DMARC verification can choose to honor the Domain Owner's requested
+message handling for authentication failures, but it is under no
+obligation to do so; it might choose different actions entirely.</t>
 <t>For a mail-receiving organization supporting DMARC, a message that
 passes verification is part of a message stream that is reliably
 associated with the RFC5322.From field Domain Owner. Therefore,
@@ -75,11 +68,19 @@ is not encumbered by accounting for unauthorized use of that domain
 in the RFC5322.From field.  A message that fails this verification
 is not necessarily associated with the Domain Owner's domain and its
 reputation.</t>
+<t>DMARC policy records can also cover non-existent sub-domains, below the
+&quot;Organizational Domain&quot;, as well as domains at the top of the name hierarchy,
+controlled by Public Suffix Operators (PSOs).</t>
 <t>DMARC, in the associated <xref target="DMARC-Aggregate-Reporting"></xref> and <xref target="DMARC-Failure-Reporting"></xref>
 documents, also specifies a reporting framework. Using it, a mail-receiving
 domain can generate regular reports about messages that claim to be from
 a domain publishing DMARC policies, sending those reports to the address(es)
-specified by the Domain Owner.</t>
+specified by the Domain Owner in the latter's DMARC policy record. Domain
+Owners can use these reports, especially the aggregate reports, to identify
+not only sources of mail attempting to fraudulently use their domain, but also
+(and perhaps more importantly) gaps in their own authentication practices. However,
+as with honoring the Domain Owner's stated mail handling preference, a mail-receiving
+organization supporting DMARC is under no obligation to send requested reports.</t>
 <t>Use of DMARC creates some interoperability challenges that require due
 consideration before deployment, particularly with configurations that
 can cause mail to be rejected.  These are discussed in <xref target="other-topics"></xref>.</t>
@@ -94,9 +95,9 @@ documented as out of scope.</t>
 <t>DMARC has the following high-level goals:</t>
 
 <ul>
-<li><t>Allow Domain Owners and PSOs to assert their severity of concern for
-authentication failures for messages purporting to have
-authorship within the domain.</t>
+<li><t>Allow Domain Owners and PSOs to assert their desired message handling
+for authentication failures for messages purporting to have authorship
+within the domain.</t>
 </li>
 <li><t>Allow Domain Owners and PSOs to verify their authentication deployment.</t>
 </li>
@@ -116,25 +117,25 @@ messages.</t>
 work.  These include the following:</t>
 
 <ul>
-<li><t>different treatment of messages that are not authenticated versus
+<li><t>Different treatment of messages that are not authenticated versus
 those that fail authentication;</t>
 </li>
-<li><t>evaluation of anything other than RFC5322.From header field;</t>
+<li><t>Evaluation of anything other than RFC5322.From header field;</t>
 </li>
-<li><t>multiple reporting formats;</t>
+<li><t>Multiple reporting formats;</t>
 </li>
-<li><t>publishing policy other than via the DNS;</t>
+<li><t>Publishing policy other than via the DNS;</t>
 </li>
-<li><t>reporting or otherwise evaluating other than the last-hop IP
+<li><t>Reporting or otherwise evaluating other than the last-hop IP
 address;</t>
 </li>
-<li><t>attacks in the From: header field, also known as &quot;display name&quot;
+<li><t>Attacks in the From: header field, also known as &quot;display name&quot;
 attacks;</t>
 </li>
-<li><t>authentication of entities other than domains, since DMARC is
+<li><t>Authentication of entities other than domains, since DMARC is
 built upon SPF and DKIM, which authenticate domains; and</t>
 </li>
-<li><t>content analysis.</t>
+<li><t>Content analysis.</t>
 </li>
 </ul>
 </section>
@@ -176,7 +177,7 @@ the RFC5322.From human-readable &lt;display-name&gt;.</t>
 <section anchor="conventions-used-in-this-document"><name>Conventions Used in This Document</name>
 <t>The key words &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;,
 &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this
-document are to be interpreted as described in BCP 14 <xref target="RFC2119"></xref> <xref target="RFC8174"></xref>
+document are to be interpreted as described in BCP 14 <xref target="RFC2119"></xref> and <xref target="RFC8174"></xref>
 when, and only when, they appear in all capitals, as shown here.</t>
 <t>Readers are encouraged to be familiar with the contents of
 <xref target="RFC5598"></xref>.  In particular, that document defines various roles in
@@ -188,6 +189,9 @@ another role.  This document does not address the distinctions among
 such roles; the reader is encouraged to become familiar with that
 material before continuing.</t>
 </section>
+
+<section anchor="definitions"><name>Defintions</name>
+<t>The following sections define terms used in this document.</t>
 
 <section anchor="authenticated-identifiers"><name>Authenticated Identifiers</name>
 <t>Domain-level identifiers that are verified using authentication technologies
@@ -235,12 +239,10 @@ is a broader definition than that in <xref target="RFC8020"></xref>.</t>
 </section>
 
 <section anchor="organizational-domain"><name>Organizational Domain</name>
-<t>The domain that was registered with a domain name registrar.  In
-the absence of more accurate methods, heuristics are used to determine
-this, since it is not always the case that the registered domain name
-is simply a top-level DNS domain plus one component (e.g., &quot;example.com&quot;,
-where &quot;com&quot; is a top-level domain).  The Organizational Domain is
-determined by applying the algorithm found in
+<t>The Organizational Domain is typically a domain that was registered with
+a domain name registrar.  More formally, it is a Public Suffix Domain
+plus one label. The Organizational Domain for the domain in the
+RFC5322.From domain is determined by applying the algorithm found in
 <xref target="determining-the-organizational-domain"></xref>.</t>
 </section>
 
@@ -257,14 +259,15 @@ determined by applying the algorithm found in
 </section>
 
 <section anchor="report-receiver"><name>Report Receiver</name>
-<t>An operator that receives reports from another operator
-implementing the reporting mechanisms described in this document
-and/or the documents <xref target="DMARC-Aggregate-Reporting"></xref> and <xref target="DMARC-Failure-Reporting"></xref>.
-Such an operator might be receiving reports about messages related
-to a domain for which it is the Domain Owner or PSO, or reports about
-messages related to another operator's domain.  This term applies
-collectively to the system components that receive and process these
-reports and the organizations that operate them.</t>
+<t>An operator that receives reports from another operator implementing the
+reporting mechanisms described in this document and/or the documents
+<xref target="DMARC-Aggregate-Reporting"></xref> and <xref target="DMARC-Failure-Reporting"></xref>. Such an
+operator might be receiving reports about messages related to a domain
+for which it is the Domain Owner or PSO, or reports about messages related
+to another operator's domain.  This term applies collectively to the
+system components that receive and process these reports and the organizations
+that operate them.</t>
+</section>
 </section>
 
 <section anchor="more-on-identifier-alignment"><name>More on Identifier Alignment</name>
@@ -319,9 +322,8 @@ because both domains have the same Organizational Domain of &quot;example.com&qu
 In strict mode, this test would fail because the d= domain does not
 exactly match the RFC5322.From domain.</t>
 <t>However, a DKIM signature bearing a value of &quot;d=com&quot; would never allow
-an &quot;in alignment&quot; result, as &quot;com&quot; should appear on all public suffix
-lists (see <xref target="public-suffix-lists"></xref>) and therefore cannot be an Organizational
-Domain.</t>
+an &quot;in alignment&quot; result, as &quot;com&quot; should be identified as a PSD and
+therefore cannot be an Organizational Domain.</t>
 <t>Note that a single email can contain multiple DKIM signatures, and it
 is considered to produce a DMARC &quot;pass&quot; result if any DKIM signature
 is aligned and verifies.</t>
@@ -566,11 +568,11 @@ for details.</t>
 used by Mail Receivers to inform their message handling decisions.</t>
 <t>A Domain Owner or PSO advertises DMARC participation of one or more of its
 domains by adding a DNS TXT record (described in <xref target="dmarc-policy-record"></xref>) to
-those domains.  In doing so, Domain Owners and PSOs indicate their severity of
-concern regarding failed authentication for email messages making use
+those domains.  In doing so, Domain Owners and PSOs indicate their handling
+preference regarding failed authentication for email messages making use
 of their domain in the RFC5322.From header field as well as the provision
 of feedback about those messages. Mail Receivers in turn can take into
-account the Domain Owner's severity of concern when making handling
+account the Domain Owner's stated preference when making handling
 decisions about email messages that fail DMARC authentication checks.</t>
 <t>A Domain Owner or PSO may choose not to participate in DMARC evaluation by
 Mail Receivers.  In this case, the Domain Owner simply declines to
@@ -694,9 +696,9 @@ s:
 <dl>
 <dt>np:</dt>
 <dd>Domain Owner Assessment Policy for non-existent subdomains
-(plain-text; OPTIONAL).  Indicates the severity of concern the
-Domain Owner or PSO has for mail using non-existent subdomains of the
-domain queried. It applies only to non-existent subdomains of
+(plain-text; OPTIONAL).  Indicates the message handling preference
+that the Domain Owner or PSO has for mail using non-existent subdomains
+of the domain queried. It applies only to non-existent subdomains of
 the domain queried and not to either existing subdomains or
 the domain itself.  Its syntax is identical to that of the &quot;p&quot;
 tag defined below.  If the &quot;np&quot; tag is absent, the policy
@@ -708,8 +710,8 @@ Domains and PSDs due to the effect of the DMARC policy discovery
 mechanism described in <xref target="policy-discovery"></xref>.</dd>
 <dt>p:</dt>
 <dd><t>Domain Owner Assessment Policy (plain-text; RECOMMENDED for policy
-records). Indicates the severity of concern the Domain Owner or PSO
-has for mail using its domain but not passing DMARC verification.
+records). Indicates the message handling preference the Domain Owner or
+PSO has for mail using its domain but not passing DMARC verification.
 Policy applies to the domain queried and to subdomains, unless
 subdomain policy is explicitly described using the &quot;sp&quot; or &quot;np&quot; tags.
 This tag is mandatory for policy records only, but not for third-party
@@ -772,9 +774,9 @@ additional considerations.</t>
 </dd>
 <dt>sp:</dt>
 <dd><t>Domain Owner Assessment Policy for all subdomains (plain-text;
-OPTIONAL). Indicates the severity of concern the Domain Owner or PSO has
-for mail using an existing subdomain of the domain queried but not
-passing DMARC verification.  It applies only to subdomains of
+OPTIONAL). Indicates the message handling preference the Domain Owner
+or PSO has for mail using an existing subdomain of the domain queried
+but not passing DMARC verification.  It applies only to subdomains of
 the domain queried and not to the domain itself.  Its syntax is
 identical to that of the &quot;p&quot; tag defined above.  If both the &quot;sp&quot;
 tag is absent and the &quot;np&quot; tag is either absent or not applicable,
@@ -1151,8 +1153,8 @@ mailstreams making use of its domain in email, to include not only
 illegitimate uses but also, and perhaps more importantly, all
 legitimate uses. Domain Owners can use aggregate reports to ensure
 that all legitimate uses of their domain for sending email are
-properly authenticated, and once they are, increase the severity of
-concern expressed in the p= tag in their DMARC policy records from
+properly authenticated, and once they are, express a stricter message
+handling preference in the p= tag in their DMARC policy records from
 none to quarantine to reject, if appropriate. In turn, DMARC policy
 records with p= tag values of 'quarantine' or 'reject' are higher
 value signals to Mail Receivers, ones that can assist Mail Receivers
@@ -2345,7 +2347,7 @@ for the full details of this mechanism.</t>
 <section anchor="subdomain-sampling-and-multiple-aggregate-report-uris"><name>Subdomain, Testing, and Multiple Aggregate Report URIs</name>
 <t>The Domain Owner has implemented SPF and DKIM in a subdomain used for
 pre-production testing of messaging services.  It now wishes to express
-a severity of concern for messages from this subdomain that fail to
+a handling preference for messages from this subdomain that fail to
 authenticate to indicate to participating receivers that use of this
 domain is not valid.</t>
 <t>As a first step, it will express that it considers to be suspicious

--- a/draft-ietf-dmarc-dmarcbis-04.xml
+++ b/draft-ietf-dmarc-dmarcbis-04.xml
@@ -1,0 +1,2812 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- name="GENERATOR" content="github.com/mmarkdown/mmark Mmark Markdown Processor - mmark.miek.nl" -->
+<rfc version="3" ipr="trust200902" docName="draft-ietf-dmarc-dmarcbis-04" submissionType="IETF" category="std" xml:lang="en" xmlns:xi="http://www.w3.org/2001/XInclude" obsoletes="7489" consensus="true">
+
+<front>
+<title abbrev="DMARCbis">Domain-based Message Authentication, Reporting, and Conformance (DMARC)</title><seriesInfo value="draft-ietf-dmarc-dmarcbis-04" stream="IETF" status="standard" name="Internet-Draft"></seriesInfo>
+<author initials="T." surname="Herr (ed)" fullname="Todd M. Herr"><organization>Valimail</organization><address><postal><street></street>
+</postal><email>todd.herr@valimail.com</email>
+</address></author>
+<author initials="J." surname="Levine (ed)" fullname="John Levine"><organization>Standcore LLC</organization><address><postal><street></street>
+</postal><email>standards@standore.com</email>
+</address></author>
+<date/>
+<area>Application</area>
+<workgroup>DMARC</workgroup>
+
+<abstract>
+<t>This document describes the Domain-based Message Authentication,
+Reporting, and Conformance (DMARC) protocol.</t>
+<t>DMARC permits the owner of an email author's domain name to enable
+verification of the domain's use, to indicate the Domain Owner's or
+Public Suffix Operator's severity of concern regarding failed
+verification, and to request reports about use of the domain name.
+Mail receiving organizations can use this information when evaluating
+handling choices for incoming mail.</t>
+<t>This document obsoletes RFC 7489.</t>
+</abstract>
+
+</front>
+
+<middle>
+
+<section anchor="introduction"><name>Introduction</name>
+<t>RFC EDITOR: PLEASE REMOVE THE FOLLOWING PARAGRAPH BEFORE PUBLISHING:
+The source for this draft is maintained in GitHub at:
+<eref target="https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis">https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis</eref></t>
+<t>Abusive email often includes unauthorized and deceptive use of a
+domain name in the RFC5322.From header field. The domain typically
+belongs to an organization expected to be known to - and presumably
+trusted by - the recipient. The Sender Policy Framework (SPF) (<xref target="RFC7208"></xref>)
+and DomainKeys Identified Mail (DKIM) (<xref target="RFC6376"></xref>) protocols provide
+domain-level authentication but are not directly associated with the
+RFC5322.From domain. DMARC leverages them, so that Domain Owners
+publish a DNS record indicating their RFC5322.From field:</t>
+
+<ul>
+<li>Email authentication policies</li>
+<li>Level of concern for mail that fails authentication checks</li>
+<li>Desire for reports about email use of the domain name</li>
+</ul>
+<t>DMARC can cover non-existent sub-domains, below the &quot;Organizational
+Domain&quot;, as well as domains at the top of the name hierarchy,
+controlled by Public Suffix Operators (PSOs).</t>
+<t>As with SPF and DKIM, DMARC classes results as &quot;pass&quot; or &quot;fail&quot;. A
+pass from either SPF or DKIM is required. Depending on the stated
+DMARC policy, the passed domain must be &quot;aligned&quot; with the RFC5322.From
+domain in one of two modes - &quot;relaxed&quot; or &quot;strict&quot;.  Domains are said
+to be &quot;in relaxed alignment&quot; if they have the same Organizational Domain,
+which is at the top of the domain hierarchy, while having the same
+administrative authority as the RFC5322.From domain, while domains are
+&quot;in strict alignment&quot; if and only if they are identical.</t>
+<t>A DMARC pass indicates only that the RFC5322.From domain has been
+authenticated for that message; authentication does not carry an
+explicit or implicit value assertion about that message or about
+the Domain Owner. Indeed, a mail-receiving organization that performs
+DMARC verification can choose to follow the Domain Owner's requested
+disposition for authentication failures, and to inform the Domain
+Owner of the mail handling decision for that message. It also might
+choose different actions.</t>
+<t>For a mail-receiving organization supporting DMARC, a message that
+passes verification is part of a message stream that is reliably
+associated with the RFC5322.From field Domain Owner. Therefore,
+reputation assessment of that stream by the mail-receiving organization
+is not encumbered by accounting for unauthorized use of that domain
+in the RFC5322.From field.  A message that fails this verification
+is not necessarily associated with the Domain Owner's domain and its
+reputation.</t>
+<t>DMARC, in the associated <xref target="DMARC-Aggregate-Reporting"></xref> and <xref target="DMARC-Failure-Reporting"></xref>
+documents, also specifies a reporting framework. Using it, a mail-receiving
+domain can generate regular reports about messages that claim to be from
+a domain publishing DMARC policies, sending those reports to the address(es)
+specified by the Domain Owner.</t>
+<t>Use of DMARC creates some interoperability challenges that require due
+consideration before deployment, particularly with configurations that
+can cause mail to be rejected.  These are discussed in <xref target="other-topics"></xref>.</t>
+</section>
+
+<section anchor="requirements"><name>Requirements</name>
+<t>Specification of DMARC is guided by the following high-level goals,
+security dependencies, detailed requirements, and items that are
+documented as out of scope.</t>
+
+<section anchor="high-level-goals"><name>High-Level Goals</name>
+<t>DMARC has the following high-level goals:</t>
+
+<ul>
+<li><t>Allow Domain Owners and PSOs to assert their severity of concern for
+authentication failures for messages purporting to have
+authorship within the domain.</t>
+</li>
+<li><t>Allow Domain Owners and PSOs to verify their authentication deployment.</t>
+</li>
+<li><t>Minimize implementation complexity for both senders and receivers,
+as well as the impact on handling and delivery of legitimate
+messages.</t>
+</li>
+<li><t>Reduce the amount of successfully delivered spoofed email.</t>
+</li>
+<li><t>Work at Internet scale.</t>
+</li>
+</ul>
+</section>
+
+<section anchor="out-of-scope"><name>Out of Scope</name>
+<t>Several topics and issues are specifically out of scope for this
+work.  These include the following:</t>
+
+<ul>
+<li><t>different treatment of messages that are not authenticated versus
+those that fail authentication;</t>
+</li>
+<li><t>evaluation of anything other than RFC5322.From header field;</t>
+</li>
+<li><t>multiple reporting formats;</t>
+</li>
+<li><t>publishing policy other than via the DNS;</t>
+</li>
+<li><t>reporting or otherwise evaluating other than the last-hop IP
+address;</t>
+</li>
+<li><t>attacks in the From: header field, also known as &quot;display name&quot;
+attacks;</t>
+</li>
+<li><t>authentication of entities other than domains, since DMARC is
+built upon SPF and DKIM, which authenticate domains; and</t>
+</li>
+<li><t>content analysis.</t>
+</li>
+</ul>
+</section>
+
+<section anchor="scalability"><name>Scalability</name>
+<t>Scalability is a major issue for systems that need to operate in a
+system as widely deployed as current SMTP email.  For this reason,
+DMARC seeks to avoid the need for third parties or pre-sending
+agreements between senders and receivers.  This preserves the
+positive aspects of the current email infrastructure.</t>
+<t>Although DMARC does not introduce third-party senders (namely
+external agents authorized to send on behalf of an operator) to the
+email-handling flow, it also does not preclude them.  Such third
+parties are free to provide services in conjunction with DMARC.</t>
+</section>
+
+<section anchor="anti-phishing"><name>Anti-Phishing</name>
+<t>DMARC is designed to prevent bad actors from sending mail that claims
+to come from legitimate senders, particularly senders of
+transactional email (official mail that is about business
+transactions).  One of the primary uses of this kind of spoofed mail
+is phishing (enticing users to provide information by pretending to
+be the legitimate service requesting the information).  Thus, DMARC
+is significantly informed by ongoing efforts to enact large-scale,
+Internet-wide anti-phishing measures.</t>
+<t>Although DMARC can only be used to combat specific forms of exact-
+domain spoofing directly, the DMARC mechanism has been found to be
+useful in the creation of reliable and defensible message streams.</t>
+<t>DMARC does not attempt to solve all problems with spoofed or
+otherwise fraudulent email.  In particular, it does not address the
+use of visually similar domain names (&quot;cousin domains&quot;) or abuse of
+the RFC5322.From human-readable &lt;display-name&gt;.</t>
+</section>
+</section>
+
+<section anchor="terminology"><name>Terminology and Definitions</name>
+<t>This section defines terms used in the rest of the document.</t>
+
+<section anchor="conventions-used-in-this-document"><name>Conventions Used in This Document</name>
+<t>The key words &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;,
+&quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this
+document are to be interpreted as described in BCP 14 <xref target="RFC2119"></xref> <xref target="RFC8174"></xref>
+when, and only when, they appear in all capitals, as shown here.</t>
+<t>Readers are encouraged to be familiar with the contents of
+<xref target="RFC5598"></xref>.  In particular, that document defines various roles in
+the messaging infrastructure that can appear the same or separate in
+various contexts.  For example, a Domain Owner could, via the
+messaging security mechanisms on which DMARC is based, delegate the
+ability to send mail as the Domain Owner to a third party with
+another role.  This document does not address the distinctions among
+such roles; the reader is encouraged to become familiar with that
+material before continuing.</t>
+</section>
+
+<section anchor="authenticated-identifiers"><name>Authenticated Identifiers</name>
+<t>Domain-level identifiers that are verified using authentication technologies
+are referred to as &quot;Authenticated Identifiers&quot;.  See <xref target="authenication-mechanisms"></xref>
+for details about the supported mechanisms.</t>
+</section>
+
+<section anchor="author-domain"><name>Author Domain</name>
+<t>The domain name of the apparent author, as extracted from the From: header field.</t>
+</section>
+
+<section anchor="domain-owner"><name>Domain Owner</name>
+<t>An entity or organization that owns a DNS domain.  The
+term &quot;owns&quot; here indicates that the entity or organization being
+referenced holds the registration of that DNS domain.  Domain
+Owners range from complex, globally distributed organizations, to
+service providers working on behalf of non-technical clients, to
+individuals responsible for maintaining personal domains.  This
+specification uses this term as analogous to an Administrative
+Management Domain as defined in <xref target="RFC5598"></xref>.  It can also refer
+to delegates, such as Report Receivers, when those are outside of
+their immediate management domain.</t>
+</section>
+
+<section anchor="identifier-alignment"><name>Identifier Alignment</name>
+<t>When the domain in the address in the From: header field has the
+same Organizational Domain as a domain verified by SPF or DKIM
+(or both), it has Identifier Alignment. (see below)</t>
+</section>
+
+<section anchor="longest-psd"><name>Longest PSD</name>
+<t>The term Longest PSD is defined in <xref target="RFC9091"></xref>.</t>
+</section>
+
+<section anchor="mail-receiver"><name>Mail Receiver</name>
+<t>The entity or organization that receives and processes email.<br />
+Mail Receivers operate one or more Internet-facing Mail Transport
+Agents (MTAs).</t>
+</section>
+
+<section anchor="non-existent-domains"><name>Non-existent Domains</name>
+<t>For DMARC purposes, a non-existent domain is a domain for which there
+is an NXDOMAIN or NODATA response for A, AAAA, and MX records.  This
+is a broader definition than that in <xref target="RFC8020"></xref>.</t>
+</section>
+
+<section anchor="organizational-domain"><name>Organizational Domain</name>
+<t>The domain that was registered with a domain name registrar.  In
+the absence of more accurate methods, heuristics are used to determine
+this, since it is not always the case that the registered domain name
+is simply a top-level DNS domain plus one component (e.g., &quot;example.com&quot;,
+where &quot;com&quot; is a top-level domain).  The Organizational Domain is
+determined by applying the algorithm found in
+<xref target="determining-the-organizational-domain"></xref>.</t>
+</section>
+
+<section anchor="public-suffix-domain"><name>Public Suffix Domain (PSD)</name>
+<t>The term Public Suffix Domain is defined in <xref target="RFC9091"></xref>.</t>
+</section>
+
+<section anchor="public-suffix-operator"><name>Public Suffix Operator (PSO)</name>
+<t>The term Public Suffix Operator is defined in <xref target="RFC9091"></xref>.</t>
+</section>
+
+<section anchor="pso-controlled-domain-names"><name>PSO Controlled Domain Names</name>
+<t>The term PSO Controlled Domain Names is defined in <xref target="RFC9091"></xref>.</t>
+</section>
+
+<section anchor="report-receiver"><name>Report Receiver</name>
+<t>An operator that receives reports from another operator
+implementing the reporting mechanisms described in this document
+and/or the documents <xref target="DMARC-Aggregate-Reporting"></xref> and <xref target="DMARC-Failure-Reporting"></xref>.
+Such an operator might be receiving reports about messages related
+to a domain for which it is the Domain Owner or PSO, or reports about
+messages related to another operator's domain.  This term applies
+collectively to the system components that receive and process these
+reports and the organizations that operate them.</t>
+</section>
+
+<section anchor="more-on-identifier-alignment"><name>More on Identifier Alignment</name>
+<t>Email authentication technologies authenticate various (and
+disparate) aspects of an individual message.  For example, DKIM <xref target="RFC6376"></xref>
+authenticates the domain that affixed a signature to the message,
+while SPF <xref target="RFC7208"></xref> can authenticate either the domain that appears in the
+RFC5321.MailFrom (MAIL FROM) portion of an SMTP <xref target="RFC5321"></xref> conversation or the
+RFC5321.EHLO/HELO domain, or both.  These may be different domains, and they
+are typically not visible to the end user.</t>
+<t>DMARC authenticates use of the RFC5322.From domain by requiring that
+it have the same Organizational Domain as (i.e., be aligned with) an
+Authenticated Identifier. Domain names in this context are to be compared
+in a case-insensitive manner, per <xref target="RFC4343"></xref>. The RFC5322.From domain
+was selected as the central identity of the DMARC mechanism because it
+is a required message header field and therefore guaranteed to be present
+in compliant messages, and most Mail User Agents (MUAs) represent the
+RFC5322.From header field as the originator of the message and render
+some or all of this header field's content to end users.</t>
+<t>It is important to note that Identifier Alignment cannot occur with a
+message that is not valid per <xref target="RFC5322"></xref>, particularly one with a
+malformed, absent, or repeated RFC5322.From header field, since in that case
+there is no reliable way to determine a DMARC policy that applies to
+the message.  Accordingly, DMARC operation is predicated on the input
+being a valid RFC5322 message object, and handling of such
+non-compliant cases is outside of the scope of this specification.
+Further discussion of this can be found in <xref target="extract-author-domain"></xref>.</t>
+<t>Each of the underlying authentication technologies that DMARC takes
+as input yields authenticated domains as their outputs when they
+succeed.</t>
+
+<section anchor="dkim-identifiers"><name>DKIM-Authenticated Identifiers</name>
+<t>DMARC requires Identifier Alignment based on the result of a DKIM
+authentication because a message can bear a valid signature from any
+domain, including domains used by a mailing list or even a bad actor.
+Therefore, merely bearing a valid signature is not enough to infer
+authenticity of the Author Domain.</t>
+<t>DMARC permits Identifier Alignment based on the result of a DKIM
+authentication to be strict or relaxed. (Note that these terms are
+not related to DKIM's &quot;simple&quot; and &quot;relaxed&quot; canonicalization modes.)</t>
+<t>In relaxed mode, the Organizational Domains of both the DKIM-authenticated
+signing domain (taken from the value of the d= tag in the signature)
+and that of the RFC5322.From domain must be equal if the identifiers
+are to be considered to be aligned. In strict mode, only an exact match
+between both Fully Qualified Domain Names (FQDNs) is considered to produce
+Identifier Alignment.</t>
+<t>To illustrate, in relaxed mode, if a verified DKIM signature
+successfully verifies with a &quot;d=&quot; domain of &quot;example.com&quot;, and the
+RFC5322.From address is &quot;alerts@news.example.com&quot;, the DKIM &quot;d=&quot;
+domain and the RFC5322.From domain are considered to be &quot;in alignment&quot;,
+because both domains have the same Organizational Domain of &quot;example.com&quot;.
+In strict mode, this test would fail because the d= domain does not
+exactly match the RFC5322.From domain.</t>
+<t>However, a DKIM signature bearing a value of &quot;d=com&quot; would never allow
+an &quot;in alignment&quot; result, as &quot;com&quot; should appear on all public suffix
+lists (see <xref target="public-suffix-lists"></xref>) and therefore cannot be an Organizational
+Domain.</t>
+<t>Note that a single email can contain multiple DKIM signatures, and it
+is considered to produce a DMARC &quot;pass&quot; result if any DKIM signature
+is aligned and verifies.</t>
+</section>
+
+<section anchor="spf-identifiers"><name>SPF-Authenticated Identifiers</name>
+<t>DMARC permits Identifier Alignment based on the result of an SPF
+authentication. As with DKIM, Identifier Alignement can be either
+strict or relaxed.</t>
+<t>In relaxed mode, the Organizational Domains of the SPF-authenticated
+domain and RFC5322.From domain must be equal if the identifiers are
+to be considered to be aligned. In strict mode, the two FQDNs must
+match exactly in order from them to be considered to be aligned.</t>
+<t>For example, in relaxed mode, if a message passes an SPF check with an
+RFC5321.MailFrom domain of &quot;cbg.bounces.example.com&quot;, and the address
+portion of the RFC5322.From header field contains
+&quot;payments@example.com&quot;, the Authenticated RFC5321.MailFrom domain
+identifier and the RFC5322.From domain are considered to be &quot;in
+alignment&quot; because they have the same Organizational Domain
+(&quot;example.com&quot;). In strict mode, this test would fail because the
+two domains are not identical.</t>
+<t>The reader should note that SPF alignment checks in DMARC rely solely
+on the RFC5321.MailFrom domain. This differs from section 2.3 of
+<xref target="RFC7208"></xref>, which recommends that SPF checks be done on not only the
+&quot;MAIL FROM&quot; but also on a separate check of the &quot;HELO&quot; identity.</t>
+</section>
+
+<section anchor="alignment-and-extension-technologies"><name>Alignment and Extension Technologies</name>
+<t>If in the future DMARC is extended to include the use of other
+authentication mechanisms, the extensions will need to allow for
+domain identifier extraction so that alignment with the RFC5322.From
+domain can be verified.</t>
+</section>
+</section>
+
+<section anchor="determining-the-organizational-domain"><name>Determining The Organizational Domain</name>
+<t>The Organizational Domain is determined using the following
+algorithm:</t>
+
+<ol>
+<li><t>Acquire a &quot;public suffix&quot; list, i.e., a list of DNS domain names
+reserved for registrations.  Some country Top-Level Domains
+(TLDs) make specific registration requirements, e.g., the United
+Kingdom places company registrations under &quot;.co.uk&quot;; other TLDs
+such as &quot;.com&quot; appear in the IANA registry of top-level DNS
+domains.  A public suffix list is the union of all of these.
+<xref target="public-suffix-lists"></xref> contains some discussion about obtaining a public
+suffix list.</t>
+</li>
+<li><t>Break the subject DNS domain name into a set of &quot;n&quot; ordered
+labels.  Number these labels from right to left; e.g., for
+&quot;example.com&quot;, &quot;com&quot; would be label 1 and &quot;example&quot; would be
+label 2.</t>
+</li>
+<li><t>Search the public suffix list for the name that matches the
+largest number of labels found in the subject DNS domain.  Let
+that number be &quot;x&quot;.</t>
+</li>
+<li><t>Construct a new DNS domain name using the name that matched from
+the public suffix list and prefixing to it the &quot;x+1&quot;th label from
+the subject domain.  This new name is the Organizational Domain.</t>
+</li>
+</ol>
+<t>Thus, since &quot;com&quot; is an IANA-registered TLD, a subject domain of
+&quot;a.b.c.d.example.com&quot; would have an Organizational Domain of
+&quot;example.com&quot;.</t>
+<t>The process of determining a suffix is currently a heuristic one.  No
+list is guaranteed to be accurate or current.</t>
+</section>
+</section>
+
+<section anchor="overview"><name>Overview</name>
+<t>This section provides a general overview of the design and operation
+of the DMARC environment.</t>
+
+<section anchor="authenication-mechanisms"><name>Authentication Mechanisms</name>
+<t>The following mechanisms for determining Authenticated Identifiers
+are supported in this version of DMARC:</t>
+
+<ul>
+<li><t>DKIM, <xref target="RFC6376"></xref>, which provides a domain-level identifier in the content of
+the &quot;d=&quot; tag of a verified DKIM-Signature header field.</t>
+</li>
+<li><t>SPF, <xref target="RFC7208"></xref>, which can authenticate both the domain found in
+an <xref target="RFC5321"></xref> HELO/EHLO command (the HELO identity) and the domain
+found in an SMTP MAIL command (the MAIL FROM identity). As noted earlier,
+however, DMARC relies solely on SPF authentication of the domain found in
+SMTP MAIL FROM command. Section 2.4 of <xref target="RFC7208"></xref> describes MAIL FROM
+processing for cases in which the MAIL command has a null path.</t>
+</li>
+</ul>
+</section>
+
+<section anchor="key-concepts"><name>Key Concepts</name>
+<t>DMARC policies are published by the Domain Owner or PSO, and retrieved by
+the Mail Receiver during the SMTP session, via the DNS.</t>
+<t>DMARC's verification function is based on whether the RFC5322.From
+domain is aligned with an authenticated domain name from SPF or DKIM.<br />
+When a DMARC policy is published for the domain name found in the
+RFC5322.From header field, and that domain name is not verified
+through SPF or DKIM, the handling of that message can be affected
+by that DMARC policy when delivered to a participating receiver.</t>
+<t>It is important to note that the authentication mechanisms employed
+by DMARC authenticate only a DNS domain and do not authenticate the
+local-part of any email address identifier found in a message, nor do
+they validate the legitimacy of message content.</t>
+<t>DMARC's feedback component involves the collection of information
+about received messages claiming to be from the Author Domain
+for periodic aggregate reports to the Domain Owner or PSO.  The
+parameters and format for such reports are discussed in <xref target="DMARC-Aggregate-Reporting"></xref></t>
+<t>A DMARC-enabled Mail Receiver might also generate per-message reports
+that contain information related to individual messages that fail SPF
+and/or DKIM.  Per-message failure reports are a useful source of
+information when debugging deployments (if messages can be determined
+to be legitimate even though failing authentication) or in analyzing
+attacks.  The capability for such services is enabled by DMARC but
+defined in other referenced material such as <xref target="RFC6591"></xref> and <xref target="DMARC-Failure-Reporting"></xref></t>
+<t>A message satisfies the DMARC checks if at least one of the supported
+authentication mechanisms:</t>
+
+<ol>
+<li><t>produces a &quot;pass&quot; result, and</t>
+</li>
+<li><t>produces that result based on an identifier that is in alignment,
+as defined in <xref target="terminology"></xref>.</t>
+</li>
+</ol>
+</section>
+
+<section anchor="flow-diagram"><name>Flow Diagram</name>
+
+<sourcecode type="ascii-art"> +---------------+                             +--------------------+
+ | Author Domain |&lt; . . . . . . . . . . . .    | Return-Path Domain |
+ +---------------+                        .    +--------------------+
+     |                                    .               ^
+     V                                    V               .
+ +-----------+     +--------+       +----------+          v
+ |   MSA     |&lt;***&gt;|  DKIM  |       |   DMARC  |     +----------+
+ |  Service  |     | Signer |       | Verifier |&lt;***&gt;|    SPF   |
+ +-----------+     +--------+       +----------+  *  | Verifier |
+     |                                    ^       *  +----------+
+     |                                    *       *
+     V                                    v       *
+  +------+        (~~~~~~~~~~~~)      +------+    *  +----------+
+  | sMTA |-------&gt;( other MTAs )-----&gt;| rMTA |    **&gt;|   DKIM   |
+  +------+        (~~~~~~~~~~~~)      +------+       | Verifier |
+                                         |           +----------+
+                                         |                ^
+                                         V                .
+                                  +-----------+           .
+                    +---------+   |    MDA    |           v
+                    |  User   |&lt;--| Filtering |      +-----------+
+                    | Mailbox |   |  Engine   |      |   DKIM    |
+                    +---------+   +-----------+      |  Signing  |
+                                                     | Domain(s) |
+                                                     +-----------+
+
+  MSA = Mail Submission Agent
+  MDA = Mail Delivery Agent
+</sourcecode>
+<t>The above diagram shows a simple flow of messages through a DMARC-
+aware system.  Solid lines denote the actual message flow, dotted
+lines involve DNS queries used to retrieve message policy related to
+the supported message authentication schemes, and asterisk lines
+indicate data exchange between message-handling modules and message
+authentication modules.  &quot;sMTA&quot; is the sending MTA, and &quot;rMTA&quot; is the
+receiving MTA.</t>
+<t>Put simply, when a message reaches a DMARC-aware rMTA, a DNS query
+will be initiated to determine if the author domain has published
+a DMARC policy. If a policy is found, the rMTA will use the results
+of SPF and DKIM verification checks to determine the ultimate DMARC
+authentication status. The DMARC status can then factor into the
+message handling decision made by the recipient's mail sytsem.</t>
+<t>More details on specific actions for the parties involved can be
+found in <xref target="domain-owner-actions"></xref> and <xref target="mail-receiver-actions"></xref>.</t>
+</section>
+</section>
+
+<section anchor="use-of-rfc5322-from"><name>Use of RFC5322.From</name>
+<t>One of the most obvious points of security scrutiny for DMARC is the
+choice to focus on an identifier, namely the RFC5322.From address,
+which is part of a body of data that has been trivially forged
+throughout the history of email. This field is the one used by end
+users to identify the source of the message, and so it has always
+been a prime target for abuse through such forgery and other means.</t>
+<t>Several points suggest that it is the most correct and safest thing
+to do in this context:</t>
+
+<ul>
+<li><t>Of all the identifiers that are part of the message itself, this
+is the only one guaranteed to be present.</t>
+</li>
+<li><t>It seems the best choice of an identifier on which to focus, as
+most MUAs display some or all of the contents of that field in a
+manner strongly suggesting those data as reflective of the true
+originator of the message.</t>
+</li>
+<li><t>Many high-profile email sources, such as email service providers,
+require that the sending agent have authenticated before email
+can be generated.  Thus, for these mailboxes, the mechanism
+described in this document provides recipient end users with strong
+evidence that the message was indeed originated by the agent they
+associate with that mailbox, if the end user knows that these
+various protections have been provided.</t>
+</li>
+</ul>
+<t>The absence of a single, properly formed RFC5322.From header field renders
+the message invalid.  Handling of such a message is outside of the
+scope of this specification.</t>
+<t>Since the sorts of mail typically protected by DMARC participants
+tend to only have single Authors, DMARC participants generally
+operate under a slightly restricted profile of RFC5322 with respect
+to the expected syntax of this field.  See <xref target="mail-receiver-actions"></xref>
+for details.</t>
+</section>
+
+<section anchor="policy"><name>Policy</name>
+<t>DMARC policies are published by Domain Owners and PSOs and can be
+used by Mail Receivers to inform their message handling decisions.</t>
+<t>A Domain Owner or PSO advertises DMARC participation of one or more of its
+domains by adding a DNS TXT record (described in <xref target="dmarc-policy-record"></xref>) to
+those domains.  In doing so, Domain Owners and PSOs indicate their severity of
+concern regarding failed authentication for email messages making use
+of their domain in the RFC5322.From header field as well as the provision
+of feedback about those messages. Mail Receivers in turn can take into
+account the Domain Owner's severity of concern when making handling
+decisions about email messages that fail DMARC authentication checks.</t>
+<t>A Domain Owner or PSO may choose not to participate in DMARC evaluation by
+Mail Receivers.  In this case, the Domain Owner simply declines to
+advertise participation in those schemes.  For example, if the
+results of path authorization checks ought not be considered as part
+of the overall DMARC result for a given Author Domain, then the
+Domain Owner does not publish an SPF policy record that can produce
+an SPF pass result.</t>
+<t>A Mail Receiver implementing the DMARC mechanism SHOULD make a
+best-effort attempt to adhere to the Domain Owner's or PSO's published DMARC
+Domain Owner Assessment Policy when a message fails the DMARC test.<br />
+Since email streams can be complicated (due to forwarding, existing RFC5322.From
+domain-spoofing services, etc.), Mail Receivers MAY deviate from a published
+Domain Owner Assessment Policy during message processing and SHOULD
+make available the fact of and reason for the deviation to the Domain
+Owner via feedback reporting, specifically using the &quot;PolicyOverride&quot;
+feature of the aggregate report defined in <xref target="DMARC-Aggregate-Reporting"></xref></t>
+
+<section anchor="dmarc-policy-record"><name>DMARC Policy Record</name>
+<t>Domain Owner and PSO DMARC preferences are stored as DNS TXT records in
+subdomains named &quot;_dmarc&quot;.  For example, the Domain Owner of
+&quot;example.com&quot; would post DMARC preferences in a TXT record at
+&quot;_dmarc.example.com&quot;.  Similarly, a Mail Receiver wishing to query
+for DMARC preferences regarding mail with an RFC5322.From domain of
+&quot;example.com&quot; would issue a TXT query to the DNS for the subdomain of
+&quot;_dmarc.example.com&quot;.  The DNS-located DMARC preference data will
+hereafter be called the &quot;DMARC record&quot;.</t>
+<t>DMARC's use of the Domain Name Service is driven by DMARC's use of
+domain names and the nature of the query it performs.  The query
+requirement matches with the DNS, for obtaining simple parametric
+information.  It uses an established method of storing the
+information, associated with the target domain name, namely an
+isolated TXT record that is restricted to the DMARC context.  Use of
+the DNS as the query service has the benefit of reusing an extremely
+well-established operations, administration, and management
+infrastructure, rather than creating a new one.</t>
+<t>Per <xref target="RFC1035"></xref>, a TXT record can comprise several &quot;character-string&quot;
+objects.  Where this is the case, the module performing DMARC
+evaluation MUST concatenate these strings by joining together the
+objects in order and parsing the result as a single string.</t>
+</section>
+
+<section anchor="dmarc-uris"><name>DMARC URIs</name>
+<t><xref target="RFC3986"></xref> defines a generic syntax for identifying a resource.  The DMARC
+mechanism uses this as the format by which a Domain Owner or PSO specifies
+the destination for the two report types that are supported.</t>
+<t>The place such URIs are specified (see <xref target="general-record-format"></xref>) allows
+a list of these to be provided.  The list of URIs is separated by commas
+(ASCII 0x2c).  A report SHOULD be sent to each listed URI provided in
+the DMARC record.</t>
+<t>A formal definition is provided in <xref target="formal-definition"></xref>.</t>
+</section>
+
+<section anchor="general-record-format"><name>General Record Format</name>
+<t>DMARC records follow the extensible &quot;tag-value&quot; syntax for DNS-based
+key records defined in DKIM <xref target="RFC6376"></xref>.</t>
+<t><xref target="iana-considerations"></xref> creates a registry for known DMARC tags and
+registers the initial set defined in this document.  Only tags defined
+in this document or in later extensions, and thus added to that registry,
+are to be processed; unknown tags MUST be ignored.</t>
+<t>The following tags are valid DMARC tags:</t>
+
+<dl>
+<dt>adkim:</dt>
+<dd><t>(plain-text; OPTIONAL; default is &quot;r&quot;.)  Indicates whether
+strict or relaxed DKIM Identifier Alignment mode is required by
+the Domain Owner.  See <xref target="dkim-identifiers"></xref> for details.  Valid values
+are as follows:</t>
+
+<dl>
+<dt>r:</dt>
+<dd>relaxed mode</dd>
+<dt>s:</dt>
+<dd>strict mode</dd>
+</dl></dd>
+<dt>aspf:</dt>
+<dd><t>(plain-text; OPTIONAL; default is &quot;r&quot;.)  Indicates whether
+strict or relaxed SPF Identifier Alignment mode is required by the
+Domain Owner.  See <xref target="spf-identifiers"></xref> for details.  Valid values are as
+follows:</t>
+
+<dl>
+<dt>r:</dt>
+<dd>relaxed mode</dd>
+<dt>s:</dt>
+<dd>strict mode</dd>
+</dl></dd>
+<dt>fo:</dt>
+<dd><t>Failure reporting options (plain-text; OPTIONAL; default is &quot;0&quot;)
+Provides requested options for generation of failure reports.
+Report generators MAY choose to adhere to the requested options.
+This tag's content MUST be ignored if a &quot;ruf&quot; tag (below) is not
+also specified.  Failure reporting options are shown below. The value
+of this tag is either &quot;0&quot;, &quot;1&quot;, or a colon-separated list of the
+options represented by alphabetic characters.</t>
+</dd>
+</dl>
+<t>The valid values and their meanings are:</t>
+
+<artwork>0:
+:  Generate a DMARC failure report if all underlying
+   authentication mechanisms fail to produce an aligned &quot;pass&quot;
+   result.
+
+1:
+:  Generate a DMARC failure report if any underlying
+   authentication mechanism produced something other than an
+   aligned &quot;pass&quot; result.
+
+d:
+:  Generate a DKIM failure report if the message had a signature
+   that failed evaluation, regardless of its alignment.  DKIM-
+   specific reporting is described in [@!RFC6651].
+
+s:
+:  Generate an SPF failure report if the message failed SPF
+   evaluation, regardless of its alignment.  SPF-specific
+   reporting is described in [@!RFC6652].
+</artwork>
+
+<dl>
+<dt>np:</dt>
+<dd>Domain Owner Assessment Policy for non-existent subdomains
+(plain-text; OPTIONAL).  Indicates the severity of concern the
+Domain Owner or PSO has for mail using non-existent subdomains of the
+domain queried. It applies only to non-existent subdomains of
+the domain queried and not to either existing subdomains or
+the domain itself.  Its syntax is identical to that of the &quot;p&quot;
+tag defined below.  If the &quot;np&quot; tag is absent, the policy
+specified by the &quot;sp&quot; tag (if the &quot;sp&quot; tag is present) or the
+policy specified by the &quot;p&quot; tag, if the &quot;sp&quot; tag is not present,
+MUST be applied for non-existent subdomains.  Note that &quot;np&quot; will
+be ignored for DMARC records published on subdomains of Organizational
+Domains and PSDs due to the effect of the DMARC policy discovery
+mechanism described in <xref target="policy-discovery"></xref>.</dd>
+<dt>p:</dt>
+<dd><t>Domain Owner Assessment Policy (plain-text; RECOMMENDED for policy
+records). Indicates the severity of concern the Domain Owner or PSO
+has for mail using its domain but not passing DMARC verification.
+Policy applies to the domain queried and to subdomains, unless
+subdomain policy is explicitly described using the &quot;sp&quot; or &quot;np&quot; tags.
+This tag is mandatory for policy records only, but not for third-party
+reporting records (see <xref target="DMARC-Aggregate-Reporting"></xref> and <xref target="DMARC-Failure-Reporting"></xref>)
+Possible values are as follows:</t>
+
+<dl>
+<dt>none:</dt>
+<dd>The Domain Owner offers no expression of concern.</dd>
+<dt>quarantine:</dt>
+<dd>The Domain Owner considers such mail to be suspicious. It
+is possible the mail is valid, although the failure creates
+a significant concern.</dd>
+<dt>reject:</dt>
+<dd>The Domain Owner considers all such failures to be a clear
+indication that the use of the domain name is not valid. See
+<xref target="rejecting-messages"></xref> for some discussion of SMTP rejection
+methods and their implications.</dd>
+</dl></dd>
+<dt>rua:</dt>
+<dd><t>Addresses to which aggregate feedback is to be sent (comma-
+separated plain-text list of DMARC URIs; OPTIONAL).  Section 3 of <xref target="DMARC-Aggregate-Reporting"></xref>
+discusses considerations that apply when the domain name of a URI differs
+from that of the domain advertising the policy.  See <xref target="external-report-addresses"></xref>
+for additional considerations.  Any valid URI can be specified.<br />
+A Mail Receiver MUST implement support for a &quot;mailto:&quot; URI, i.e., the
+ability to send a DMARC report via electronic mail.  If not provided,
+Mail Receivers MUST NOT generate aggregate feedback reports.  URIs
+not supported by Mail Receivers MUST be ignored.  The aggregate
+feedback report format is described in <xref target="DMARC-Aggregate-Reporting"></xref></t>
+</dd>
+<dt>ruf:</dt>
+<dd><t>Addresses to which message-specific failure information is to
+be reported (comma-separated plain-text list of DMARC URIs;
+OPTIONAL).  If present, the Domain Owner or PSO is requesting Mail
+Receivers to send detailed failure reports about messages that
+fail the DMARC evaluation in specific ways (see the &quot;fo&quot; tag
+above).  The format of the message to be generated MUST follow the
+format specified for the &quot;rf&quot; tag. Section 3 of <xref target="DMARC-Aggregate-Reporting"></xref> discusses
+considerations that apply when the domain name of a URI differs
+from that of the domain advertising the policy.  A Mail Receiver
+MUST implement support for a &quot;mailto:&quot; URI, i.e., the ability to
+send a DMARC report via electronic mail.  If not provided, Mail
+Receivers MUST NOT generate failure reports.  See <xref target="external-report-addresses"></xref> for
+additional considerations.</t>
+</dd>
+<dt>sp:</dt>
+<dd><t>Domain Owner Assessment Policy for all subdomains (plain-text;
+OPTIONAL). Indicates the severity of concern the Domain Owner or PSO has
+for mail using an existing subdomain of the domain queried but not
+passing DMARC verification.  It applies only to subdomains of
+the domain queried and not to the domain itself.  Its syntax is
+identical to that of the &quot;p&quot; tag defined above.  If both the &quot;sp&quot;
+tag is absent and the &quot;np&quot; tag is either absent or not applicable,
+the policy specified by the &quot;p&quot; tag MUST be applied for subdomains.
+Note that &quot;sp&quot; will be ignored for DMARC records published on
+subdomains of Organizational Domains due to the effect of the
+DMARC policy discovery mechanism described in <xref target="policy-discovery"></xref>.</t>
+</dd>
+<dt>t:</dt>
+<dd><t>DMARC policy test mode (plain-text; OPTIONAL; default is 'n'). For
+the RFC5322.From domain to which the DMARC record applies, the &quot;t&quot;
+tag serves as a signal to the actor performing DMARC verification checks
+as to whether or not the domain owner wishes the assessment policy
+declared in the &quot;p=&quot;, &quot;sp=&quot;, and/or &quot;np=&quot; tags to actually be applied. This
+parameter does not affect the generation of DMARC reports.  Possible values
+are as follows:</t>
+
+<dl>
+<dt>y:</dt>
+<dd>A request that the actor performing the DMARC verification check not
+apply the policy, but instead apply any special handling rules it might have
+in place, such as rewriting the RFC5322.From header.  The domain owner is
+currently testing its specified DMARC assessment policy.</dd>
+<dt>n:</dt>
+<dd>The default, a request to apply the policy as specified to any
+message that produces a DMARC &quot;fail&quot; result.</dd>
+</dl></dd>
+<dt>v:</dt>
+<dd><t>Version (plain-text; REQUIRED).  Identifies the record retrieved
+as a DMARC record.  It MUST have the value of &quot;DMARC1&quot;.  The value
+of this tag MUST match precisely; if it does not or it is absent,
+the entire retrieved record MUST be ignored.  It MUST be the first
+tag in the list.</t>
+</dd>
+</dl>
+<t>A DMARC policy record MUST comply with the formal specification found
+in <xref target="formal-definition"></xref> in that the &quot;v&quot; tag MUST be present and MUST
+appear first.  Unknown tags MUST be ignored.  Syntax errors
+in the remainder of the record SHOULD be discarded in favor of
+default values (if any) or ignored outright.</t>
+<t>Note that given the rules of the previous paragraph, addition of a
+new tag into the registered list of tags does not itself require a
+new version of DMARC to be generated (with a corresponding change to
+the &quot;v&quot; tag's value), but a change to any existing tags does require
+a new version of DMARC.</t>
+</section>
+
+<section anchor="formal-definition"><name>Formal Definition</name>
+<t>The formal definition of the DMARC format, using <xref target="RFC5234"></xref>, is as
+follows:</t>
+
+<artwork>  dmarc-uri       = URI 
+                    ; &quot;URI&quot; is imported from [RFC3986]; commas (ASCII
+                    ; 0x2C) and exclamation points (ASCII 0x21)
+                    ; MUST be encoded
+
+  dmarc-record    = dmarc-version dmarc-sep *(dmarc-tag dmarc-sep)
+
+  dmarc-tag       = dmarc-request /
+                    dmarc-test /
+                    dmarc-srequest /
+                    dmarc-nprequest /
+                    dmarc-adkim /
+                    dmarc-aspf /
+                    dmarc-auri /
+                    dmarc-furi /
+                    dmarc-fo /
+                    dmarc-rfmt 
+                    ; components other than dmarc-version and
+                    ; dmarc-request may appear in any order
+
+  dmarc-version   = &quot;v&quot; *WSP &quot;=&quot; *WSP %x44 %x4d %x41 %x52 %x43 %x31
+
+  dmarc-sep       = *WSP %x3b *WSP
+
+  dmarc-request   = &quot;p&quot; *WSP &quot;=&quot; *WSP
+                    ( &quot;none&quot; / &quot;quarantine&quot; / &quot;reject&quot; )
+
+  dmarc-test      = &quot;t&quot; *WSP &quot;=&quot; ( &quot;y&quot; / &quot;n&quot; )
+
+  dmarc-srequest  = &quot;sp&quot; *WSP &quot;=&quot; *WSP
+                    ( &quot;none&quot; / &quot;quarantine&quot; / &quot;reject&quot; )
+
+  dmarc-nprequest  = &quot;np&quot; *WSP &quot;=&quot; *WSP
+                    ( &quot;none&quot; / &quot;quarantine&quot; / &quot;reject&quot; )
+
+  dmarc-adkim     = &quot;adkim&quot; *WSP &quot;=&quot; *WSP ( &quot;r&quot; / &quot;s&quot; )
+
+  dmarc-aspf      = &quot;aspf&quot; *WSP &quot;=&quot; *WSP ( &quot;r&quot; / &quot;s&quot; )
+
+  dmarc-auri      = &quot;rua&quot; *WSP &quot;=&quot; *WSP
+                    dmarc-uri *(*WSP &quot;,&quot; *WSP dmarc-uri)
+
+  dmarc-furi      = &quot;ruf&quot; *WSP &quot;=&quot; *WSP
+                    dmarc-uri *(*WSP &quot;,&quot; *WSP dmarc-uri)
+
+  dmarc-fo        = &quot;fo&quot; *WSP &quot;=&quot; *WSP
+                    ( &quot;0&quot; / &quot;1&quot; / ( &quot;d&quot; / &quot;s&quot; / &quot;d:s&quot; / &quot;s:d&quot; ) ) 
+
+  dmarc-rfmt      = &quot;rf&quot;  *WSP &quot;=&quot; *WSP Keyword *(*WSP &quot;:&quot; Keyword)
+                    ; registered reporting formats only
+
+</artwork>
+<t>&quot;Keyword&quot; is imported from Section 4.1.2 of <xref target="RFC5321"></xref>.</t>
+</section>
+
+<section anchor="domain-owner-actions"><name>Domain Owner Actions</name>
+<t>This section describes Domain Owner actions to fully implement the
+DMARC mechanism.</t>
+
+<section anchor="publish-an-spf-policy-for-an-aligned-domain"><name>Publish an SPF Policy for an Aligned Domain</name>
+<t>Because DMARC relies on SPF <xref target="RFC7208"></xref> and DKIM <xref target="RFC6376"></xref>, in
+order to take full advantage of DMARC, a Domain Owner SHOULD first
+ensure that SPF and DKIM authentication are properly configured.
+The easiest first step here is to choose a domain to use as the
+RFC5321.From domain (i.e., the Return-Path domain) for its mail,
+one that aligns with the Author Domain, and then publish an SPF
+policy in DNS for that domain.</t>
+</section>
+
+<section anchor="configure-sending-system-for-dkim-signing-using-an-aligned-domain"><name>Configure Sending System for DKIM Signing Using an Aligned Domain</name>
+<t>While it is possible to secure a DMARC pass verdict based on only
+SPF or DKIM, it is commonly accepted best practice to ensure that
+both authentication mechanisms are in place in order to guard
+against failure of just one of them. The Domain Owner SHOULD choose
+a DKIM-Signing domain (i.e., the d= domain in the DKIM-Signature
+header) that aligns with the Author Domain and configure its system
+to sign using that domain.</t>
+</section>
+
+<section anchor="setup-a-mailbox-to-receive-aggregate-reports"><name>Setup a Mailbox to Receive Aggregate Reports</name>
+<t>Proper consumption and analysis of DMARC aggregate reports is the
+key to any successful DMARC deployment for a Domain Owner. DMARC
+aggregate reports, which are XML documents and are defined in
+<xref target="DMARC-Aggregate-Reporting"></xref>, contain valuable data for the Domain
+Owner, showing sources of mail using the Author Domain. Depending
+on how mature the Domain Owner's DMARC rollout is, some of these
+sources could be legitimate ones that were overlooked during the
+intial deployment of SPF and/or DKIM.</t>
+<t>Because the aggregate reports are XML documents, it is strongly
+advised that they be machine-parsed, so setting up a mailbox
+involves more than just the physical creation of the mailbox. Many
+third-party services exist that will process DMARC aggregate reports,
+or the Domain Owner can create its own set of tools. No matter which
+method is chosen, the ability to parse these reports and consume
+the data contained in them will go a long way to ensuring a
+successful deployment.</t>
+</section>
+
+<section anchor="publish-a-dmarc-policy-for-the-author-domain"><name>Publish a DMARC Policy for the Author Domain</name>
+<t>Once SPF, DKIM, and the aggregate reports mailbox are all in place,
+it's time to publish a DMARC record. For best results, Domain Owners
+SHOULD start with &quot;p=none&quot;, with the rua tag containg the mailbox
+created in the previous step.</t>
+</section>
+
+<section anchor="collect-and-analyze-reports-and-adjust-authentication"><name>Collect and Analyze Reports and Adjust Authentication</name>
+<t>The reason for starting at &quot;p=none&quot; is to ensure that nothing's been
+missed in the initial SPF and DKIM deployments. In all but the most
+trivial setups, it is possible for a Domain Owner to overlook a
+server here or be unaware of a third party sending agreeement there.
+Starting at &quot;p=none&quot;, therefore, takes advantage of DMARC's aggregate
+reporting function, with the Domain Owner using the reports to audit
+its own mail streams. Should any overlooked systems be found in the
+reports, the Domain Owner can adjust the SPF record and/or configure
+DKIM signing for those systems.</t>
+</section>
+
+<section anchor="decide-if-and-when-to-update-dmarc-policy"><name>Decide If and When to Update DMARC Policy</name>
+<t>Once the Domain Owner is satisfied that it is properly authenticating
+all of its mail, then it is time to decide if it is appropriate to
+change the p= value in its DMARC record to p=quarantine or p=reject.
+Depending on its cadence for sending mail, it may take many months
+of consuming DMARC aggregate reports before a Domain Owner reaches
+the point where it is sure that it is properly authenticating all
+of its mail, and the decision on which p= value to use will depend
+on its needs.</t>
+</section>
+</section>
+
+<section anchor="pso-actions"><name>PSO Actions</name>
+<t>In addition to the DMARC Domain Owner actions, PSOs that require use
+of DMARC and participate in PSD DMARC ought to make that information
+availablle to Mail Receivers. <xref target="RFC9091"></xref> is an experimental
+method for doing so, and the experiment is described in Appendix B
+of that document.</t>
+</section>
+
+<section anchor="mail-receiver-actions"><name>Mail Receiver Actions</name>
+<t>This section describes receiver actions in the DMARC environment.</t>
+
+<section anchor="extract-author-domain"><name>Extract Author Domain</name>
+<t>The domain in the RFC5322.From header field is extracted as the domain
+to be evaluated by DMARC.  If the domain is encoded with UTF-8, the
+domain name must be converted to an A-label, as described in Section
+2.3 of <xref target="RFC5890"></xref>, for further processing.</t>
+<t>In order to be processed by DMARC, a message typically needs to
+contain exactly one RFC5322.From domain (a single From: field with a
+single domain in it). Not all messages meet this requirement, and
+the handling of those that are forbidden under <xref target="RFC5322"></xref> or that
+contain no meaningful domains is outside the scope of this document.</t>
+<t>The case of a syntactically valid multi-valued RFC5322.From header
+field presents a particular challenge. When a single RFC5322.From
+header field contains multiple addresses, it is possible that there
+may be multiple domains used in those addresses. The process in this
+case is to only proceed with DMARC checking if the domain is
+identical for all of the addresses in a multi-valued RFC5322.From
+header field. Multi-valued RFC5322.From header fields with multiple
+domains MUST be exempt from DMARC checking.</t>
+<t>Note that domain names that appear on a public suffix list are not
+exempt from DMARC policy application and reporting.</t>
+</section>
+
+<section anchor="determine-handling-policy"><name>Determine Handling Policy</name>
+<t>To arrive at a policy for an individual message, Mail Receivers MUST
+perform the following actions or their semantic equivalents.
+Steps 2-4 MAY be done in parallel, whereas steps 5 and 6 require
+input from previous steps.</t>
+<t>The steps are as follows:</t>
+
+<ol>
+<li><t>Extract the RFC5322.From domain from the message (as above).</t>
+</li>
+<li><t>Query the DNS for a DMARC policy record.  Continue if one is
+found, or terminate DMARC evaluation otherwise.  See
+<xref target="policy-discovery"></xref> for details.</t>
+</li>
+<li><t>Perform DKIM signature verification checks.  A single email could
+contain multiple DKIM signatures.  The results of this step are
+passed to the remainder of the algorithm, MUST include &quot;pass&quot; or
+&quot;fail&quot;, and if &quot;fail&quot;, SHOULD include information about the reasons
+for failure. The results MUST further include the value of the &quot;d=&quot;
+and &quot;s=&quot; tags from each checked DKIM signature.</t>
+</li>
+<li><t>Perform SPF verification checks.  The results of this step are
+passed to the remainder of the algorithm, MUST include &quot;pass&quot; or
+&quot;fail&quot;, and if &quot;fail&quot;, SHOULD include information about the reasons
+for failure. The results MUST further include the domain name used
+to complete the SPF check.</t>
+</li>
+<li><t>Conduct Identifier Alignment checks.  With authentication checks
+and policy discovery performed, the Mail Receiver checks to see
+if Authenticated Identifiers fall into alignment as described in
+<xref target="terminology"></xref>.  If one or more of the Authenticated Identifiers align
+with the RFC5322.From domain, the message is considered to pass
+the DMARC mechanism check.  All other conditions (authentication
+failures, identifier mismatches) are considered to be DMARC
+mechanism check failures.</t>
+</li>
+<li><t>Apply policy.  Emails that fail the DMARC mechanism check are
+handled in accordance with the discovered DMARC policy of the
+Domain Owner and any local policy rules enforced by the Mail Receiver.
+See <xref target="general-record-format"></xref> for details.</t>
+</li>
+</ol>
+<t>Heuristics applied in the absence of use by a Domain Owner of either
+SPF or DKIM (e.g., <xref target="Best-Guess-SPF"></xref>) SHOULD NOT be used, as it may be
+the case that the Domain Owner wishes a Message Receiver not to
+consider the results of that underlying authentication protocol at
+all.</t>
+<t>DMARC evaluation can only yield a &quot;pass&quot; result after one of the
+underlying authentication mechanisms passes for an aligned
+identifier.  If neither passes and one or both of them fail due to a
+temporary error, the Receiver evaluating the message is unable to
+conclude that the DMARC mechanism had a permanent failure; they
+therefore cannot apply the advertised DMARC policy.  When otherwise
+appropriate, Receivers MAY send feedback reports regarding temporary
+errors.</t>
+<t>Handling of messages for which SPF and/or DKIM evaluation encounter a
+permanent DNS error is left to the discretion of the Mail Receiver.</t>
+</section>
+
+<section anchor="policy-discovery"><name>Policy Discovery</name>
+<t>As stated above, the DMARC mechanism uses DNS TXT records to
+advertise policy.  Policy discovery is accomplished via a method
+similar to the method used for SPF records.  This method, and the
+important differences between DMARC and SPF mechanisms, are discussed
+below.</t>
+<t>To balance the conflicting requirements of supporting wildcarding,
+allowing subdomain policy overrides, and limiting DNS query load, the
+following DNS lookup scheme is employed:</t>
+
+<ol>
+<li><t>Mail Receivers MUST query the DNS for a DMARC TXT record at the
+DNS domain matching the one found in the RFC5322.From domain in
+the message.  A possibly empty set of records is returned.</t>
+</li>
+<li><t>Records that do not start with a &quot;v=&quot; tag that identifies the
+current version of DMARC are discarded.</t>
+</li>
+<li><t>If the set is now empty, the Mail Receiver MUST query the DNS for
+a DMARC TXT record at the DNS domain matching the Organizational
+Domain in place of the RFC5322.From domain in the message (if
+different).  This record can contain policy to be asserted for
+subdomains of the Organizational Domain.  A possibly empty set of
+records is returned.</t>
+</li>
+<li><t>Records that do not start with a &quot;v=&quot; tag that identifies the
+current version of DMARC are discarded.</t>
+</li>
+<li><t>If the set is now empty and the longest PSD <xref target="longest-psd"></xref> of the
+Organizational Domain is one that the receiver has determined is
+acceptable for PSD DMARC (based on the data in one of the DMARC
+PSD Registry Examples decribed in Appendix B of <xref target="RFC9091"></xref>)
+the Mail Receiver MUST query the DNS for a DMARC TXT record at
+the DNS domain matching the longest PSD in place of the RFC5322.From
+domain in the message (if different).  A possibly empty set of records
+is returned.</t>
+</li>
+<li><t>Records that do not start with a &quot;v=&quot; tag that identifies the
+current version of DMARC are discarded.</t>
+</li>
+<li><t>If the remaining set contains multiple records or no records,
+policy discovery terminates and DMARC processing is not applied
+to this message.</t>
+</li>
+<li><t>If a retrieved policy record does not contain a valid &quot;p&quot; tag, or
+contains an &quot;sp&quot; tag that is not valid, then:</t>
+
+<ol>
+<li><t>if a &quot;rua&quot; tag is present and contains at least one
+syntactically valid reporting URI, the Mail Receiver SHOULD
+act as if a record containing a valid &quot;v&quot; tag and &quot;p=none&quot;
+was retrieved, and continue processing;</t>
+</li>
+<li><t>otherwise, the Mail Receiver applies no DMARC processing to
+this message.</t>
+</li>
+</ol></li>
+</ol>
+<t>If the set produced by the mechanism above contains no DMARC policy
+record (i.e., any indication that there is no such record as opposed
+to a transient DNS error), Mail Receivers SHOULD NOT apply the DMARC
+mechanism to the message.</t>
+<t>Handling of DNS errors when querying for the DMARC policy record is
+left to the discretion of the Mail Receiver.  For example, to ensure
+minimal disruption of mail flow, transient errors could result in
+delivery of the message (&quot;fail open&quot;), or they could result in the
+message being temporarily rejected (i.e., an SMTP 4yx reply), which
+invites the sending MTA to try again after the condition has possibly
+cleared, allowing a definite DMARC conclusion to be reached (&quot;fail
+closed&quot;).</t>
+
+<section anchor="longest-psd-example"><name>Longest PSD Example</name>
+<t>As an example of step 5 above, for a message with the Organizational
+Domain of &quot;example.compute.cloudcompany.com.example&quot;, the query for
+PSD DMARC would use &quot;compute.cloudcompany.com.example&quot; as the longest
+PSD. The receiver would check to see if that PSD is listed in the DMARC
+PSD Registry, and if so, perform the policy lookup at
+&quot;_dmarc.compute.cloudcompany.com.example&quot;.</t>
+<t>Note: Because the PSD policy query comes after the Organizational
+Domain policy query, PSD policy is not used for Organizational
+domains that have published a DMARC policy.  Specifically, this is
+not a mechanism to provide feedback addresses (RUA/RUF) when an
+Organizational Domain has declined to do so.</t>
+</section>
+</section>
+
+<section anchor="store-results-of-dmarc-processing"><name>Store Results of DMARC Processing</name>
+<t>The results of Mail Receiver-based DMARC processing should be stored
+for eventual presentation back to the Domain Owner in the form of
+aggregate feedback reports.  <xref target="general-record-format"></xref> and
+<xref target="DMARC-Aggregate-Reporting"></xref> discuss aggregate feedback.</t>
+</section>
+
+<section anchor="send-aggregate-reports"><name>Send Aggregate Reports</name>
+<t>For a Domain Owner, DMARC aggregate reports provide data about all
+mailstreams making use of its domain in email, to include not only
+illegitimate uses but also, and perhaps more importantly, all
+legitimate uses. Domain Owners can use aggregate reports to ensure
+that all legitimate uses of their domain for sending email are
+properly authenticated, and once they are, increase the severity of
+concern expressed in the p= tag in their DMARC policy records from
+none to quarantine to reject, if appropriate. In turn, DMARC policy
+records with p= tag values of 'quarantine' or 'reject' are higher
+value signals to Mail Receivers, ones that can assist Mail Receivers
+with handling decisions for a message in ways that p= tag values of
+'none' cannot.</t>
+<t>In order to ensure maximum usefulness for DMARC across the email
+ecosystem, then, Mail Receivers MUST generate and send aggregate
+reports with a frequency of at least once every 24 hours.</t>
+</section>
+</section>
+
+<section anchor="policy-enforcement-considerations"><name>Policy Enforcement Considerations</name>
+<t>Mail Receivers MAY choose to reject or quarantine email even if email
+passes the DMARC mechanism check. The DMARC mechanism does not
+inform Mail Receivers whether an email stream is &quot;good&quot;; a DMARC result
+of &quot;pass&quot; only means that the domain in the RFC5322.From header has been
+verified by the DMARC mechanism. Mail Receivers are encouraged to maintain
+anti-abuse technologies to combat the possibility of DMARC-enabled criminal
+campaigns.</t>
+<t>Mail Receivers MAY choose to accept email that fails the DMARC
+mechanism check even if the published Domain Owner Assessment Policy
+is &quot;reject&quot;.  Mail Receivers need to make a best effort not to increase
+the likelihood of accepting abusive mail if they choose not to honor
+the published Domain Owner Assessment Policy.  At a minimum, addition
+of the Authentication-Results header field (see <xref target="RFC8601"></xref>) is
+RECOMMENDED when delivery of failing mail is done.  When this is
+done, the DNS domain name thus recorded MUST be encoded as an
+A-label.</t>
+<t>Mail Receivers are only obligated to report reject or quarantine
+policy actions in aggregate feedback reports that are due to published
+DMARC Domain Owner Assessment Policy. They are not required to report
+reject or quarantine actions that are the result of local policy. If
+local policy information is exposed, abusers can gain insight into the
+effectiveness and delivery rates of spam campaigns.</t>
+<t>Final handling of a message is always a matter of local policy.
+An operator that wishes to favor DMARC policy over SPF policy, for
+example, will disregard the SPF policy, since enacting an
+SPF-determined rejection prevents evaluation of DKIM; DKIM might
+otherwise pass, satisfying the DMARC evaluation.  There is a
+trade-off to doing so, namely acceptance and processing of the entire
+message body in exchange for the enhanced protection DMARC provides.</t>
+<t>DMARC-compliant Mail Receivers typically disregard any mail-handling
+directive discovered as part of an authentication mechanism (e.g.,
+Author Domain Signing Practices (ADSP), SPF) where a DMARC record is
+also discovered that specifies a policy other than &quot;none&quot;.  Deviating
+from this practice introduces inconsistency among DMARC operators in
+terms of handling of the message.  However, such deviation is not
+proscribed.</t>
+<t>To enable Domain Owners to receive DMARC feedback without impacting
+existing mail processing, discovered policies of &quot;p=none&quot; SHOULD NOT
+modify existing mail handling processes.</t>
+<t>Mail Receivers MUST also implement reporting instructions of DMARC,
+even in the absence of a request for DKIM reporting <xref target="RFC6651"></xref> or
+SPF reporting <xref target="RFC6652"></xref>.  Furthermore, the presence of such requests
+SHOULD NOT affect DMARC reporting.</t>
+</section>
+</section>
+
+<section anchor="dmarc-feedback"><name>DMARC Feedback</name>
+<t>Providing Domain Owners with visibility into how Mail Receivers
+implement and enforce the DMARC mechanism in the form of feedback is
+critical to establishing and maintaining accurate authentication
+deployments.  When Domain Owners can see what effect their policies
+and practices are having, they are better willing and able to use
+quarantine and reject policies.</t>
+<t>The details of this feedback are described in <xref target="DMARC-Aggregate-Reporting"></xref></t>
+<t>Operational note for PSD DMARC: For PSOs, feedback for non-existent
+domains is desirable and useful, just as it is for org-level DMARC
+operators.  See Section 4 of <xref target="RFC9091"></xref> for discussion of
+Privacy Considerations for PSD DMARC</t>
+</section>
+
+<section anchor="other-topics"><name>Other Topics</name>
+<t>This section discusses some topics regarding choices made in the
+development of DMARC, largely to commit the history to record.</t>
+
+<section anchor="issues-specific-to-spf"><name>Issues Specific to SPF</name>
+<t>Though DMARC does not inherently change the semantics of an SPF
+policy record, historically lax enforcement of such policies has led
+many to publish extremely broad records containing many large network
+ranges.  Domain Owners are strongly encouraged to carefully review
+their SPF records to understand which networks are authorized to send
+on behalf of the Domain Owner before publishing a DMARC record.</t>
+<t>Some receiver architectures might implement SPF in advance of any
+DMARC operations.  This means that a &quot;-&quot; prefix on a sender's SPF
+mechanism, such as &quot;-all&quot;, could cause that rejection to go into
+effect early in handling, causing message rejection before any DMARC
+processing takes place.  Operators choosing to use &quot;-all&quot; should be
+aware of this.</t>
+</section>
+
+<section anchor="dns-load-and-caching"><name>DNS Load and Caching</name>
+<t>DMARC policies are communicated using the DNS and therefore inherit a
+number of considerations related to DNS caching.  The inherent
+conflict between freshness and the impact of caching on the reduction
+of DNS-lookup overhead should be considered from the Mail Receiver's
+point of view.  Should Domain Owners or PSOs publish a DNS record with a very
+short TTL, Mail Receivers can be provoked through the injection of
+large volumes of messages to overwhelm the publisher's DNS.
+Although this is not a concern specific to DMARC, the implications of
+a very short TTL should be considered when publishing DMARC policies.</t>
+<t>Conversely, long TTLs will cause records to be cached for long
+periods of time.  This can cause a critical change to DMARC
+parameters advertised by a Domain Owner or PSO to go unnoticed for the
+length of the TTL (while waiting for DNS caches to expire).  Avoiding
+this problem can mean shorter TTLs, with the potential problems
+described above.  A balance should be sought to maintain
+responsiveness of DMARC preference changes while preserving the
+benefits of DNS caching.</t>
+</section>
+
+<section anchor="rejecting-messages"><name>Rejecting Messages</name>
+<t>This protocol calls for rejection of a message during the SMTP
+session under certain circumstances.  This is preferable to
+generation of a Delivery Status Notification (<xref target="RFC3464"></xref>), since
+fraudulent messages caught and rejected using DMARC would then result
+in annoying generation of such failure reports that go back to the
+RFC5321.MailFrom address.</t>
+<t>This synchronous rejection is typically done in one of two ways:</t>
+
+<ul>
+<li><t>Full rejection, wherein the SMTP server issues a 5xy reply code as
+an indication to the SMTP client that the transaction failed; the
+SMTP client is then responsible for generating notification that
+delivery failed (see Section 4.2.5 of <xref target="RFC5321"></xref>).</t>
+</li>
+<li><t>A &quot;silent discard&quot;, wherein the SMTP server returns a 2xy reply
+code implying to the client that delivery (or, at least, relay)
+was successfully completed, but then simply discarding the message
+with no further action.</t>
+</li>
+</ul>
+<t>Each of these has a cost.  For instance, a silent discard can help to
+prevent backscatter, but it also effectively means that the SMTP
+server has to be programmed to give a false result, which can
+confound external debugging efforts.</t>
+<t>Similarly, the text portion of the SMTP reply may be important to
+consider.  For example, when rejecting a message, revealing the
+reason for the rejection might give an attacker enough information to
+bypass those efforts on a later attempt, though it might also assist
+a legitimate client to determine the source of some local issue that
+caused the rejection.</t>
+<t>In the latter case, when doing an SMTP rejection, providing a clear
+hint can be useful in resolving issues.  A receiver might indicate in
+plain text the reason for the rejection by using the word &quot;DMARC&quot;
+somewhere in the reply text.  Many systems are able to scan the SMTP
+reply text to determine the nature of the rejection.  Thus, providing
+a machine-detectable reason for rejection allows the problems causing
+rejections to be properly addressed by automated systems.  For
+example:</t>
+
+<artwork>550 5.7.1 Email rejected per DMARC policy for example.com
+</artwork>
+<t>If a Mail Receiver elects to defer delivery due to inability to
+retrieve or apply DMARC policy, this is best done with a 4xy SMTP
+reply code.</t>
+</section>
+
+<section anchor="identifier-alignment-considerations"><name>Identifier Alignment Considerations</name>
+<t>The DMARC mechanism allows both DKIM and SPF-authenticated
+identifiers to authenticate email on behalf of a Domain Owner and,
+possibly, on behalf of different subdomains.  If malicious or unaware
+users can gain control of the SPF record or DKIM selector records for
+a subdomain, the subdomain can be used to generate DMARC-passing
+email on behalf of the Organizational Domain.</t>
+<t>For example, an attacker who controls the SPF record for
+&quot;evil.example.com&quot; can send mail with an RFC5322.From header field
+containing &quot;foo@example.com&quot; that can pass both authentication and
+the DMARC check against &quot;example.com&quot;.</t>
+<t>The Organizational Domain administrator should be careful not to
+delegate control of subdomains if this is an issue, and to consider
+using the &quot;strict&quot; Identifier Alignment option if appropriate.</t>
+</section>
+
+<section anchor="interoperability-issues"><name>Interoperability Issues</name>
+<t>DMARC limits which end-to-end scenarios can achieve a &quot;pass&quot; result.</t>
+<t>Because DMARC relies on SPF <xref target="RFC7208"></xref> and/or DKIM <xref target="RFC6376"></xref> to achieve
+a &quot;pass&quot;, their limitations also apply.</t>
+<t>Additional DMARC constraints occur when a message is processed by
+some Mediators, such as mailing lists.  Transiting a Mediator often
+causes either the authentication to fail or Identifier Alignment to
+be lost.  These transformations may conform to standards but will
+still prevent a DMARC &quot;pass&quot;.</t>
+<t>In addition to Mediators, mail that is sent by authorized,
+independent third parties might not be sent with Identifier
+Alignment, also preventing a &quot;pass&quot; result.</t>
+<t>Issues specific to the use of policy mechanisms alongside DKIM are
+further discussed in <xref target="RFC6377"></xref>, particularly Section 5.2.</t>
+</section>
+</section>
+
+<section anchor="iana-considerations"><name>IANA Considerations</name>
+<t>This section describes actions completed by IANA.</t>
+
+<section anchor="authentication-results-method-registry-update"><name>Authentication-Results Method Registry Update</name>
+<t>IANA has added the following to the &quot;Email Authentication Methods&quot;
+registry:</t>
+<table align="left"><name>&quot;Authentication-Results Method Registry Update&quot;
+</name>
+<thead>
+<tr>
+<th align="left">Method</th>
+<th align="left">Defined</th>
+<th align="left">ptype</th>
+<th align="left">Property</th>
+<th align="left">Value</th>
+<th align="left">Status</th>
+<th align="left">Version</th>
+</tr>
+</thead>
+
+<tbody>
+<tr>
+<td align="left">dmarc</td>
+<td align="left"><xref target="RFC7489"></xref></td>
+<td align="left">header</td>
+<td align="left">from</td>
+<td align="left">the domain portion of the RFC5322.From header field</td>
+<td align="left">active</td>
+<td align="left">1</td>
+</tr>
+
+<tr>
+<td align="left">dmarc</td>
+<td align="left"><xref target="RFC7489"></xref></td>
+<td align="left">polrec</td>
+<td align="left">p</td>
+<td align="left">the p= value read from the discovered policy record</td>
+<td align="left">active</td>
+<td align="left">1</td>
+</tr>
+
+<tr>
+<td align="left">dmarc</td>
+<td align="left"><xref target="RFC7489"></xref></td>
+<td align="left">polrec</td>
+<td align="left">domain</td>
+<td align="left">the domain at which the policy record was discovered, if different from the RFC5322.From domain</td>
+<td align="left">active</td>
+<td align="left">1</td>
+</tr>
+</tbody>
+</table></section>
+
+<section anchor="authentication-results-result-registry-update"><name>Authentication-Results Result Registry Update</name>
+<t>IANA has added the following in the &quot;Email Authentication Result
+Names&quot; registry:</t>
+<table align="left"><name>&quot;Authentication-Results Result Registry Update&quot;
+</name>
+<thead>
+<tr>
+<th align="left">Code</th>
+<th align="left">Existing/New Code</th>
+<th align="left">Defined</th>
+<th align="left">Auth Method</th>
+<th align="left">Meaning</th>
+<th align="left">Status</th>
+</tr>
+</thead>
+
+<tbody>
+<tr>
+<td align="left">none</td>
+<td align="left">existing</td>
+<td align="left"><xref target="RFC8601"></xref></td>
+<td align="left">dmarc (added)</td>
+<td align="left">No DMARC policy record was published for the aligned identifier, or no aligned identifier could be extracted.</td>
+<td align="left">active</td>
+</tr>
+
+<tr>
+<td align="left">pass</td>
+<td align="left">existing</td>
+<td align="left"><xref target="RFC8601"></xref></td>
+<td align="left">dmarc (added)</td>
+<td align="left">A DMARC policy record was published for the aligned identifier, and at least one of the authentication mechanisms passed.</td>
+<td align="left">active</td>
+</tr>
+
+<tr>
+<td align="left">fail</td>
+<td align="left">existing</td>
+<td align="left"><xref target="RFC8601"></xref></td>
+<td align="left">dmarc (added)</td>
+<td align="left">A DMARC policy record was published for the aligned identifier, and none of the authentication mechanisms passed.</td>
+<td align="left">active</td>
+</tr>
+
+<tr>
+<td align="left">temperror</td>
+<td align="left">existing</td>
+<td align="left"><xref target="RFC8601"></xref></td>
+<td align="left">dmarc (added)</td>
+<td align="left">A temporary error occurred during DMARC evaluation. A later attempt might produce a final result.</td>
+<td align="left">active</td>
+</tr>
+
+<tr>
+<td align="left">permerror</td>
+<td align="left">existing</td>
+<td align="left"><xref target="RFC8601"></xref></td>
+<td align="left">dmarc (added)</td>
+<td align="left">A permanent error occurred during DMARC evaluation, such as encountering a syntactically incorrect DMARC record. A later attempt is unlikely to produce a final result.</td>
+<td align="left">active</td>
+</tr>
+</tbody>
+</table></section>
+
+<section anchor="feedback-report-header-fields-registry-update"><name>Feedback Report Header Fields Registry Update</name>
+<t>The following has been added to the &quot;Feedback Report Header Fields&quot;
+registry:</t>
+<t>Field Name:  Identity-Alignment</t>
+
+<dl>
+<dt>Description:</dt>
+<dd>indicates whether the message about which a report is
+being generated had any identifiers in alignment as defined in
+RFC 7489</dd>
+</dl>
+<t>Multiple Appearances:  No</t>
+<t>Related &quot;Feedback-Type&quot;:  auth-failure</t>
+<t>Reference:  RFC 7489</t>
+<t>Status:  current</t>
+</section>
+
+<section anchor="dmarc-tag-registry"><name>DMARC Tag Registry</name>
+<t>A new registry tree called &quot;Domain-based Message Authentication,
+Reporting, and Conformance (DMARC) Parameters&quot; has been created.
+Within it, a new sub-registry called the &quot;DMARC Tag Registry&quot; has
+been created.</t>
+<t>Names of DMARC tags must be registered with IANA in this new
+sub-registry.  New entries are assigned only for values that have
+been documented in a manner that satisfies the terms of Specification
+Required, per <xref target="RFC8126"></xref>.  Each registration must include
+the tag name; the specification that defines it; a brief description;
+and its status, which must be one of &quot;current&quot;, &quot;experimental&quot;, or
+&quot;historic&quot;.  The Designated Expert needs to confirm that the provided
+specification adequately describes the new tag and clearly presents
+how it would be used within the DMARC context by Domain Owners and
+Mail Receivers.</t>
+<t>To avoid version compatibility issues, tags added to the DMARC
+specification are to avoid changing the semantics of existing records
+when processed by implementations conforming to prior specifications.</t>
+<t>The initial set of entries in this registry is as follows:</t>
+<table align="left"><name>&quot;DMARC Tag Registry&quot;
+</name>
+<thead>
+<tr>
+<th align="left">Tag Name</th>
+<th align="left">Reference</th>
+<th align="left">Status</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+
+<tbody>
+<tr>
+<td align="left">adkim</td>
+<td align="left">RFC 7489</td>
+<td align="left">current</td>
+<td align="left">DKIM alignment mode</td>
+</tr>
+
+<tr>
+<td align="left">aspf</td>
+<td align="left">RFC 7489</td>
+<td align="left">current</td>
+<td align="left">SPF alignment mode</td>
+</tr>
+
+<tr>
+<td align="left">fo</td>
+<td align="left">RFC 7489</td>
+<td align="left">current</td>
+<td align="left">Failure reporting options</td>
+</tr>
+
+<tr>
+<td align="left">p</td>
+<td align="left">RFC 7489</td>
+<td align="left">current</td>
+<td align="left">Requested handling policy</td>
+</tr>
+
+<tr>
+<td align="left">pct</td>
+<td align="left">RFC 7489</td>
+<td align="left">historic</td>
+<td align="left">Sampling rate</td>
+</tr>
+
+<tr>
+<td align="left">rf</td>
+<td align="left">RFC 7489</td>
+<td align="left">historic</td>
+<td align="left">Failure reporting format(s)</td>
+</tr>
+
+<tr>
+<td align="left">ri</td>
+<td align="left">RFC 7489</td>
+<td align="left">historic</td>
+<td align="left">Aggregate Reporting interval</td>
+</tr>
+
+<tr>
+<td align="left">rua</td>
+<td align="left">RFC 7489</td>
+<td align="left">current</td>
+<td align="left">Reporting URI(s) for aggregate data</td>
+</tr>
+
+<tr>
+<td align="left">ruf</td>
+<td align="left">RFC 7489</td>
+<td align="left">current</td>
+<td align="left">Reporting URI(s) for failure data</td>
+</tr>
+
+<tr>
+<td align="left">sp</td>
+<td align="left">RFC 7489</td>
+<td align="left">current</td>
+<td align="left">Requested handling policy for subdomains</td>
+</tr>
+
+<tr>
+<td align="left">t</td>
+<td align="left">RFC 7489</td>
+<td align="left">current</td>
+<td align="left">Test mode for the specified policy</td>
+</tr>
+
+<tr>
+<td align="left">v</td>
+<td align="left">RFC 7489</td>
+<td align="left">current</td>
+<td align="left">Specification version</td>
+</tr>
+</tbody>
+</table></section>
+
+<section anchor="dmarc-report-format-registry"><name>DMARC Report Format Registry</name>
+<t>Also within &quot;Domain-based Message Authentication, Reporting, and
+Conformance (DMARC) Parameters&quot;, a new sub-registry called &quot;DMARC
+Report Format Registry&quot; has been created.</t>
+<t>Names of DMARC failure reporting formats must be registered with IANA
+in this registry.  New entries are assigned only for values that
+satisfy the definition of Specification Required, per
+<xref target="RFC8126"></xref>.  In addition to a reference to a permanent
+specification, each registration must include the format name; a
+brief description; and its status, which must be one of &quot;current&quot;,
+&quot;experimental&quot;, or &quot;historic&quot;.  The Designated Expert needs to
+confirm that the provided specification adequately describes the
+report format and clearly presents how it would be used within the
+DMARC context by Domain Owners and Mail Receivers.</t>
+<t>The initial entry in this registry is as follows:</t>
+<table align="left"><name>&quot;DMARC Report Format Registry&quot;
+</name>
+<thead>
+<tr>
+<th>Format Name</th>
+<th>Reference</th>
+<th>Status</th>
+<th>Description</th>
+</tr>
+</thead>
+
+<tbody>
+<tr>
+<td>afrf</td>
+<td>RFC 7489</td>
+<td>current</td>
+<td>Authentication Failure Reporting Format (see <xref target="RFC6591"></xref>)</td>
+</tr>
+</tbody>
+</table></section>
+
+<section anchor="underscored-and-globally-scoped-dns-node-names-registry"><name>Underscored and Globally Scoped DNS Node Names Registry</name>
+<t>Per <xref target="RFC8552"></xref>, please add the following entry to the &quot;Underscored
+and Globally Scoped DNS Node Names&quot; registry:</t>
+<table align="left"><name>&quot;Underscored and Globally Scoped DNS Node Names&quot; registry
+</name>
+<thead>
+<tr>
+<th>RR Type</th>
+<th>_NODE NAME</th>
+<th>Reference</th>
+</tr>
+</thead>
+
+<tbody>
+<tr>
+<td>TXT</td>
+<td>_dmarc</td>
+<td>RFC 7489</td>
+</tr>
+</tbody>
+</table></section>
+</section>
+
+<section anchor="security-considerations"><name>Security Considerations</name>
+<t>This section discusses security issues and possible remediations
+(where available) for DMARC.</t>
+
+<section anchor="authentication-methods"><name>Authentication Methods</name>
+<t>Security considerations from the authentication methods used by DMARC
+are incorporated here by reference.</t>
+</section>
+
+<section anchor="attacks-on-reporting-uris"><name>Attacks on Reporting URIs</name>
+<t>URIs published in DNS TXT records are well-understood possible
+targets for attack.  Specifications such as <xref target="RFC1035"></xref> and <xref target="RFC2142"></xref> either
+expose or cause the exposure of email addresses that could be flooded
+by an attacker, for example; MX, NS, and other records found in the
+DNS advertise potential attack destinations; common DNS names such as
+&quot;www&quot; plainly identify the locations at which particular services can
+be found, providing destinations for targeted denial-of-service or
+penetration attacks.</t>
+<t>Thus, Domain Owners will need to harden these addresses against
+various attacks, including but not limited to:</t>
+
+<ul>
+<li><t>high-volume denial-of-service attacks;</t>
+</li>
+<li><t>deliberate construction of malformed reports intended to identify
+or exploit parsing or processing vulnerabilities;</t>
+</li>
+<li><t>deliberate construction of reports containing false claims for the
+Submitter or Reported-Domain fields, including the possibility of
+false data from compromised but known Mail Receivers.</t>
+</li>
+</ul>
+</section>
+
+<section anchor="dns-security"><name>DNS Security</name>
+<t>The DMARC mechanism and its underlying technologies (SPF, DKIM)
+depend on the security of the DNS. Examples of how hostile parties can
+have an adverse impact on DNS traffic include:
+*  If they can snoop on DNS traffic, they can get an idea of who is
+   sending mail.</t>
+
+<ul>
+<li><t>If they can block outgoing or reply DNS messages, they can prevent
+systems from discovering senders' DMARC policies, causing recipients
+to assume p=none by default.</t>
+</li>
+<li><t>If they can send forged response packets, they can make aligned mail
+appear unaligned or vice-versa.</t>
+</li>
+</ul>
+<t>None of these threats are unique to DMARC, and they can be addressed using
+a variety of techniques, including, but not limited to:</t>
+
+<ul>
+<li><t>Signing DNS records with DNSSEC <xref target="RFC4033"></xref>, which enables recipients to
+detect and discard forged responses.</t>
+</li>
+<li><t>DNS over TLS <xref target="RFC7858"></xref> or DNS over HTTPS <xref target="RFC8484"></xref> can mitigate snooping
+and forged responses.</t>
+</li>
+</ul>
+</section>
+
+<section anchor="display-name-attacks"><name>Display Name Attacks</name>
+<t>A common attack in messaging abuse is the presentation of false
+information in the display-name portion of the RFC5322.From header field.
+For example, it is possible for the email address in that field to be
+an arbitrary address or domain name, while containing a well-known
+name (a person, brand, role, etc.) in the display name, intending to
+fool the end user into believing that the name is used legitimately.
+The attack is predicated on the notion that most common MUAs will
+show the display name and not the email address when both are
+available.</t>
+<t>Generally, display name attacks are out of scope for DMARC, as
+further exploration of possible defenses against these attacks needs
+to be undertaken.</t>
+<t>There are a few possible mechanisms that attempt mitigation of these
+attacks, such as the following:</t>
+
+<ul>
+<li><t>If the display name is found to include an email address (as
+specified in <xref target="RFC5322"></xref>), execute the DMARC mechanism on the domain
+name found there rather than the domain name discovered
+originally.  However, this addresses only a very specific attack
+space, and spoofers can easily circumvent it by simply not using
+an email address in the display name.  There are also known cases
+of legitimate uses of an email address in the display name with a
+domain different from the one in the address portion, e.g.,</t>
+<t>From: &quot;user@example.org via Bug Tracker&quot; <eref target="mailto:support@example.com">support@example.com</eref></t>
+</li>
+<li><t>In the MUA, only show the display name if the DMARC mechanism
+succeeds.  This too is easily defeated, as an attacker could
+arrange to pass the DMARC tests while fraudulently using another
+domain name in the display name.</t>
+</li>
+<li><t>In the MUA, only show the display name if the DMARC mechanism
+passes and the email address thus verified matches one found in
+the receiving user's list of known addresses.</t>
+</li>
+</ul>
+</section>
+
+<section anchor="external-report-addresses"><name>External Reporting Addresses</name>
+<t>To avoid abuse by bad actors, reporting addresses generally have to
+be inside the domains about which reports are requested.  In order to
+accommodate special cases such as a need to get reports about domains
+that cannot actually receive mail, Section 3 of <xref target="DMARC-Aggregate-Reporting"></xref> describes
+a DNS-based mechanism for verifying approved external reporting.</t>
+<t>The obvious consideration here is an increased DNS load against
+domains that are claimed as external recipients.  Negative caching
+will mitigate this problem, but only to a limited extent, mostly
+dependent on the default TTL in the domain's SOA record.</t>
+<t>Where possible, external reporting is best achieved by having the
+report be directed to domains that can receive mail and simply having
+it automatically forwarded to the desired external destination.</t>
+<t>Note that the addresses shown in the &quot;ruf&quot; tag receive more
+information that might be considered private data, since it is
+possible for actual email content to appear in the failure reports.
+The URIs identified there are thus more attractive targets for
+intrusion attempts than those found in the &quot;rua&quot; tag.  Moreover,
+attacking the DNS of the subject domain to cause failure data to be
+routed fraudulently to an attacker's systems may be an attractive
+prospect.  Deployment of <xref target="RFC4033"></xref> is advisable if this is a concern.</t>
+</section>
+
+<section anchor="secure-protocols"><name>Secure Protocols</name>
+<t>This document encourages use of secure transport mechanisms to
+prevent loss of private data to third parties that may be able to
+monitor such transmissions.  Unencrypted mechanisms should be
+avoided.</t>
+<t>In particular, a message that was originally encrypted or otherwise
+secured might appear in a report that is not sent securely, which
+could reveal private information.</t>
+</section>
+</section>
+
+</middle>
+
+<back>
+<references><name>Normative References</name>
+<reference anchor="DMARC-Aggregate-Reporting" target="https://datatracker.ietf.org/doc/draft-ietf-dmarc-aggregate-reporting/">
+  <front>
+    <title>DMARC Aggregate Reporting</title>
+    <author fullname="Alex Brotman" initials="A." surname="Brotman" role="editor">
+      <organization>Comcast, Inc.</organization>
+    </author>
+    <date year="2021" month="February"></date>
+  </front>
+</reference>
+<reference anchor="DMARC-Failure-Reporting" target="https://datatracker.ietf.org/doc/draft-ietf-dmarc-failure-reporting/">
+  <front>
+    <title>DMARC Failure Reporting</title>
+    <author fullname="Steven M. Jones" initials="S.M." surname="Jones" role="editor">
+      <organization>DMARC.org</organization>
+    </author>
+    <author fullname="Alessandro Vesely" initials="A." surname="Vesely" role="editor">
+      <organization>Tana</organization>
+    </author>
+    <date year="2021" month="February"></date>
+  </front>
+</reference>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.1035.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.3986.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.4343.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.5234.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.5321.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.5322.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.5890.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.6376.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.6591.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.6651.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.6652.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.7208.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.7489.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8552.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.9091.xml"/>
+</references>
+<references><name>Informative References</name>
+<reference anchor="Best-Guess-SPF" target="http://www.openspf.org/FAQ/Best_guess_record">
+  <front>
+    <title>Sender Policy Framework: Best guess record (FAQ entry)</title>
+    <author fullname="S. Kitterman" initials="S." surname="Kitterman"></author>
+    <date year="2010" month="May"></date>
+  </front>
+</reference>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.2142.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.3464.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.4033.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.5598.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.5617.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.6377.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.7858.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8020.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8126.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8484.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8601.xml"/>
+</references>
+
+<section anchor="technology-considerations"><name>Technology Considerations</name>
+<t>This section documents some design decisions that were made in the
+development of DMARC.  Specifically, addressed here are some
+suggestions that were considered but not included in the design.
+This text is included to explain why they were considered and not
+included in this version.</t>
+
+<section anchor="s-mime"><name>S/MIME</name>
+<t>S/MIME, or Secure Multipurpose Internet Mail Extensions, is a
+standard for encryption and signing of MIME data in a message.  This
+was suggested and considered as a third security protocol for
+authenticating the source of a message.</t>
+<t>DMARC is focused on authentication at the domain level (i.e., the
+Domain Owner taking responsibility for the message), while S/MIME is
+really intended for user-to-user authentication and encryption.  This
+alone appears to make it a bad fit for DMARC's goals.</t>
+<t>S/MIME also suffers from the heavyweight problem of Public Key
+Infrastructure, which means that distribution of keys used to verify
+signatures needs to be incorporated.  In many instances, this alone
+is a showstopper.  There have been consistent promises that PKI
+usability and deployment will improve, but these have yet to
+materialize.  DMARC can revisit this choice after those barriers are
+addressed.</t>
+<t>S/MIME has extensive deployment in specific market segments
+(government, for example) but does not enjoy similar widespread
+deployment over the general Internet, and this shows no signs of
+changing.  DKIM and SPF both are deployed widely over the general
+Internet, and their adoption rates continue to be positive.</t>
+<t>Finally, experiments have shown that including S/MIME support in the
+initial version of DMARC would neither cause nor enable a substantial
+increase in the accuracy of the overall mechanism.</t>
+</section>
+
+<section anchor="method-exclusion"><name>Method Exclusion</name>
+<t>It was suggested that DMARC include a mechanism by which a Domain
+Owner could tell Message Receivers not to attempt verification by one
+of the supported methods (e.g., &quot;check DKIM, but not SPF&quot;).</t>
+<t>Specifically, consider a Domain Owner that has deployed one of the
+technologies, and that technology fails for some messages, but such
+failures don't cause enforcement action.  Deploying DMARC would cause
+enforcement action for policies other than &quot;none&quot;, which would appear
+to exclude participation by that Domain Owner.</t>
+<t>The DMARC development team evaluated the idea of policy exception
+mechanisms on several occasions and invariably concluded that there
+was not a strong enough use case to include them.  The specific
+target audience for DMARC does not appear to have concerns about the
+failure modes of one or the other being a barrier to DMARC's
+adoption.</t>
+<t>In the scenario described above, the Domain Owner has a few options:</t>
+
+<ol>
+<li><t>Tighten up its infrastructure to minimize the failure modes of
+the single deployed technology.</t>
+</li>
+<li><t>Deploy the other supported authentication mechanism, to offset
+the failure modes of the first.</t>
+</li>
+<li><t>Deploy DMARC in a reporting-only mode.</t>
+</li>
+</ol>
+</section>
+
+<section anchor="sender-header-field"><name>Sender Header Field</name>
+<t>It has been suggested in several message authentication efforts that
+the Sender header field be checked for an identifier of interest, as
+the standards indicate this as the proper way to indicate a
+re-mailing of content such as through a mailing list.  Most recently,
+it was a protocol-level option for DomainKeys, but on evolution to
+DKIM, this property was removed.</t>
+<t>The DMARC development team considered this and decided not to include
+support for doing so, for the following reasons:</t>
+
+<ol>
+<li><t>The main user protection approach is to be concerned with what
+the user sees when a message is rendered.  There is no consistent
+behavior among MUAs regarding what to do with the content of the
+Sender field, if present.  Accordingly, supporting checking of
+the Sender identifier would mean applying policy to an identifier
+the end user might never actually see, which can create a vector
+for attack against end users by simply forging a Sender field
+containing some identifier that DMARC will like.</t>
+</li>
+<li><t>Although it is certainly true that this is what the Sender field
+is for, its use in this way is also unreliable, making it a poor
+candidate for inclusion in the DMARC evaluation algorithm.</t>
+</li>
+<li><t>Allowing multiple ways to discover policy introduces unacceptable
+ambiguity into the DMARC evaluation algorithm in terms of which
+policy is to be applied and when.</t>
+</li>
+</ol>
+</section>
+
+<section anchor="domain-existence-test"><name>Domain Existence Test</name>
+<t>A common practice among MTA operators, and indeed one documented in
+<xref target="RFC5617"></xref>, is a test to determine domain existence prior to any more
+expensive processing.  This is typically done by querying the DNS for
+MX, A, or AAAA resource records for the name being evaluated and
+assuming that the domain is nonexistent if it could be determined
+that no such records were published for that domain name.</t>
+<t>The original pre-standardization version of this protocol included a
+mandatory check of this nature.  It was ultimately removed, as the
+method's error rate was too high without substantial manual tuning
+and heuristic work.  There are indeed use cases this work needs to
+address where such a method would return a negative result about a
+domain for which reporting is desired, such as a registered domain
+name that never sends legitimate mail and thus has none of these
+records present in the DNS. The addition of the &quot;np=&quot; tag in this
+version of the protocol is one way to address these use cases.</t>
+</section>
+
+<section anchor="issues-with-adsp-in-operation"><name>Issues with ADSP in Operation</name>
+<t>DMARC has been characterized as a &quot;super-ADSP&quot; of sorts.</t>
+<t>Contributors to DMARC have compiled a list of issues associated with
+ADSP, gained from operational experience, that have influenced the
+direction of DMARC:</t>
+
+<ol>
+<li><t>ADSP has no support for subdomains, i.e., the ADSP record for
+example.com does not explicitly or implicitly apply to
+subdomain.example.com.  If wildcarding is not applied, then
+spammers can trivially bypass ADSP by sending from a subdomain
+with no ADSP record.</t>
+</li>
+<li><t>Nonexistent subdomains are explicitly out of scope in ADSP.
+There is nothing in ADSP that states receivers should simply
+reject mail from NXDOMAINs regardless of ADSP policy (which of
+course allows spammers to trivially bypass ADSP by sending email
+from nonexistent subdomains).</t>
+</li>
+<li><t>ADSP has no operational advice on when to look up the ADSP
+record.</t>
+</li>
+<li><t>ADSP has no support for using SPF as an auxiliary mechanism to
+DKIM.</t>
+</li>
+<li><t>ADSP has no support for a slow rollout, i.e., no way to configure
+a percentage of email on which the receiver should apply the
+policy.  This is important for large-volume senders.</t>
+</li>
+<li><t>ADSP has no explicit support for an intermediate phase where the
+receiver quarantines (e.g., sends to the recipient's &quot;spam&quot;
+folder) rather than rejects the email.</t>
+</li>
+<li><t>The binding between the &quot;From&quot; header domain and DKIM is too
+tight for ADSP; they must match exactly.</t>
+</li>
+</ol>
+</section>
+
+<section anchor="organizational-domain-discovery-issues"><name>Organizational Domain Discovery Issues</name>
+<t>Although protocols like ADSP are useful for &quot;protecting&quot; a specific
+domain name, they are not helpful at protecting subdomains.  If one
+wished to protect &quot;example.com&quot; by requiring via ADSP that all mail
+bearing an RFC5322.From domain of &quot;example.com&quot; be signed, this would
+&quot;protect&quot; that domain; however, one could then craft an email whose
+RFC5322.From domain is &quot;security.example.com&quot;, and ADSP would not
+provide any protection.  One could use a DNS wildcard, but this can
+undesirably interfere with other DNS activity; one could add ADSP
+records as fraudulent domains are discovered, but this solution does
+not scale and is a purely reactive measure against abuse.</t>
+<t>The DNS does not provide a method by which the &quot;domain of record&quot;, or
+the domain that was actually registered with a domain registrar, can
+be determined given an arbitrary domain name.  Suggestions have been
+made that attempt to glean such information from SOA or NS resource
+records, but these too are not fully reliable, as the partitioning of
+the DNS is not always done at administrative boundaries.</t>
+<t>When seeking domain-specific policy based on an arbitrary domain
+name, one could &quot;climb the tree&quot;, dropping labels off the left end of
+the name until the root is reached or a policy is discovered, but
+then one could craft a name that has a large number of nonsense
+labels; this would cause a Mail Receiver to attempt a large number of
+queries in search of a policy record.  Sending many such messages
+constitutes an amplified denial-of-service attack.</t>
+<t>The Organizational Domain mechanism is a necessary component to the
+goals of DMARC.  The method described in <xref target="determining-the-organizational-domain"></xref> is far from
+perfect but serves this purpose reasonably well without adding undue
+burden or semantics to the DNS.  If a method is created to do so that
+is more reliable and secure than the use of a public suffix list,
+DMARC should be amended to use that method as soon as it is generally
+available.</t>
+
+<section anchor="public-suffix-lists"><name>Public Suffix Lists</name>
+<t>A public suffix list for the purposes of determining the
+Organizational Domain can be obtained from various sources.  The most
+common one is maintained by the Mozilla Foundation and made public at
+<eref target="http://publicsuffix.org">http://publicsuffix.org</eref>.  License terms governing the use of that
+list are available at that URI.</t>
+<t>Note that if operators use a variety of public suffix lists,
+interoperability will be difficult or impossible to guarantee.</t>
+</section>
+</section>
+
+<section anchor="removal-of-the-pct-tag"><name>Removal of the &quot;pct&quot; Tag</name>
+<t>An earlier informational version of the DMARC protocol <xref target="RFC7489"></xref>
+included a &quot;pct&quot; tag and specified all integers from 0 to 100 inclusive
+as valid values for the tag. The intent of the tag was to provide domain
+owners with a method to gradually change their preferred assessment policy
+(the p= tag) from 'none' to 'quarantine' or from 'quarantine' to 'reject'
+by requesting the stricter treatment for just a percentage of messages
+that produced DMARC results of &quot;fail&quot;.</t>
+<t>Operational experience and mathematics (specifically the Probability Mass
+Function as applied to Binomial Distributions) showed that the pct tag
+was usually not accurately applied, unless the value specified was either &quot;0&quot;
+or &quot;100&quot; (the default), and the inaccuracies with other values varied widely
+from implementation to implementation. The default value was easily implemented,
+as it required no special processing on the part of the message receiver, while
+the value of &quot;0&quot; took on unintended significance as a value used by some
+intermediaries and mailbox providers as an indicator to deviate from
+standard handling of the message, usually by rewriting the RFC5322.From
+header in an effort to avoid DMARC failures downstream.</t>
+<t>These custom actions when the pct= tag was set to &quot;0&quot; proved valuable to the
+email community. In particular, header rewriting by an intermediary meant
+that a Domain Owner's aggregate reports could reveal to the Domain Owner
+how much of its traffic was routing through intermediaries that don't rewrite
+the RFC5322.From header. It required work on the part of the Domain Owner to
+compare aggregate reports from before and after the p= value was changed
+and pct= was included in the DMARC policy record with a value of &quot;0&quot;, but
+the data was there. Consequently, knowing how much mail was subject to
+possible DMARC failure due to lack of RFC5322.From header rewriting by
+intermediaries could assist the Domain Owner in choosing whether or not
+to proceed from an applied policy of p=none to p=quarantine or p=reject.
+Armed with this knowledge, the Domain Owner could make an informed decision
+regarding subjecting its mail traffic to possible DMARC failures based on
+the Domain Owner's tolerance for such things.</t>
+<t>Because of the value provided by &quot;pct=0&quot; to Domain Owners, it was logical
+to keep this functionality in the protocol; at the same time it didn't make
+sense to support a tag named &quot;pct&quot; that had only two valid values. This version
+of the DMARC protocol therefore introduces the &quot;t&quot; tag as shorthand for &quot;testing&quot;,
+with the valid values of &quot;y&quot; and &quot;n&quot;, which are meant to be analogous in their
+application by mailbox providers and intermediaries to the &quot;pct&quot; tag values
+&quot;0&quot; and &quot;100&quot;, respectively.</t>
+</section>
+</section>
+
+<section anchor="examples"><name>Examples</name>
+<t>This section illustrates both the Domain Owner side and the Mail
+Receiver side of a DMARC exchange.</t>
+
+<section anchor="identifier-alignment-examples"><name>Identifier Alignment Examples</name>
+<t>The following examples illustrate the DMARC mechanism's use of
+Identifier Alignment.  For brevity's sake, only message headers are
+shown, as message bodies are not considered when conducting DMARC
+checks.</t>
+
+<section anchor="spf"><name>SPF</name>
+<t>The following SPF examples assume that SPF produces a passing result.
+Alignment cannot exist if SPF does not produce a passing result.</t>
+<t>Example 1: SPF in alignment:</t>
+
+<artwork>     MAIL FROM: &lt;sender@example.com&gt;
+
+     From: sender@example.com
+     Date: Fri, Feb 15 2002 16:54:30 -0800
+     To: receiver@example.org
+     Subject: here's a sample
+</artwork>
+<t>In this case, the RFC5321.MailFrom parameter and the RFC5322.From
+header field have identical DNS domains.  Thus, the identifiers are in
+strict alignment.</t>
+<t>Example 2: SPF in alignment (parent):</t>
+
+<artwork>     MAIL FROM: &lt;sender@child.example.com&gt;
+
+     From: sender@example.com
+     Date: Fri, Feb 15 2002 16:54:30 -0800
+     To: receiver@example.org
+     Subject: here's a sample
+</artwork>
+<t>In this case, the RFC5322.From header parameter includes a DNS
+domain that is a parent of the RFC5321.MailFrom domain.  Thus, the
+identifiers are in relaxed alignment, because they both have the
+same Organizational Domain (example.com).</t>
+<t>Example 3: SPF not in alignment:</t>
+
+<artwork>     MAIL FROM: &lt;sender@example.net&gt;
+
+     From: sender@child.example.com
+     Date: Fri, Feb 15 2002 16:54:30 -0800
+     To: receiver@example.org
+     Subject: here's a sample
+</artwork>
+<t>In this case, the RFC5321.MailFrom parameter includes a DNS domain
+that is neither the same as, a parent of, nor a child of the
+RFC5322.From domain.  Thus, the identifiers are not in alignment.</t>
+</section>
+
+<section anchor="dkim"><name>DKIM</name>
+<t>The examples below assume that the DKIM signatures pass verification.
+Alignment cannot exist with a DKIM signature that does not verify.</t>
+<t>Example 1: DKIM in alignment:</t>
+
+<artwork>     DKIM-Signature: v=1; ...; d=example.com; ...
+     From: sender@example.com
+     Date: Fri, Feb 15 2002 16:54:30 -0800
+     To: receiver@example.org
+     Subject: here's a sample
+</artwork>
+<t>In this case, the DKIM &quot;d=&quot; parameter and the RFC5322.From header field have
+identical DNS domains.  Thus, the identifiers are in strict alignment.</t>
+<t>Example 2: DKIM in alignment (parent):</t>
+
+<artwork>     DKIM-Signature: v=1; ...; d=example.com; ...
+     From: sender@child.example.com
+     Date: Fri, Feb 15 2002 16:54:30 -0800
+     To: receiver@example.org
+     Subject: here's a sample
+</artwork>
+<t>In this case, the DKIM signature's &quot;d=&quot; parameter includes a DNS
+domain that is a parent of the RFC5322.From domain.  Thus, the
+identifiers are in relaxed alignment, as they have the same
+Organizational Domain (example.com).</t>
+<t>Example 3: DKIM not in alignment:</t>
+
+<artwork>     DKIM-Signature: v=1; ...; d=sample.net; ...
+     From: sender@child.example.com
+     Date: Fri, Feb 15 2002 16:54:30 -0800
+     To: receiver@example.org
+     Subject: here's a sample
+</artwork>
+<t>In this case, the DKIM signature's &quot;d=&quot; parameter includes a DNS
+domain that is neither the same as, a parent of, nor a child of the
+RFC5322.From domain.  Thus, the identifiers are not in alignment.</t>
+</section>
+</section>
+
+<section anchor="domain-owner-example"><name>Domain Owner Example</name>
+<t>A Domain Owner that wants to use DMARC should have already deployed
+and tested SPF and DKIM.  The next step is to publish a DNS record
+that advertises a DMARC policy for the Domain Owner's Organizational
+Domain.</t>
+
+<section anchor="entire-domain-monitoring-only"><name>Entire Domain, Monitoring Only</name>
+<t>The owner of the domain &quot;example.com&quot; has deployed SPF and DKIM on
+its messaging infrastructure.  The owner wishes to begin using DMARC
+with a policy that will solicit aggregate feedback from receivers
+without affecting how the messages are processed, in order to:</t>
+
+<ul>
+<li><t>Confirm that its legitimate messages are authenticating correctly</t>
+</li>
+<li><t>Verify that all authorized message sources have implemented
+authentication measures</t>
+</li>
+<li><t>Determine how many messages from other sources would be affected
+by a blocking policy</t>
+</li>
+</ul>
+<t>The Domain Owner accomplishes this by constructing a policy record
+indicating that:</t>
+
+<ul>
+<li><t>The version of DMARC being used is &quot;DMARC1&quot; (&quot;v=DMARC1;&quot;)</t>
+</li>
+<li><t>Receivers should not alter how they treat these messages because
+of this DMARC policy record (&quot;p=none&quot;)</t>
+</li>
+<li><t>Aggregate feedback reports should be sent via email to the address
+&quot;dmarc-feedback@example.com&quot;
+(&quot;rua=mailto:dmarc-feedback@example.com&quot;)</t>
+</li>
+<li><t>All messages from this Organizational Domain are subject to this
+policy (no &quot;t&quot; tag present, so the default of &quot;n&quot; applies).</t>
+</li>
+</ul>
+<t>The DMARC policy record might look like this when retrieved using a
+common command-line tool:</t>
+
+<artwork>  % dig +short TXT _dmarc.example.com.
+  &quot;v=DMARC1; p=none; rua=mailto:dmarc-feedback@example.com&quot;
+</artwork>
+<t>To publish such a record, the DNS administrator for the Domain Owner
+creates an entry like the following in the appropriate zone file
+(following the conventional zone file format):</t>
+
+<artwork>  ; DMARC record for the domain example.com
+
+  _dmarc  IN TXT ( &quot;v=DMARC1; p=none; &quot;
+                   &quot;rua=mailto:dmarc-feedback@example.com&quot; )
+</artwork>
+</section>
+
+<section anchor="entire-domain-monitoring-only-per-message-reports"><name>Entire Domain, Monitoring Only, Per-Message Reports</name>
+<t>The Domain Owner from the previous example has used the aggregate
+reporting to discover some messaging systems that had not yet
+implemented DKIM correctly, but they are still seeing periodic
+authentication failures.  In order to diagnose these intermittent
+problems, they wish to request per-message failure reports when
+authentication failures occur.</t>
+<t>Not all Receivers will honor such a request, but the Domain Owner
+feels that any reports it does receive will be helpful enough to
+justify publishing this record.  The default per-message report
+format (<xref target="RFC6591"></xref>) meets the Domain Owner's needs in this scenario.</t>
+<t>The Domain Owner accomplishes this by adding the following to its
+policy record from <xref target="domain-owner-example"></xref>:</t>
+
+<ul>
+<li>Per-message failure reports should be sent via email to the
+address &quot;auth-reports@example.com&quot;
+(&quot;ruf=mailto:auth-reports@example.com&quot;)</li>
+</ul>
+<t>The DMARC policy record might look like this when retrieved using a
+common command-line tool (the output shown would appear on a single
+line but is wrapped here for publication):</t>
+
+<artwork>  % dig +short TXT _dmarc.example.com.
+  &quot;v=DMARC1; p=none; rua=mailto:dmarc-feedback@example.com;
+   ruf=mailto:auth-reports@example.com&quot;
+</artwork>
+<t>To publish such a record, the DNS administrator for the Domain Owner
+might create an entry like the following in the appropriate zone file
+(following the conventional zone file format):</t>
+
+<artwork>  ; DMARC record for the domain example.com
+
+  _dmarc  IN TXT ( &quot;v=DMARC1; p=none; &quot;
+                    &quot;rua=mailto:dmarc-feedback@example.com; &quot;
+                    &quot;ruf=mailto:auth-reports@example.com&quot; )
+</artwork>
+</section>
+
+<section anchor="per-message-failure-reports-directed-to-third-party"><name>Per-Message Failure Reports Directed to Third Party</name>
+<t>The Domain Owner from the previous example is maintaining the same
+policy but now wishes to have a third party receive and process the
+per-message failure reports.  Again, not all Receivers will honor
+this request, but those that do may implement additional checks to
+verify that the third party wishes to receive the failure reports
+for this domain.</t>
+<t>The Domain Owner needs to alter its policy record from <xref target="entire-domain-monitoring-only-per-message-reports"></xref>
+as follows:</t>
+
+<ul>
+<li>Per-message failure reports should be sent via email to the
+address &quot;auth-reports@thirdparty.example.net&quot;
+(&quot;ruf=mailto:auth-reports@thirdparty.example.net&quot;)</li>
+</ul>
+<t>The DMARC policy record might look like this when retrieved using a
+common command-line tool (the output shown would appear on a single
+line but is wrapped here for publication):</t>
+
+<artwork>  % dig +short TXT _dmarc.example.com.
+  &quot;v=DMARC1; p=none; rua=mailto:dmarc-feedback@example.com;
+   ruf=mailto:auth-reports@thirdparty.example.net&quot;
+</artwork>
+<t>To publish such a record, the DNS administrator for the Domain Owner
+might create an entry like the following in the appropriate zone file
+(following the conventional zone file format):</t>
+
+<artwork>  ; DMARC record for the domain example.com
+
+  _dmarc IN TXT ( &quot;v=DMARC1; p=none; &quot;
+                  &quot;rua=mailto:dmarc-feedback@example.com; &quot;
+                  &quot;ruf=mailto:auth-reports@thirdparty.example.net&quot; )
+</artwork>
+<t>Because the address used in the &quot;ruf&quot; tag is outside the
+Organizational Domain in which this record is published, conforming
+Receivers will implement additional checks as described in Section 3 of
+<xref target="DMARC-Aggregate-Reporting"></xref>.  In order to pass these additional
+checks, the third party will need to publish an additional DNS record
+as follows:</t>
+
+<ul>
+<li>Given the DMARC record published by the Domain Owner at
+&quot;_dmarc.example.com&quot;, the DNS administrator for the third party
+will need to publish a TXT resource record at
+&quot;example.com._report._dmarc.thirdparty.example.net&quot; with the value
+&quot;v=DMARC1;&quot;.</li>
+</ul>
+<t>The resulting DNS record might look like this when retrieved using a
+common command-line tool (the output shown would appear on a single
+line but is wrapped here for publication):</t>
+
+<artwork>  % dig +short TXT example.com._report._dmarc.thirdparty.example.net
+  &quot;v=DMARC1;&quot;
+</artwork>
+<t>To publish such a record, the DNS administrator for example.net might
+create an entry like the following in the appropriate zone file
+(following the conventional zone file format):</t>
+
+<artwork>  ; zone file for thirdparty.example.net
+  ; Accept DMARC failure reports on behalf of example.com
+
+  example.com._report._dmarc   IN   TXT    &quot;v=DMARC1;&quot;
+</artwork>
+<t>Mediators and other third parties should refer to Section 3 of <xref target="DMARC-Aggregate-Reporting"></xref>
+for the full details of this mechanism.</t>
+</section>
+
+<section anchor="subdomain-sampling-and-multiple-aggregate-report-uris"><name>Subdomain, Testing, and Multiple Aggregate Report URIs</name>
+<t>The Domain Owner has implemented SPF and DKIM in a subdomain used for
+pre-production testing of messaging services.  It now wishes to express
+a severity of concern for messages from this subdomain that fail to
+authenticate to indicate to participating receivers that use of this
+domain is not valid.</t>
+<t>As a first step, it will express that it considers to be suspicious
+messages using this subdomain that fail authentication. The goal here
+will be to enable examination of messages sent to mailboxes hosted by
+participating receivers as method for troubleshooting any existing
+authentication issues.  Aggregate feedback reports will be sent to
+a mailbox within the Organizational Domain, and to a mailbox at a third
+party selected and authorized to receive same by the Domain Owner.</t>
+<t>The Domain Owner will accomplish this by constructing a policy record
+indicating that:</t>
+
+<ul>
+<li><t>The version of DMARC being used is &quot;DMARC1&quot; (&quot;v=DMARC1;&quot;)</t>
+</li>
+<li><t>It is applied only to this subdomain (record is published at
+&quot;_dmarc.test.example.com&quot; and not &quot;_dmarc.example.com&quot;)</t>
+</li>
+<li><t>Receivers are advised that the Domain Owner considers messages
+that fail to authenticate to be suspicious (&quot;p=quarantine&quot;)</t>
+</li>
+<li><t>Aggregate feedback reports should be sent via email to the
+addresses &quot;dmarc-feedback@example.com&quot; and
+&quot;example-tld-test@thirdparty.example.net&quot;
+(&quot;rua=mailto:dmarc-feedback@example.com,
+ mailto:tld-test@thirdparty.example.net&quot;)</t>
+</li>
+<li><t>The Domain Owner desires only that an actor performing a DMARC
+verification check apply any special handling rules it might have
+in place, such as rewriting the RFC53322.From header; the Domain
+Owner is testing its setup at this point, and so does not want
+the handling policy to be applied. (&quot;t=y&quot;)</t>
+</li>
+</ul>
+<t>The DMARC policy record might look like this when retrieved using a
+common command-line tool (the output shown would appear on a single
+line but is wrapped here for publication):</t>
+
+<artwork>  % dig +short TXT _dmarc.test.example.com
+  &quot;v=DMARC1; p=quarantine; rua=mailto:dmarc-feedback@example.com,
+   mailto:tld-test@thirdparty.example.net t=y&quot;
+</artwork>
+<t>To publish such a record, the DNS administrator for the Domain Owner
+might create an entry like the following in the appropriate zone
+file:</t>
+
+<artwork>  ; DMARC record for the domain test.example.com
+
+  _dmarc IN  TXT  ( &quot;v=DMARC1; p=quarantine; &quot;
+                    &quot;rua=mailto:dmarc-feedback@example.com,&quot;
+                    &quot;mailto:tld-test@thirdparty.example.net;&quot;
+                    &quot;t=y&quot; )
+</artwork>
+<t>Once enough time has passed to allow for collecting enough reports to
+give the Domain Owner confidence that all legitimate email sent using
+the subdomain is properly authenticating and passing DMARC checks, then
+the Domain Owner can update the policy record to indicate that it considers
+authentication failures to be a clear indication that use of the subdomain
+is not valid. It would do this by altering the DNS record to advise
+receivers of its position on such messages (&quot;p=reject&quot;).</t>
+<t>After alteration, the DMARC policy record might look like this when retrieved
+using a common command-line tool (the output shown would appear on a single
+line but is wrapped here for publication):</t>
+
+<artwork>  % dig +short TXT _dmarc.test.example.com
+  &quot;v=DMARC1; p=reject; rua=mailto:dmarc-feedback@example.com,
+   mailto:tld-test@thirdparty.example.net&quot;
+</artwork>
+<t>To publish such a record, the DNS administrator for the Domain Owner
+might create an entry like the following in the appropriate zone
+file:</t>
+
+<artwork>  ; DMARC record for the domain test.example.com
+
+  _dmarc IN  TXT  ( &quot;v=DMARC1; p=reject; &quot;
+                    &quot;rua=mailto:dmarc-feedback@example.com,&quot;
+                    &quot;mailto:tld-test@thirdparty.example.net&quot; )
+</artwork>
+</section>
+</section>
+
+<section anchor="mail-receiver-example"><name>Mail Receiver Example</name>
+<t>A Mail Receiver that wants to use DMARC should already be checking
+SPF and DKIM, and possess the ability to collect relevant information
+from various email-processing stages to provide feedback to Domain
+Owners (possibly via Report Receivers).</t>
+</section>
+
+<section anchor="processing-of-smtp-time"><name>Processing of SMTP Time</name>
+<t>An optimal DMARC-enabled Mail Receiver performs authentication and
+Identifier Alignment checking during the SMTP <xref target="RFC5321"></xref> conversation.</t>
+<t>Prior to returning a final reply to the DATA command, the Mail
+Receiver's MTA has performed:</t>
+
+<ol>
+<li><t>An SPF check to determine an SPF-authenticated Identifier.</t>
+</li>
+<li><t>DKIM checks that yield one or more DKIM-authenticated
+Identifiers.</t>
+</li>
+<li><t>A DMARC policy lookup.</t>
+</li>
+</ol>
+<t>The presence of an Author Domain DMARC record indicates that the Mail
+Receiver should continue with DMARC-specific processing before
+returning a reply to the DATA command.</t>
+<t>Given a DMARC record and the set of Authenticated Identifiers, the
+Mail Receiver checks to see if the Authenticated Identifiers align
+with the Author Domain (taking into consideration any strict versus
+relaxed options found in the DMARC record).</t>
+<t>For example, the following sample data is considered to be from a
+piece of email originating from the Domain Owner of &quot;example.com&quot;:</t>
+
+<artwork>  Author Domain: example.com
+  SPF-authenticated Identifier: mail.example.com
+  DKIM-authenticated Identifier: example.com
+  DMARC record:
+    &quot;v=DMARC1; p=reject; aspf=r; 
+     rua=mailto:dmarc-feedback@example.com&quot;
+</artwork>
+<t>In the above sample, both the SPF-authenticated Identifier and the
+DKIM-authenticated Identifier align with the Author Domain.  The Mail
+Receiver considers the above email to pass the DMARC check, avoiding
+the &quot;reject&quot; policy that is requested to be applied to email that fails
+to pass the DMARC check.</t>
+<t>If no Authenticated Identifiers align with the Author Domain, then
+the Mail Receiver applies the DMARC-record-specified policy.
+However, before this action is taken, the Mail Receiver can consult
+external information to override the Domain Owner's Assessment Policy.<br />
+For example, if the Mail Receiver knows that this particular email
+came from a known and trusted forwarder (that happens to break both
+SPF and DKIM), then the Mail Receiver may choose to ignore the Domain
+Owner's policy.</t>
+<t>The Mail Receiver is now ready to reply to the DATA command.  If the
+DMARC check yields that the message is to be rejected, then the Mail
+Receiver replies with a 5xy code to inform the sender of failure.  If
+the DMARC check cannot be resolved due to transient network errors,
+then the Mail Receiver replies with a 4xy code to inform the sender
+as to the need to reattempt delivery later.  If the DMARC check
+yields a passing message, then the Mail Receiver continues on with
+email processing, perhaps using the result of the DMARC check as an
+input to additional processing modules such as a domain reputation
+query.</t>
+<t>Before exiting DMARC-specific processing, the Mail Receiver checks to
+see if the Author Domain DMARC record requests AFRF-based reporting.
+If so, then the Mail Receiver can emit an AFRF to the reporting
+address supplied in the DMARC record.</t>
+<t>At the exit of DMARC-specific processing, the Mail Receiver captures
+(through logging or direct insertion into a data store) the result of
+DMARC processing.  Captured information is used to build feedback for
+Domain Owner consumption.  This is not necessary if the Domain Owner
+has not requested aggregate reports, i.e., no &quot;rua&quot; tag was found in
+the policy record.</t>
+</section>
+
+<section anchor="utilization-of-aggregate-feedback-example"><name>Utilization of Aggregate Feedback: Example</name>
+<t>Aggregate feedback is consumed by Domain Owners to verify their
+understanding of how a given domain is being processed by the Mail
+Receiver.  Aggregate reporting data on emails that pass all
+DMARC-supporting authentication checks is used by Domain Owners to
+verify that their authentication practices remain accurate.  For
+example, if a third party is sending on behalf of a Domain Owner,
+the Domain Owner can use aggregate report data to verify ongoing
+authentication practices of the third party.</t>
+<t>Data on email that only partially passes underlying authentication
+checks provides visibility into problems that need to be addressed by
+the Domain Owner.  For example, if either SPF or DKIM fails to pass,
+the Domain Owner is provided with enough information to either
+directly correct the problem or understand where authentication-
+breaking changes are being introduced in the email transmission path.
+If authentication-breaking changes due to email transmission path
+cannot be directly corrected, then the Domain Owner at least
+maintains an understanding of the effect of DMARC-based policies upon
+the Domain Owner's email.</t>
+<t>Data on email that fails all underlying authentication checks
+provides baseline visibility on how the Domain Owner's domain is
+being received at the Mail Receiver.  Based on this visibility, the
+Domain Owner can begin deployment of authentication technologies
+across uncovered email sources, if the mail that is failing the checks
+was generated by or on behalf of the Domain Owner.  Data regarding
+failing authentication checks can also allow the Domain Owner to
+come to an understanding of how its domain is being misused.</t>
+<t>(Aggregate report example should be moved to <xref target="DMARC-Aggregate-Reporting"></xref>)</t>
+</section>
+</section>
+
+<section anchor="change-log"><name>Change Log</name>
+
+<section anchor="january-5-2021"><name>January 5, 2021</name>
+
+<section anchor="ticket-80-dmarcbis-should-have-clear-and-concise-defintion-of-dmarc"><name>Ticket 80 - DMARCbis SHould Have Clear and Concise Defintion of DMARC</name>
+
+<ul>
+<li>Updated text for Abstract and Introduction sections.</li>
+<li>Diffs are recorded here - <eref target="https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/1/files">https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/1/files</eref></li>
+</ul>
+</section>
+</section>
+
+<section anchor="february-4-2021"><name>February 4, 2021</name>
+
+<section anchor="ticket-1-spf-rfc-4408-vs-7208"><name>Ticket 1 - SPF RFC 4408 vs 7208</name>
+
+<ul>
+<li>Some rearranging of text in the &quot;SPF-Authenticated Identifiers&quot; section</li>
+<li>Clarification of the term &quot;in alignment&quot; in that same section</li>
+<li>Diffs are here - <eref target="https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/3/files">https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/3/files</eref></li>
+</ul>
+</section>
+</section>
+
+<section anchor="february-10-2021"><name>February 10, 2021</name>
+
+<section anchor="ticket-84-remove-erroneous-references-to-rfc3986"><name>Ticket 84 - Remove Erroneous References to RFC3986</name>
+
+<ul>
+<li>Several references to RFC3986 changed to RFC7208</li>
+<li>Diffs are here - <eref target="https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/4/files">https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/4/files</eref></li>
+</ul>
+</section>
+</section>
+
+<section anchor="march-1-2021"><name>March 1, 2021</name>
+
+<section anchor="design-team-work-begins"><name>Design Team Work Begins</name>
+
+<ul>
+<li>Added change log section to document</li>
+</ul>
+</section>
+</section>
+
+<section anchor="march-8-2021"><name>March 8, 2021</name>
+
+<section anchor="removed-e-gustafsson-as-editor"><name>Removed E. Gustafsson as editor</name>
+
+<ul>
+<li>He withdrew as editor after a job change.</li>
+</ul>
+</section>
+
+<section anchor="ticket-3-two-tiny-nits"><name>Ticket 3 - Two tiny nits</name>
+
+<ul>
+<li>Changes to wording in section 6.6.2, Determine Handling Policy, steps
+3 and 4.</li>
+<li>New text documented here - <eref target="https://trac.ietf.org/trac/dmarc/ticket/3#comment:6">https://trac.ietf.org/trac/dmarc/ticket/3#comment:6</eref></li>
+<li>No change to section 6.6.3, Policy Discovery; ticket seems to pre-date
+current text, which appears to have answered the concern raised.</li>
+</ul>
+</section>
+
+<section anchor="ticket-4-definition-of-fo-parameter"><name>Ticket 4 - Definition of &quot;fo&quot; parameter</name>
+
+<ul>
+<li>Changes to wording in section 6.3, to bring clarity to use of colon-separated
+list as possible value to &quot;fo&quot;</li>
+<li>New text documented here - <eref target="https://trac.ietf.org/trac/dmarc/ticket/4#comment:4">https://trac.ietf.org/trac/dmarc/ticket/4#comment:4</eref></li>
+</ul>
+</section>
+</section>
+
+<section anchor="march-16-2021"><name>March 16, 2021</name>
+
+<section anchor="ticket-7-abnf-for-dmarc-record-is-slightly-wrong"><name>Ticket 7 - ABNF for dmarc-record is slightly wrong</name>
+
+<ul>
+<li>New text documented here - <eref target="https://trac.ietf.org/trac/dmarc/ticket/7">https://trac.ietf.org/trac/dmarc/ticket/7</eref></li>
+</ul>
+</section>
+
+<section anchor="ticket-26-abnf-for-pct-allows-999"><name>Ticket 26 - ABNF for pct allows &quot;999&quot;</name>
+
+<ul>
+<li>Updated ABNF for dmarc-percent</li>
+<li>New text documented here - <eref target="https://trac.ietf.org/trac/dmarc/ticket/26#comment:6">https://trac.ietf.org/trac/dmarc/ticket/26#comment:6</eref></li>
+<li>Ticket 47, Remove pct= tag, rendered change obsolete</li>
+</ul>
+</section>
+</section>
+
+<section anchor="march-23-2021"><name>March 23, 2021</name>
+
+<section anchor="ticket-75-using-wording-alternatives-to-disposition-dispose-and-the-like"><name>Ticket 75 - Using wording alternatives to 'disposition', 'dispose', and the like</name>
+
+<ul>
+<li>Changed disposition/dispose to &quot;handling&quot;</li>
+<li>Diffs documented here - <eref target="https://trac.ietf.org/trac/dmarc/ticket/75#comment:3">https://trac.ietf.org/trac/dmarc/ticket/75#comment:3</eref></li>
+</ul>
+</section>
+
+<section anchor="ticket-72-remove-absolute-requirement-for-p-tag-in-dmarc-record"><name>Ticket 72 - Remove absolute requirement for p= tag in DMARC record</name>
+
+<ul>
+<li>Changed from REQUIRED to RECOMMENDED, noted default with forward reference to discussion</li>
+<li>Diffs documented here - <eref target="https://trac.ietf.org/trac/dmarc/ticket/72#comment:3">https://trac.ietf.org/trac/dmarc/ticket/72#comment:3</eref></li>
+</ul>
+</section>
+</section>
+
+<section anchor="march-29-2021"><name>March 29, 2021</name>
+
+<section anchor="ticket-54-remove-or-expand-limits-on-number-of-recipients-per-report"><name>Ticket 54 - Remove or expand limits on number of recipients per report</name>
+
+<ul>
+<li>Removed limit</li>
+<li>Diffs documented here - <eref target="https://trac.ietf.org/trac/dmarc/ticket/54#comment:5">https://trac.ietf.org/trac/dmarc/ticket/54#comment:5</eref></li>
+</ul>
+</section>
+</section>
+
+<section anchor="april-12-2021"><name>April 12, 2021</name>
+
+<section anchor="ticket-50-remove-ri-tag"><name>Ticket 50 - Remove ri= tag</name>
+
+<ul>
+<li>Updated text to recommend against its usage, a la the ptr mechanism in RFC 7208</li>
+<li>Diffs documented here - <eref target="https://trac.ietf.org/trac/dmarc/ticket/50#comment:5">https://trac.ietf.org/trac/dmarc/ticket/50#comment:5</eref></li>
+</ul>
+</section>
+
+<section anchor="ticket-66-define-what-it-means-to-have-implemented-dmarc"><name>Ticket 66 - Define what it means to have implemented DMARC</name>
+
+<ul>
+<li>Proposed new text (taken straight from <eref target="https://trac.ietf.org/trac/dmarc/ticket/66">https://trac.ietf.org/trac/dmarc/ticket/66</eref>
+as replacement for current text in &quot;Minimum Implemenatations&quot;</li>
+</ul>
+</section>
+
+<section anchor="ticket-96-tweaks-to-abstract-and-introduction"><name>Ticket 96 - Tweaks to Abstract and Introduction</name>
+
+<ul>
+<li>Changed phrase in Abstract to &quot;an email author's domain name&quot;</li>
+<li>Changed phrase in Introduction to &quot;reports about email use of the domain name&quot;</li>
+</ul>
+</section>
+</section>
+
+<section anchor="april-13-2021"><name>April 13, 2021</name>
+
+<section anchor="ticket-53-remove-reporting-message-size-chunking"><name>Ticket 53 - Remove reporting message size chunking</name>
+
+<ul>
+<li>Proposed text to remove all references to message size chunking</li>
+<li>Data demonstrating lack of use of feature entered into ticket -
+<eref target="https://trac.ietf.org/trac/dmarc/ticket/53#comment:4">https://trac.ietf.org/trac/dmarc/ticket/53#comment:4</eref></li>
+</ul>
+</section>
+
+<section anchor="ticket-52-remove-strict-alignment-and-adkim-and-aspf-tags"><name>Ticket 52 - Remove strict alignment (and adkim and aspf tags)</name>
+
+<ul>
+<li>Proposed text to remove all references to strict alignment</li>
+<li>Data demonstrating lack of use of feature entered into ticket -
+<eref target="https://trac.ietf.org/trac/dmarc/ticket/52#comment:2">https://trac.ietf.org/trac/dmarc/ticket/52#comment:2</eref></li>
+</ul>
+</section>
+
+<section anchor="ticket-47-remove-pct-tag"><name>Ticket 47 - Remove pct= tag</name>
+
+<ul>
+<li>Proposed text to remove all references to pct and message sampling</li>
+<li>Data demonstrating lack of use of feature entered into ticket -
+<eref target="https://trac.ietf.org/trac/dmarc/ticket/47#comment:4">https://trac.ietf.org/trac/dmarc/ticket/47#comment:4</eref></li>
+</ul>
+</section>
+
+<section anchor="ticket-2-flow-of-operations-text-in-dmarc-base"><name>Ticket 2 - Flow of operations text in dmarc-base</name>
+
+<ul>
+<li>Update ASCII Art</li>
+<li>Proposed text to replace description of ASCII Art</li>
+<li>Proposed text to update Domain Owner Actions section</li>
+</ul>
+</section>
+</section>
+
+<section anchor="april-14-2021"><name>April 14, 2021</name>
+
+<section anchor="ticket-107-dmarcbis-should-take-a-stand-on-multi-valued-from-fields"><name>Ticket 107 - DMARCbis should take a stand on multi-valued From fields</name>
+
+<ul>
+<li>Proposed text that limits processing to only those times when all domains
+are the same.</li>
+</ul>
+</section>
+
+<section anchor="ticket-82-deprecate-rf-and-maybe-fo-tag"><name>Ticket 82 - Deprecate rf= and maybe fo= tag</name>
+
+<ul>
+<li>Proposed text to deprecate rf= tag, while leaving fo= tag as is</li>
+</ul>
+</section>
+
+<section anchor="ticket-85-proposed-change-to-wording-describing-p-tag-and-values"><name>Ticket 85 - Proposed change to wording describing 'p' tag and values</name>
+
+<ul>
+<li>The language expressing the semantics is proposed to be changed to be,
+in a sense, egocentric. How do I, the domain owner feel about (assess)
+the meaning of a DMARC failure?</li>
+</ul>
+</section>
+</section>
+
+<section anchor="april-15-2021"><name>April 15, 2021</name>
+
+<section anchor="ticket-86-a-r-results-for-dmarc"><name>Ticket 86 - A-R results for DMARC</name>
+
+<ul>
+<li>Proposed text to add for polrec.p and polrec.domain methods for registry
+update.</li>
+<li>Did not include polrec.pct due to proposal to remove pct tag (Ticket 47)</li>
+</ul>
+</section>
+
+<section anchor="ticket-62-make-aggregate-reporting-a-normative-must"><name>Ticket 62 - Make aggregate reporting a normative MUST</name>
+
+<ul>
+<li>Proposed text to do just that in Mail Receiver Actions, section
+titled &quot;Send Aggregate Reports&quot;</li>
+</ul>
+</section>
+</section>
+
+<section anchor="april-19-2021"><name>April 19, 2021</name>
+
+<section anchor="ticket-109-sanity-check-dmarcbis-document"><name>Ticket 109 - Sanity Check DMARCbis Document</name>
+
+<ul>
+<li>Updated document to remove all &quot;original text&quot;/&quot;proposed text&quot; couplets
+in favor of one (hopefully coherent) document full of proposed text
+changes.</li>
+<li>Noted which tickets were the cause of whatever rfcdiff output will show
+in tracker</li>
+</ul>
+</section>
+</section>
+
+<section anchor="april-20-2021"><name>April 20, 2021</name>
+
+<section anchor="ticket-108-changes-to-dmarcbis-for-psd"><name>Ticket 108 - Changes to DMARCbis for PSD</name>
+
+<ul>
+<li>Incorporating requests for changes to DMARCbis made in text of
+&quot;Experimental DMARC Extension for Public Suffix Domains&quot;
+(<eref target="https://datatracker.ietf.org/doc/draft-ietf-dmarc-psd/">https://datatracker.ietf.org/doc/draft-ietf-dmarc-psd/</eref>)</li>
+</ul>
+</section>
+</section>
+
+<section anchor="april-22-2021"><name>April 22, 2021</name>
+
+<section anchor="ticket-104-update-the-security-considerations-section-11-3-on-dns"><name>Ticket 104 - Update the Security Considerations section 11.3 on DNS</name>
+
+<ul>
+<li>Updated text. Diffs are here - <eref target="https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/31/files">https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/31/files</eref></li>
+</ul>
+</section>
+</section>
+
+<section anchor="june-16-2021"><name>June 16, 2021</name>
+
+<section anchor="publication-of-draft-ietf-dmarc-dmarcbis-02"><name>Publication of draft-ietf-dmarc-dmarcbis-02</name>
+
+<ul>
+<li>Includes final resolution for tickets 4, 47, 50, 52, 53, 54, and 82</li>
+</ul>
+</section>
+</section>
+
+<section anchor="august-12-2021"><name>August 12, 2021</name>
+
+<section anchor="publication-of-draft-ietf-dmarc-dmarcbis-03"><name>Publication of draft-ietf-dmarc-dmarcbis-03</name>
+
+<ul>
+<li>Removal of &quot;pct&quot; tag</li>
+<li>Addition of &quot;t&quot; tag</li>
+<li>Rearranging of some text and formatting for better readability and consistency.</li>
+</ul>
+</section>
+</section>
+</section>
+
+<section anchor="acknowledgements" numbered="false"><name>Acknowledgements</name>
+<t>DMARC and the draft version of this document submitted to the
+Independent Submission Editor were the result of lengthy efforts by
+an informal industry consortium: DMARC.org (see <eref target="http://dmarc.org">http://dmarc.org</eref>).
+Participating companies included Agari, American Greetings, AOL, Bank
+of America, Cloudmark, Comcast, Facebook, Fidelity Investments,
+Google, JPMorgan Chase &amp; Company, LinkedIn, Microsoft, Netease,
+PayPal, ReturnPath, The Trusted Domain Project, and Yahoo!.  Although
+the contributors and supporters are too numerous to mention, notable
+individual contributions were made by J. Trent Adams, Michael Adkins,
+Monica Chew, Dave Crocker, Tim Draegen, Steve Jones, Franck Martin,
+Brett McDowell, and Paul Midgen.  The contributors would also like to
+recognize the invaluable input and guidance that was provided early
+on by J.D. Falk.</t>
+<t>Additional contributions within the IETF context were made by Kurt
+Anderson, Michael Jack Assels, Les Barstow, Anne Bennett, Jim Fenton,
+J. Gomez, Mike Jones, Scott Kitterman, Eliot Lear, John Levine,
+S. Moonesamy, Rolf Sonneveld, Henry Timmes, and Stephen J. Turnbull.</t>
+</section>
+
+</back>
+
+</rfc>

--- a/draft-ietf-dmarc-dmarcbis-04.xml
+++ b/draft-ietf-dmarc-dmarcbis-04.xml
@@ -195,7 +195,7 @@ material before continuing.</t>
 
 <section anchor="authenticated-identifiers"><name>Authenticated Identifiers</name>
 <t>Domain-level identifiers that are verified using authentication technologies
-are referred to as &quot;Authenticated Identifiers&quot;.  See <xref target="authenication-mechanisms"></xref>
+are referred to as &quot;Authenticated Identifiers&quot;.  See <xref target="authentication-mechanisms"></xref>
 for details about the supported mechanisms.</t>
 </section>
 
@@ -240,7 +240,7 @@ is a broader definition than that in <xref target="RFC8020"></xref>.</t>
 
 <section anchor="organizational-domain"><name>Organizational Domain</name>
 <t>The Organizational Domain is typically a domain that was registered with
-a domain name registrar.  More formally, it is a Public Suffix Domain
+a domain name registrar.  More formally, it is any Public Suffix Domain
 plus one label. The Organizational Domain for the domain in the
 RFC5322.From domain is determined by applying the algorithm found in
 <xref target="determining-the-organizational-domain"></xref>.</t>
@@ -269,8 +269,156 @@ system components that receive and process these reports and the organizations
 that operate them.</t>
 </section>
 </section>
+</section>
 
-<section anchor="more-on-identifier-alignment"><name>More on Identifier Alignment</name>
+<section anchor="overview-and-key-concepts"><name>Overview and Key Concepts</name>
+<t>This section provides a general overview of the design and operation
+of the DMARC environment.</t>
+<t>DMARC permits a Domain Owner or PSO to enable verification of a domain's
+use in an email message, to indicate the Domain Owner's or PSO's message
+handling preference regarding failed verification, and to request reports
+about use of the domain name.  All information about a Domain Owner's or
+PSO's DMARC policy is published and retrieved via the DNS.</t>
+<t>DMARC's verification function is based on whether the RFC5322.From
+domain is aligned with a domain name used in a supported authentication
+mechanism. <xref target="authentication-mechanisms"></xref> When a DMARC policy exists
+for the domain name found in the RFC5322.From header field, and that
+domain name is not verified through an aligned supported authentication
+mechanism, the handling of that message can be affected based on the
+DMARC policy when delivered to a participating receiver.</t>
+<t>A message satisfies the DMARC checks if at least one of the supported
+authentication mechanisms:</t>
+
+<ol>
+<li><t>produces a &quot;pass&quot; result, and</t>
+</li>
+<li><t>produces that result based on an identifier that is in alignment,
+as described in <xref target="identifier-alignment-explained"></xref>.</t>
+</li>
+</ol>
+<t>It is important to note that the authentication mechanisms employed
+by DMARC authenticate only a DNS domain and do not authenticate the
+local-part of any email address identifier found in a message, nor do
+they validate the legitimacy of message content.</t>
+<t>DMARC's feedback component involves the collection of information
+about received messages claiming to be from the Author Domain
+for periodic aggregate reports to the Domain Owner or PSO.  The
+parameters and format for such reports are discussed in
+<xref target="DMARC-Aggregate-Reporting"></xref></t>
+<t>A DMARC-enabled Mail Receiver might also generate per-message reports
+that contain information related to individual messages that fail
+authentication checks. Per-message failure reports are a useful source of
+information when debugging deployments (if messages can be determined
+to be legitimate even though failing authentication) or in analyzing
+attacks.  The capability for such services is enabled by DMARC but
+defined in other referenced material such as <xref target="RFC6591"></xref> and
+<xref target="DMARC-Failure-Reporting"></xref></t>
+
+<section anchor="use-of-rfc5322-from"><name>Use of RFC5322.From</name>
+<t>One of the most obvious points of security scrutiny for DMARC is the
+choice to focus on an identifier, namely the RFC5322.From address,
+which is part of a body of data that has been trivially forged
+throughout the history of email. This field is the one used by end
+users to identify the source of the message, and so it has always
+been a prime target for abuse through such forgery and other means.</t>
+<t>Several points suggest that it is the most correct and safest thing
+to do in this context:</t>
+
+<ul>
+<li><t>Of all the identifiers that are part of the message itself, this
+is the only one guaranteed to be present.</t>
+</li>
+<li><t>It seems the best choice of an identifier on which to focus, as
+most MUAs display some or all of the contents of that field in a
+manner strongly suggesting those data as reflective of the true
+originator of the message.</t>
+</li>
+<li><t>Many high-profile email sources, such as email service providers,
+require that the sending agent have authenticated before email
+can be generated.  Thus, for these mailboxes, the mechanism
+described in this document provides recipient end users with strong
+evidence that the message was indeed originated by the agent they
+associate with that mailbox, if the end user knows that these
+various protections have been provided.</t>
+</li>
+</ul>
+<t>The absence of a single, properly formed RFC5322.From header field renders
+the message invalid.  Handling of such a message is outside of the
+scope of this specification.</t>
+<t>Since the sorts of mail typically protected by DMARC participants
+tend to only have single Authors, DMARC participants generally
+operate under a slightly restricted profile of RFC5322 with respect
+to the expected syntax of this field.  See <xref target="mail-receiver-actions"></xref>
+for details.</t>
+</section>
+
+<section anchor="authentication-mechanisms"><name>Authentication Mechanisms</name>
+<t>The following mechanisms for determining Authenticated Identifiers
+are supported in this version of DMARC:</t>
+
+<ul>
+<li><t>DKIM, <xref target="RFC6376"></xref>, which provides a domain-level identifier in the content of
+the &quot;d=&quot; tag of a verified DKIM-Signature header field.</t>
+</li>
+<li><t>SPF, <xref target="RFC7208"></xref>, which can authenticate both the domain found in
+an <xref target="RFC5321"></xref> HELO/EHLO command (the HELO identity) and the domain
+found in an SMTP MAIL command (the MAIL FROM identity). As noted earlier,
+however, DMARC relies solely on SPF authentication of the domain found in
+SMTP MAIL FROM command. Section 2.4 of <xref target="RFC7208"></xref> describes MAIL FROM
+processing for cases in which the MAIL command has a null path.</t>
+</li>
+</ul>
+</section>
+
+<section anchor="flow-diagram"><name>Flow Diagram</name>
+
+<sourcecode type="ascii-art"> +---------------+                             +--------------------+
+ | Author Domain |&lt; . . . . . . . . . . . .    | Return-Path Domain |
+ +---------------+                        .    +--------------------+
+     |                                    .               ^
+     V                                    V               .
+ +-----------+     +--------+       +----------+          v
+ |   MSA     |&lt;***&gt;|  DKIM  |       |   DMARC  |     +----------+
+ |  Service  |     | Signer |       | Verifier |&lt;***&gt;|    SPF   |
+ +-----------+     +--------+       +----------+  *  | Verifier |
+     |                                    ^       *  +----------+
+     |                                    *       *
+     V                                    v       *
+  +------+        (~~~~~~~~~~~~)      +------+    *  +----------+
+  | sMTA |-------&gt;( other MTAs )-----&gt;| rMTA |    **&gt;|   DKIM   |
+  +------+        (~~~~~~~~~~~~)      +------+       | Verifier |
+                                         |           +----------+
+                                         |                ^
+                                         V                .
+                                  +-----------+           .
+                    +---------+   |    MDA    |           v
+                    |  User   |&lt;--| Filtering |      +-----------+
+                    | Mailbox |   |  Engine   |      |   DKIM    |
+                    +---------+   +-----------+      |  Signing  |
+                                                     | Domain(s) |
+                                                     +-----------+
+
+  MSA = Mail Submission Agent
+  MDA = Mail Delivery Agent
+</sourcecode>
+<t>The above diagram shows a simple flow of messages through a
+DMARC-aware system.  Solid lines denote the actual message flow,
+dotted lines involve DNS queries used to retrieve message policy
+related to the supported message authentication schemes, and asterisk
+lines indicate data exchange between message-handling modules and
+message authentication modules.  &quot;sMTA&quot; is the sending MTA, and &quot;rMTA&quot;
+is the receiving MTA.</t>
+<t>Put simply, when a message reaches a DMARC-aware rMTA, a DNS query
+will be initiated to determine if a DMARC policy exists that applies
+to the author domain. If a policy is found, the rMTA will use the results
+of SPF and DKIM verification checks to determine the ultimate DMARC
+authentication status. The DMARC status can then factor into the
+message handling decision made by the recipient's mail sytsem.</t>
+<t>More details on specific actions for the parties involved can be
+found in <xref target="domain-owner-actions"></xref> and <xref target="mail-receiver-actions"></xref>.</t>
+</section>
+
+<section anchor="identifier-alignment-explained"><name>Identifier Alignment Explained</name>
 <t>Email authentication technologies authenticate various (and
 disparate) aspects of an individual message.  For example, DKIM <xref target="RFC6376"></xref>
 authenticates the domain that affixed a signature to the message,
@@ -281,12 +429,7 @@ are typically not visible to the end user.</t>
 <t>DMARC authenticates use of the RFC5322.From domain by requiring that
 it have the same Organizational Domain as (i.e., be aligned with) an
 Authenticated Identifier. Domain names in this context are to be compared
-in a case-insensitive manner, per <xref target="RFC4343"></xref>. The RFC5322.From domain
-was selected as the central identity of the DMARC mechanism because it
-is a required message header field and therefore guaranteed to be present
-in compliant messages, and most Mail User Agents (MUAs) represent the
-RFC5322.From header field as the originator of the message and render
-some or all of this header field's content to end users.</t>
+in a case-insensitive manner, per <xref target="RFC4343"></xref>.</t>
 <t>It is important to note that Identifier Alignment cannot occur with a
 message that is not valid per <xref target="RFC5322"></xref>, particularly one with a
 malformed, absent, or repeated RFC5322.From header field, since in that case
@@ -360,10 +503,13 @@ domain can be verified.</t>
 </section>
 
 <section anchor="determining-the-organizational-domain"><name>Determining The Organizational Domain</name>
-<t>The Organizational Domain for a subject DNS domain name is defined as
-the domain that is found in the DNS hierarchy one level below the PSD
-in the subject DNS domain name.  The Organizational Domain is determined
-using the following algorithm, similar to the one described in <xref target="policy-discovery"></xref></t>
+<t>The DMARC protocol defines a method for a Public Suffix Domain to identify
+itself as such using a tag in its published DMARC policy record. An Organizational
+Domain is any subdomain of a PSD that includes exactly one more label than
+the PSD in its name.</t>
+<t>For any email message, the Organizational Domain of the RFC5322.From domain
+is determined using the following algorithm, similar to the one described
+in <xref target="policy-discovery"></xref></t>
 
 <ol>
 <li><t>Query the DNS for a DMARC TXT record at the DNS domain matching the one
@@ -379,8 +525,8 @@ additional queries, using steps 4 through 8 below.</t>
 </li>
 <li><t>Break the subject DNS domain name into a set of &quot;n&quot; ordered
 labels.  Number these labels from right to left; e.g., for
-&quot;example.com&quot;, &quot;com&quot; would be label 1 and &quot;example&quot; would be
-label 2.</t>
+&quot;a.mail.example.com&quot;, &quot;com&quot; would be label 1 and &quot;example&quot; would be
+label 2 and so forth.</t>
 </li>
 <li><t>Count the number of labels found in the subject DNS domain. Let that
 number be &quot;x&quot;. If x &lt; 5, remove the left-most (highest-numbered)
@@ -416,151 +562,6 @@ record would contain a psd tag with a value of 'y', and so the Organizational
 Domain for this RFC5322.From domain would be determined to be &quot;example.com&quot;,
 the domain of the DMARC query executed prior to the query for &quot;</em>dmarc.com&quot;.</t>
 </section>
-</section>
-
-<section anchor="overview"><name>Overview</name>
-<t>This section provides a general overview of the design and operation
-of the DMARC environment.</t>
-
-<section anchor="authenication-mechanisms"><name>Authentication Mechanisms</name>
-<t>The following mechanisms for determining Authenticated Identifiers
-are supported in this version of DMARC:</t>
-
-<ul>
-<li><t>DKIM, <xref target="RFC6376"></xref>, which provides a domain-level identifier in the content of
-the &quot;d=&quot; tag of a verified DKIM-Signature header field.</t>
-</li>
-<li><t>SPF, <xref target="RFC7208"></xref>, which can authenticate both the domain found in
-an <xref target="RFC5321"></xref> HELO/EHLO command (the HELO identity) and the domain
-found in an SMTP MAIL command (the MAIL FROM identity). As noted earlier,
-however, DMARC relies solely on SPF authentication of the domain found in
-SMTP MAIL FROM command. Section 2.4 of <xref target="RFC7208"></xref> describes MAIL FROM
-processing for cases in which the MAIL command has a null path.</t>
-</li>
-</ul>
-</section>
-
-<section anchor="key-concepts"><name>Key Concepts</name>
-<t>DMARC policies are published by the Domain Owner or PSO, and retrieved by
-the Mail Receiver during the SMTP session, via the DNS.</t>
-<t>DMARC's verification function is based on whether the RFC5322.From
-domain is aligned with an authenticated domain name from SPF or DKIM.<br />
-When a DMARC policy is published for the domain name found in the
-RFC5322.From header field, and that domain name is not verified
-through SPF or DKIM, the handling of that message can be affected
-by that DMARC policy when delivered to a participating receiver.</t>
-<t>It is important to note that the authentication mechanisms employed
-by DMARC authenticate only a DNS domain and do not authenticate the
-local-part of any email address identifier found in a message, nor do
-they validate the legitimacy of message content.</t>
-<t>DMARC's feedback component involves the collection of information
-about received messages claiming to be from the Author Domain
-for periodic aggregate reports to the Domain Owner or PSO.  The
-parameters and format for such reports are discussed in <xref target="DMARC-Aggregate-Reporting"></xref></t>
-<t>A DMARC-enabled Mail Receiver might also generate per-message reports
-that contain information related to individual messages that fail SPF
-and/or DKIM.  Per-message failure reports are a useful source of
-information when debugging deployments (if messages can be determined
-to be legitimate even though failing authentication) or in analyzing
-attacks.  The capability for such services is enabled by DMARC but
-defined in other referenced material such as <xref target="RFC6591"></xref> and <xref target="DMARC-Failure-Reporting"></xref></t>
-<t>A message satisfies the DMARC checks if at least one of the supported
-authentication mechanisms:</t>
-
-<ol>
-<li><t>produces a &quot;pass&quot; result, and</t>
-</li>
-<li><t>produces that result based on an identifier that is in alignment,
-as defined in <xref target="terminology"></xref>.</t>
-</li>
-</ol>
-</section>
-
-<section anchor="flow-diagram"><name>Flow Diagram</name>
-
-<sourcecode type="ascii-art"> +---------------+                             +--------------------+
- | Author Domain |&lt; . . . . . . . . . . . .    | Return-Path Domain |
- +---------------+                        .    +--------------------+
-     |                                    .               ^
-     V                                    V               .
- +-----------+     +--------+       +----------+          v
- |   MSA     |&lt;***&gt;|  DKIM  |       |   DMARC  |     +----------+
- |  Service  |     | Signer |       | Verifier |&lt;***&gt;|    SPF   |
- +-----------+     +--------+       +----------+  *  | Verifier |
-     |                                    ^       *  +----------+
-     |                                    *       *
-     V                                    v       *
-  +------+        (~~~~~~~~~~~~)      +------+    *  +----------+
-  | sMTA |-------&gt;( other MTAs )-----&gt;| rMTA |    **&gt;|   DKIM   |
-  +------+        (~~~~~~~~~~~~)      +------+       | Verifier |
-                                         |           +----------+
-                                         |                ^
-                                         V                .
-                                  +-----------+           .
-                    +---------+   |    MDA    |           v
-                    |  User   |&lt;--| Filtering |      +-----------+
-                    | Mailbox |   |  Engine   |      |   DKIM    |
-                    +---------+   +-----------+      |  Signing  |
-                                                     | Domain(s) |
-                                                     +-----------+
-
-  MSA = Mail Submission Agent
-  MDA = Mail Delivery Agent
-</sourcecode>
-<t>The above diagram shows a simple flow of messages through a DMARC-
-aware system.  Solid lines denote the actual message flow, dotted
-lines involve DNS queries used to retrieve message policy related to
-the supported message authentication schemes, and asterisk lines
-indicate data exchange between message-handling modules and message
-authentication modules.  &quot;sMTA&quot; is the sending MTA, and &quot;rMTA&quot; is the
-receiving MTA.</t>
-<t>Put simply, when a message reaches a DMARC-aware rMTA, a DNS query
-will be initiated to determine if the author domain has published
-a DMARC policy. If a policy is found, the rMTA will use the results
-of SPF and DKIM verification checks to determine the ultimate DMARC
-authentication status. The DMARC status can then factor into the
-message handling decision made by the recipient's mail sytsem.</t>
-<t>More details on specific actions for the parties involved can be
-found in <xref target="domain-owner-actions"></xref> and <xref target="mail-receiver-actions"></xref>.</t>
-</section>
-</section>
-
-<section anchor="use-of-rfc5322-from"><name>Use of RFC5322.From</name>
-<t>One of the most obvious points of security scrutiny for DMARC is the
-choice to focus on an identifier, namely the RFC5322.From address,
-which is part of a body of data that has been trivially forged
-throughout the history of email. This field is the one used by end
-users to identify the source of the message, and so it has always
-been a prime target for abuse through such forgery and other means.</t>
-<t>Several points suggest that it is the most correct and safest thing
-to do in this context:</t>
-
-<ul>
-<li><t>Of all the identifiers that are part of the message itself, this
-is the only one guaranteed to be present.</t>
-</li>
-<li><t>It seems the best choice of an identifier on which to focus, as
-most MUAs display some or all of the contents of that field in a
-manner strongly suggesting those data as reflective of the true
-originator of the message.</t>
-</li>
-<li><t>Many high-profile email sources, such as email service providers,
-require that the sending agent have authenticated before email
-can be generated.  Thus, for these mailboxes, the mechanism
-described in this document provides recipient end users with strong
-evidence that the message was indeed originated by the agent they
-associate with that mailbox, if the end user knows that these
-various protections have been provided.</t>
-</li>
-</ul>
-<t>The absence of a single, properly formed RFC5322.From header field renders
-the message invalid.  Handling of such a message is outside of the
-scope of this specification.</t>
-<t>Since the sorts of mail typically protected by DMARC participants
-tend to only have single Authors, DMARC participants generally
-operate under a slightly restricted profile of RFC5322 with respect
-to the expected syntax of this field.  See <xref target="mail-receiver-actions"></xref>
-for details.</t>
 </section>
 
 <section anchor="policy"><name>Policy</name>

--- a/draft-ietf-dmarc-dmarcbis-04.xml
+++ b/draft-ietf-dmarc-dmarcbis-04.xml
@@ -218,8 +218,8 @@ their immediate management domain.</t>
 
 <section anchor="identifier-alignment"><name>Identifier Alignment</name>
 <t>When the domain in the address in the From: header field has the
-same Organizational Domain as a domain verified by SPF or DKIM
-(or both), it has Identifier Alignment. (see below)</t>
+same Organizational Domain as a domain verified by an authenticated
+identifier, it has Identifier Alignment. (see below)</t>
 </section>
 
 <section anchor="longest-psd"><name>Longest PSD</name>
@@ -274,6 +274,8 @@ that operate them.</t>
 <section anchor="overview-and-key-concepts"><name>Overview and Key Concepts</name>
 <t>This section provides a general overview of the design and operation
 of the DMARC environment.</t>
+
+<section anchor="dmarc-basics"><name>DMARC Basics</name>
 <t>DMARC permits a Domain Owner or PSO to enable verification of a domain's
 use in an email message, to indicate the Domain Owner's or PSO's message
 handling preference regarding failed verification, and to request reports
@@ -313,6 +315,7 @@ to be legitimate even though failing authentication) or in analyzing
 attacks.  The capability for such services is enabled by DMARC but
 defined in other referenced material such as <xref target="RFC6591"></xref> and
 <xref target="DMARC-Failure-Reporting"></xref></t>
+</section>
 
 <section anchor="use-of-rfc5322-from"><name>Use of RFC5322.From</name>
 <t>One of the most obvious points of security scrutiny for DMARC is the
@@ -418,6 +421,93 @@ message handling decision made by the recipient's mail sytsem.</t>
 found in <xref target="domain-owner-actions"></xref> and <xref target="mail-receiver-actions"></xref>.</t>
 </section>
 
+<section anchor="dns-tree-walk"><name>DNS Tree Walk</name>
+<t>While the DMARC protocol defines a method for communicating information
+through publishing records in DNS, it is not necessarily true that a
+DMARC policy record for a given domain will be found in DNS at the same
+level as the name label for the domain in question. Instead, some domains
+will inherit their DNS policy records from parent domains one level or more
+above them in the DNS hierarchy, and these records can only be discovered
+through a technique described here, one known colloquially as a &quot;DNS Tree Walk&quot;.</t>
+<t>The process for a DNS Tree Walk will always start at the point in
+the DNS hierarchy that matches the domain in the RFC5322.From header of
+the message, and will always end at the Public Suffix Domain that terminates
+the RFC5322.From domain. To prevent possible abuse of the DNS, a
+shortcut is built into the process so that RFC5322.From domains that have
+more than five labels do not result in more than five DNS queries.</t>
+<t>The generic steps for a DNS Tree Walk are as follows:</t>
+
+<ol>
+<li><t>Query the DNS for a DMARC TXT record at the DNS domain matching the one
+found in the RFC5322.From domain in the message.  A possibly empty set
+of records is returned.</t>
+</li>
+<li><t>Records that do not start with a &quot;v=&quot; tag that identifies the
+current version of DMARC are discarded.</t>
+</li>
+<li><t>If the set is now empty, or the set contains one valid DMARC record that
+does not contain the information sought, then determine the target for
+additional queries, using steps 4 through 8 below.</t>
+</li>
+<li><t>Break the subject DNS domain name into a set of &quot;n&quot; ordered
+labels.  Number these labels from right to left; e.g., for
+&quot;a.mail.example.com&quot;, &quot;com&quot; would be label 1, &quot;example&quot; would be
+label 2, &quot;mail.example.com&quot; would be label 3, and so forth.</t>
+</li>
+<li><t>Count the number of labels found in the subject DNS domain. Let that
+number be &quot;x&quot;. If x &lt; 5, remove the left-most (highest-numbered)
+label from the subject domain. If x &gt;= 5, remove the left-most
+(highest-numbered) labels from the subject domain until 4 labels remain.
+The resulting DNS domain name is the new target for subsequent lookups.</t>
+</li>
+<li><t>Query the DNS for a DMARC TXT record at the DNS domain matching this
+new target in place of the RFC5322.From domain in the message.  A possibly
+empty set of records is returned.</t>
+</li>
+<li><t>Records that do not start with a &quot;v=&quot; tag that identifies the
+current version of DMARC are discarded.</t>
+</li>
+<li><t>If the set is now empty, or the set contains one valid DMARC record that
+does not contain the information sought, then determine the target for
+additional queries by removing a single label from the target domain as
+described in step 5 and repeating steps 6 and 7 until there are no more
+labels remaining or a valid DMARC record containing the information sought
+has been retrieved.</t>
+</li>
+</ol>
+<t>To illustrate, for a message with the arbitrary RFC5322.From domain of
+&quot;a.b.c.d.e.mail.example.com&quot;, a full DNS Tree Walk would require the following
+five queries, in order:</t>
+
+<ul>
+<li>_dmarc.a.b.c.d.e.mail.example.com</li>
+<li>_dmarc.e.mail.example.com</li>
+<li>_dmarc.mail.example.com</li>
+<li>_dmarc.example.com</li>
+<li>_dmarc.com</li>
+</ul>
+</section>
+
+<section anchor="determining-the-organizational-domain"><name>Determining the Organizational Domain</name>
+<t>The DMARC protocol defines a method for a Public Suffix Domain to identify
+itself as such using a tag in its published DMARC policy record. An Organizational
+Domain is any subdomain of a PSD that includes exactly one more label than
+the PSD in its name.</t>
+<t>For any email message, the Organizational Domain of the RFC5322.From domain
+is determined by performing a DNS Tree Walk as described in <xref target="dns-tree-walk"></xref>.
+The target of the search is a valid DMARC record that contains a psd tag with
+a value of 'y'. Once such a record has been found, the Organizational Domain
+for the DNS domain matching the one found in the RFC5322.From domain can be
+declared to be the target domain queried for in the step just prior to the
+query that found the PSD domain.</t>
+<t>For example, given the RFC5322.From domain &quot;a.mail.example.com&quot;, a series
+of DNS queries for DMARC records would be executed starting with
+&quot;_dmarc.a.mail.example.com&quot; and finishing with &quot;_dmarc.com&quot;. The &quot;_dmarc.com&quot;
+record would contain a psd tag with a value of 'y', and so the Organizational
+Domain for this RFC5322.From domain would be determined to be &quot;example.com&quot;,
+the domain of the DMARC query executed prior to the query for &quot;_dmarc.com&quot;.</t>
+</section>
+
 <section anchor="identifier-alignment-explained"><name>Identifier Alignment Explained</name>
 <t>Email authentication technologies authenticate various (and
 disparate) aspects of an individual message.  For example, DKIM <xref target="RFC6376"></xref>
@@ -426,10 +516,13 @@ while SPF <xref target="RFC7208"></xref> can authenticate either the domain that
 RFC5321.MailFrom (MAIL FROM) portion of an SMTP <xref target="RFC5321"></xref> conversation or the
 RFC5321.EHLO/HELO domain, or both.  These may be different domains, and they
 are typically not visible to the end user.</t>
-<t>DMARC authenticates use of the RFC5322.From domain by requiring that
-it have the same Organizational Domain as (i.e., be aligned with) an
-Authenticated Identifier. Domain names in this context are to be compared
-in a case-insensitive manner, per <xref target="RFC4343"></xref>.</t>
+<t>DMARC authenticates use of the RFC5322.From domain by requiring either
+that it have the same Organizational Domain as an Authenticated Identifier
+(a condition known as &quot;relaxed alignment&quot;) or that it be identical to the
+domain of the Authenticated Identifier (a condition known as &quot;strict
+alignment&quot;). The choice of relaxed or strict alignment is left to the domain
+owner and is expressed in the domain's DMARC policy record.  Domain names
+in this context are to be compared in a case-insensitive manner, per <xref target="RFC4343"></xref>.</t>
 <t>It is important to note that Identifier Alignment cannot occur with a
 message that is not valid per <xref target="RFC5322"></xref>, particularly one with a
 malformed, absent, or repeated RFC5322.From header field, since in that case
@@ -501,67 +594,6 @@ domain identifier extraction so that alignment with the RFC5322.From
 domain can be verified.</t>
 </section>
 </section>
-
-<section anchor="determining-the-organizational-domain"><name>Determining The Organizational Domain</name>
-<t>The DMARC protocol defines a method for a Public Suffix Domain to identify
-itself as such using a tag in its published DMARC policy record. An Organizational
-Domain is any subdomain of a PSD that includes exactly one more label than
-the PSD in its name.</t>
-<t>For any email message, the Organizational Domain of the RFC5322.From domain
-is determined using the following algorithm, similar to the one described
-in <xref target="policy-discovery"></xref></t>
-
-<ol>
-<li><t>Query the DNS for a DMARC TXT record at the DNS domain matching the one
-found in the RFC5322.From domain in the message.  A possibly empty set
-of records is returned.</t>
-</li>
-<li><t>Records that do not start with a &quot;v=&quot; tag that identifies the
-current version of DMARC are discarded.</t>
-</li>
-<li><t>If the set is now empty, or the set contains one valid DMARC record that
-does not include a psd tag with a value of 'y', then determine the target for
-additional queries, using steps 4 through 8 below.</t>
-</li>
-<li><t>Break the subject DNS domain name into a set of &quot;n&quot; ordered
-labels.  Number these labels from right to left; e.g., for
-&quot;a.mail.example.com&quot;, &quot;com&quot; would be label 1 and &quot;example&quot; would be
-label 2 and so forth.</t>
-</li>
-<li><t>Count the number of labels found in the subject DNS domain. Let that
-number be &quot;x&quot;. If x &lt; 5, remove the left-most (highest-numbered)
-label from the subject domain. If x &gt;= 5, remove the left-most
-(highest-numbered) labels from the subject domain until 4 labels remain.
-The resulting DNS domain name is the new target for subsequent lookups.</t>
-</li>
-<li><t>Query the DNS for a DMARC TXT record at the DNS domain matching this
-new target in place of the RFC5322.From domain in the message.  A possibly
-empty set of records is returned.</t>
-</li>
-<li><t>Records that do not start with a &quot;v=&quot; tag that identifies the
-current version of DMARC are discarded.</t>
-</li>
-<li><t>If the set is now empty, or the set contains one valid DMARC record that
-does not include a psd tag with the value of 'y', then determine the
-target for additional queries by removing a single label from the target
-domain as described in step 5 and repeating steps 6 and 7 until
-there are no more labels remaining or a record containing a psd tag with
-a value of 'y' is found.</t>
-</li>
-<li><t>Once a valid DMARC record containing a psd tag with a value of 'y' has
-been found, the Organizational Domain for the DNS domain matching the
-one found in the RFC5322.From domain can be declared to be the target
-domain queried for in the step prior to the query that found the PSD
-domain.</t>
-</li>
-</ol>
-<t>For example, given the RFC5322.From domain &quot;a.mail.example.com&quot;, a series
-of DNS queries for DMARC records would be executed starting with
-&quot;<em>dmarc.a.mail.example.com&quot; and finishing with &quot;</em>dmarc.com&quot;. The &quot;<em>dmarc.com&quot;
-record would contain a psd tag with a value of 'y', and so the Organizational
-Domain for this RFC5322.From domain would be determined to be &quot;example.com&quot;,
-the domain of the DMARC query executed prior to the query for &quot;</em>dmarc.com&quot;.</t>
-</section>
 </section>
 
 <section anchor="policy"><name>Policy</name>
@@ -582,10 +614,10 @@ results of path authorization checks ought not be considered as part
 of the overall DMARC result for a given Author Domain, then the
 Domain Owner does not publish an SPF policy record that can produce
 an SPF pass result.</t>
-<t>A Mail Receiver implementing the DMARC mechanism SHOULD make a
-best-effort attempt to adhere to the Domain Owner's or PSO's published DMARC
-Domain Owner Assessment Policy when a message fails the DMARC test.<br />
-Since email streams can be complicated (due to forwarding, existing RFC5322.From
+<t>A Mail Receiver implementing the DMARC mechanism SHOULD make a best-effort
+attempt to adhere to the Domain Owner's or PSO's published DMARC Domain
+Owner Assessment Policy when a message fails the DMARC test. Since email
+streams can be complicated (due to forwarding, existing RFC5322.From
 domain-spoofing services, etc.), Mail Receivers MAY deviate from a published
 Domain Owner Assessment Policy during message processing and SHOULD
 make available the fact of and reason for the deviation to the Domain
@@ -708,7 +740,7 @@ policy specified by the &quot;p&quot; tag, if the &quot;sp&quot; tag is not pres
 MUST be applied for non-existent subdomains.  Note that &quot;np&quot; will
 be ignored for DMARC records published on subdomains of Organizational
 Domains and PSDs due to the effect of the DMARC policy discovery
-mechanism described in <xref target="policy-discovery"></xref>.</dd>
+mechanism described in <xref target="dmarc-policy-discovery"></xref>.</dd>
 <dt>p:</dt>
 <dd><t>Domain Owner Assessment Policy (plain-text; RECOMMENDED for policy
 records). Indicates the message handling preference the Domain Owner or
@@ -721,7 +753,7 @@ Possible values are as follows:</t>
 
 <dl>
 <dt>none:</dt>
-<dd>The Domain Owner offers no expression of concern.</dd>
+<dd>The Domain Owner offers no expression of preference.</dd>
 <dt>quarantine:</dt>
 <dd>The Domain Owner considers such mail to be suspicious. It
 is possible the mail is valid, although the failure creates
@@ -748,7 +780,7 @@ for a domain that is not a PSD.</dd>
 </dl></dd>
 <dt>rua:</dt>
 <dd><t>Addresses to which aggregate feedback is to be sent (comma-
-separated plain-text list of DMARC URIs; OPTIONAL).  Section 3 of <xref target="DMARC-Aggregate-Reporting"></xref>
+separated plain-text list of DMARC URIs; OPTIONAL).  <xref target="DMARC-Aggregate-Reporting"></xref>
 discusses considerations that apply when the domain name of a URI differs
 from that of the domain advertising the policy.  See <xref target="external-report-addresses"></xref>
 for additional considerations.  Any valid URI can be specified.<br />
@@ -765,7 +797,7 @@ OPTIONAL).  If present, the Domain Owner or PSO is requesting Mail
 Receivers to send detailed failure reports about messages that
 fail the DMARC evaluation in specific ways (see the &quot;fo&quot; tag
 above).  The format of the message to be generated MUST follow the
-format specified for the &quot;rf&quot; tag. Section 3 of <xref target="DMARC-Aggregate-Reporting"></xref> discusses
+format specified for the &quot;rf&quot; tag. <xref target="DMARC-Aggregate-Reporting"></xref> discusses
 considerations that apply when the domain name of a URI differs
 from that of the domain advertising the policy.  A Mail Receiver
 MUST implement support for a &quot;mailto:&quot; URI, i.e., the ability to
@@ -784,7 +816,7 @@ tag is absent and the &quot;np&quot; tag is either absent or not applicable,
 the policy specified by the &quot;p&quot; tag MUST be applied for subdomains.
 Note that &quot;sp&quot; will be ignored for DMARC records published on
 subdomains of Organizational Domains due to the effect of the
-DMARC policy discovery mechanism described in <xref target="policy-discovery"></xref>.</t>
+DMARC policy discovery mechanism described in <xref target="dmarc-policy-discovery"></xref>.</t>
 </dd>
 <dt>t:</dt>
 <dd><t>DMARC policy test mode (plain-text; OPTIONAL; default is 'n'). For
@@ -838,6 +870,7 @@ follows:</t>
 
   dmarc-tag       = dmarc-request /
                     dmarc-test /
+                    dmarc-psd /
                     dmarc-srequest /
                     dmarc-nprequest /
                     dmarc-adkim /
@@ -857,6 +890,8 @@ follows:</t>
                     ( &quot;none&quot; / &quot;quarantine&quot; / &quot;reject&quot; )
 
   dmarc-test      = &quot;t&quot; *WSP &quot;=&quot; ( &quot;y&quot; / &quot;n&quot; )
+
+  dmarc-psd       = &quot;psd&quot; *WSP &quot;=&quot; ( &quot;y&quot; / &quot;n&quot; )
 
   dmarc-srequest  = &quot;sp&quot; *WSP &quot;=&quot; *WSP
                     ( &quot;none&quot; / &quot;quarantine&quot; / &quot;reject&quot; )
@@ -987,8 +1022,8 @@ case is to only proceed with DMARC checking if the domain is
 identical for all of the addresses in a multi-valued RFC5322.From
 header field. Multi-valued RFC5322.From header fields with multiple
 domains MUST be exempt from DMARC checking.</t>
-<t>Note that domain names that appear on a public suffix list are not
-exempt from DMARC policy application and reporting.</t>
+<t>Note that Public Suffix Domains are not exempt from DMARC policy
+application and reporting.</t>
 </section>
 
 <section anchor="determine-handling-policy"><name>Determine Handling Policy</name>
@@ -1003,7 +1038,7 @@ input from previous steps.</t>
 </li>
 <li><t>Query the DNS for a DMARC policy record.  Continue if one is
 found, or terminate DMARC evaluation otherwise.  See
-<xref target="policy-discovery"></xref> for details.</t>
+<xref target="dmarc-policy-discovery"></xref> for details.</t>
 </li>
 <li><t>Perform DKIM signature verification checks.  A single email could
 contain multiple DKIM signatures.  The results of this step are
@@ -1027,8 +1062,8 @@ the DMARC mechanism check.  All other conditions (authentication
 failures, identifier mismatches) are considered to be DMARC
 mechanism check failures.</t>
 </li>
-<li><t>Apply policy.  Emails that fail the DMARC mechanism check are
-handled in accordance with the discovered DMARC policy of the
+<li><t>Apply policy, if appropriate.  Emails that fail the DMARC mechanism
+check are handled in accordance with the discovered DMARC policy of the
 Domain Owner and any local policy rules enforced by the Mail Receiver.
 See <xref target="general-record-format"></xref> for details.</t>
 </li>
@@ -1048,72 +1083,32 @@ appropriate, Receivers MAY send feedback reports regarding temporary
 errors.</t>
 <t>Handling of messages for which SPF and/or DKIM evaluation encounter a
 permanent DNS error is left to the discretion of the Mail Receiver.</t>
-</section>
 
-<section anchor="policy-discovery"><name>Policy Discovery</name>
-<t>As stated above, the DMARC mechanism uses DNS TXT records to
-advertise policy.  Policy discovery is accomplished via a method
-similar to the method used for SPF records.  This method, and the
-important differences between DMARC and SPF mechanisms, are discussed
-below.</t>
-<t>To balance the conflicting requirements of supporting wildcarding and
-allowing subdomain policy overrides, the following DNS lookup scheme
-is employed:</t>
+<section anchor="dmarc-policy-discovery"><name>DMARC Policy Discovery</name>
+<t>Discovery of the applicable DMARC policy for any domain is accomplished
+via a DNS Tree Walk as described in <xref target="dns-tree-walk"></xref>.  The target of this
+tree walk is a valid DMARC policy record, and the following rules should
+be applied to records that are found in this manner:</t>
 
 <ol>
-<li><t>Mail Receivers MUST query the DNS for a DMARC TXT record at the
-DNS domain matching the one found in the RFC5322.From domain in
-the message.  A possibly empty set of records is returned.</t>
-</li>
-<li><t>Records that do not start with a &quot;v=&quot; tag that identifies the
-current version of DMARC are discarded.</t>
-</li>
-<li><t>If the set is now empty, the Mail Receiver determines the target
-for additional queries, using steps 4 through 8 below.</t>
-</li>
-<li><t>Break the subject DNS domain name into a set of &quot;n&quot; ordered labels.
-Number these lables from right to left; e.g., for &quot;example.com&quot;,
-&quot;com&quot; would be label 1 and &quot;example&quot; would be label 2.</t>
-</li>
-<li><t>Count the number of labels found in the subject DNS domain. Let that
-number be &quot;x&quot;. If x &lt; 5, remove the left-most (highest-numbered)
-label from the subject domain. If x &gt;= 5, remove the left-most
-(highest-numbered) labels from the subject domain until 4 labels remain.
-The resulting DNS domain name is the new target for subsequent lookups.</t>
-</li>
-<li><t>The Mail Receiver MUST query the DNS for a DMARC TXT record at
-the DNS domain matching this new target in place of the RFC5322.From
-domain in the message. This record can contain policy to be asserted
-for subdomains of the target. A possibly empty set of records is
-returned.</t>
-</li>
-<li><t>Records that do not start with a &quot;v=&quot; tag that identifies the
-current version of DMARC are discarded.</t>
-</li>
-<li><t>If the set is now empty, the Mail Receiver determines the target
-for additional queries by removing a single label from the target
-domain as described in step 5 and repeating steps 6 and 7 until
-there are no more labels remaining.</t>
-</li>
-<li><t>If the remaining set contains multiple records or no records,
-policy discovery terminates and DMARC processing is not applied
-to this message.</t>
+<li><t>If the tree walk ends in the discovery of multiple records or no
+records, DMARC processing is not applied to this message.</t>
 </li>
 <li><t>If a retrieved policy record does not contain a valid &quot;p&quot; tag, or
 contains an &quot;sp&quot; tag that is not valid, then:</t>
 
-<ol>
-<li><t>if a &quot;rua&quot; tag is present and contains at least one
+<ul>
+<li><t>If a &quot;rua&quot; tag is present and contains at least one
 syntactically valid reporting URI, the Mail Receiver SHOULD
 act as if a record containing a valid &quot;v&quot; tag and &quot;p=none&quot;
 was retrieved, and continue processing;</t>
 </li>
-<li><t>otherwise, the Mail Receiver applies no DMARC processing to
+<li><t>Otherwise, the Mail Receiver applies no DMARC processing to
 this message.</t>
 </li>
-</ol></li>
+</ul></li>
 </ol>
-<t>If the set produced by the mechanism above contains no DMARC policy
+<t>If the set produced by the DNS Tree Walk contains no DMARC policy
 record (i.e., any indication that there is no such record as opposed
 to a transient DNS error), Mail Receivers SHOULD NOT apply the DMARC
 mechanism to the message.</t>
@@ -1125,14 +1120,6 @@ message being temporarily rejected (i.e., an SMTP 4yx reply), which
 invites the sending MTA to try again after the condition has possibly
 cleared, allowing a definite DMARC conclusion to be reached (&quot;fail
 closed&quot;).</t>
-
-<section anchor="longest-psd-example"><name>Longest PSD Example</name>
-<t>As an example of step 5 above, for a message with the Organizational
-Domain of &quot;example.compute.cloudcompany.com.example&quot;, the query for
-PSD DMARC would use &quot;compute.cloudcompany.com.example&quot; as the longest
-PSD. The receiver would check to see if that PSD is listed in the DMARC
-PSD Registry, and if so, perform the policy lookup at
-&quot;_dmarc.compute.cloudcompany.com.example&quot;.</t>
 <t>Note: Because the PSD policy query comes after the Organizational
 Domain policy query, PSD policy is not used for Organizational
 domains that have published a DMARC policy.  Specifically, this is
@@ -1162,7 +1149,7 @@ value signals to Mail Receivers, ones that can assist Mail Receivers
 with handling decisions for a message in ways that p= tag values of
 'none' cannot.</t>
 <t>In order to ensure maximum usefulness for DMARC across the email
-ecosystem, then, Mail Receivers MUST generate and send aggregate
+ecosystem, then, Mail Receivers SHOULD generate and send aggregate
 reports with a frequency of at least once every 24 hours.</t>
 </section>
 </section>
@@ -1301,14 +1288,13 @@ caused the rejection.</t>
 <t>In the latter case, when doing an SMTP rejection, providing a clear
 hint can be useful in resolving issues.  A receiver might indicate in
 plain text the reason for the rejection by using the word &quot;DMARC&quot;
-somewhere in the reply text.  Many systems are able to scan the SMTP
-reply text to determine the nature of the rejection.  Thus, providing
-a machine-detectable reason for rejection allows the problems causing
-rejections to be properly addressed by automated systems.  For
-example:</t>
+somewhere in the reply text. For example:</t>
 
 <artwork>550 5.7.1 Email rejected per DMARC policy for example.com
 </artwork>
+<t>Many systems are able to scan the SMTP reply text to determine the nature
+of the rejection.  Thus, providing a machine-detectable reason for rejection
+allows the problems causing rejections to be properly addressed by automated systems.</t>
 <t>If a Mail Receiver elects to defer delivery due to inability to
 retrieve or apply DMARC policy, this is best done with a 4xy SMTP
 reply code.</t>
@@ -1534,6 +1520,13 @@ when processed by implementations conforming to prior specifications.</t>
 </tr>
 
 <tr>
+<td align="left">np</td>
+<td align="left">RFC 7489</td>
+<td align="left">current</td>
+<td align="left">Requested handling policy for non-existent subdomains</td>
+</tr>
+
+<tr>
 <td align="left">p</td>
 <td align="left">RFC 7489</td>
 <td align="left">current</td>
@@ -1545,6 +1538,13 @@ when processed by implementations conforming to prior specifications.</t>
 <td align="left">RFC 7489</td>
 <td align="left">historic</td>
 <td align="left">Sampling rate</td>
+</tr>
+
+<tr>
+<td align="left">psd</td>
+<td align="left">RFC 7489</td>
+<td align="left">current</td>
+<td align="left">Indicates whether policy record is published by a Public Suffix Domain</td>
 </tr>
 
 <tr>

--- a/draft-ietf-dmarc-dmarcbis-04.xml
+++ b/draft-ietf-dmarc-dmarcbis-04.xml
@@ -358,38 +358,61 @@ domain can be verified.</t>
 </section>
 
 <section anchor="determining-the-organizational-domain"><name>Determining The Organizational Domain</name>
-<t>The Organizational Domain is determined using the following
-algorithm:</t>
+<t>The Organizational Domain for a subject DNS domain name is defined as
+the domain that is found in the DNS hierarchy one level below the PSD
+in the subject DNS domain name.  The Organizational Domain is determined
+using the following algorithm, similar to the one described in <xref target="policy-discovery"></xref></t>
 
 <ol>
-<li><t>Acquire a &quot;public suffix&quot; list, i.e., a list of DNS domain names
-reserved for registrations.  Some country Top-Level Domains
-(TLDs) make specific registration requirements, e.g., the United
-Kingdom places company registrations under &quot;.co.uk&quot;; other TLDs
-such as &quot;.com&quot; appear in the IANA registry of top-level DNS
-domains.  A public suffix list is the union of all of these.
-<xref target="public-suffix-lists"></xref> contains some discussion about obtaining a public
-suffix list.</t>
+<li><t>Query the DNS for a DMARC TXT record at the DNS domain matching the one
+found in the RFC5322.From domain in the message.  A possibly empty set
+of records is returned.</t>
+</li>
+<li><t>Records that do not start with a &quot;v=&quot; tag that identifies the
+current version of DMARC are discarded.</t>
+</li>
+<li><t>If the set is now empty, or the set contains one valid DMARC record that
+does not include a psd tag with a value of 'y', then determine the target for
+additional queries, using steps 4 through 8 below.</t>
 </li>
 <li><t>Break the subject DNS domain name into a set of &quot;n&quot; ordered
 labels.  Number these labels from right to left; e.g., for
 &quot;example.com&quot;, &quot;com&quot; would be label 1 and &quot;example&quot; would be
 label 2.</t>
 </li>
-<li><t>Search the public suffix list for the name that matches the
-largest number of labels found in the subject DNS domain.  Let
-that number be &quot;x&quot;.</t>
+<li><t>Count the number of labels found in the subject DNS domain. Let that
+number be &quot;x&quot;. If x &lt; 5, remove the left-most (highest-numbered)
+label from the subject domain. If x &gt;= 5, remove the left-most
+(highest-numbered) labels from the subject domain until 4 labels remain.
+The resulting DNS domain name is the new target for subsequent lookups.</t>
 </li>
-<li><t>Construct a new DNS domain name using the name that matched from
-the public suffix list and prefixing to it the &quot;x+1&quot;th label from
-the subject domain.  This new name is the Organizational Domain.</t>
+<li><t>Query the DNS for a DMARC TXT record at the DNS domain matching this
+new target in place of the RFC5322.From domain in the message.  A possibly
+empty set of records is returned.</t>
+</li>
+<li><t>Records that do not start with a &quot;v=&quot; tag that identifies the
+current version of DMARC are discarded.</t>
+</li>
+<li><t>If the set is now empty, or the set contains one valid DMARC record that
+does not include a psd tag with the value of 'y', then determine the
+target for additional queries by removing a single label from the target
+domain as described in step 5 and repeating steps 6 and 7 until
+there are no more labels remaining or a record containing a psd tag with
+a value of 'y' is found.</t>
+</li>
+<li><t>Once a valid DMARC record containing a psd tag with a value of 'y' has
+been found, the Organizational Domain for the DNS domain matching the
+one found in the RFC5322.From domain can be declared to be the target
+domain queried for in the step prior to the query that found the PSD
+domain.</t>
 </li>
 </ol>
-<t>Thus, since &quot;com&quot; is an IANA-registered TLD, a subject domain of
-&quot;a.b.c.d.example.com&quot; would have an Organizational Domain of
-&quot;example.com&quot;.</t>
-<t>The process of determining a suffix is currently a heuristic one.  No
-list is guaranteed to be accurate or current.</t>
+<t>For example, given the RFC5322.From domain &quot;a.mail.example.com&quot;, a series
+of DNS queries for DMARC records would be executed starting with
+&quot;<em>dmarc.a.mail.example.com&quot; and finishing with &quot;</em>dmarc.com&quot;. The &quot;<em>dmarc.com&quot;
+record would contain a psd tag with a value of 'y', and so the Organizational
+Domain for this RFC5322.From domain would be determined to be &quot;example.com&quot;,
+the domain of the DMARC query executed prior to the query for &quot;</em>dmarc.com&quot;.</t>
 </section>
 </section>
 
@@ -706,6 +729,20 @@ indication that the use of the domain name is not valid. See
 <xref target="rejecting-messages"></xref> for some discussion of SMTP rejection
 methods and their implications.</dd>
 </dl></dd>
+<dt>psd:</dt>
+<dd><t>A flag indicating whether the domain is a PSD. (plain-text; OPTIONAL;
+default is 'n'). Possible values are:</t>
+
+<dl>
+<dt>y:</dt>
+<dd>Domains on the PSL that publish DMARC policy records SHOULD include
+this tag with a value of 'y' to indicate that the domain is a PSD. This
+information will be used during policy discovery to determine how to
+apply any DMARC policy records that are discovered during the tree walk.</dd>
+<dt>n:</dt>
+<dd>The default, indicating that the DMARC policy record is published
+for a domain that is not a PSD.</dd>
+</dl></dd>
 <dt>rua:</dt>
 <dd><t>Addresses to which aggregate feedback is to be sent (comma-
 separated plain-text list of DMARC URIs; OPTIONAL).  Section 3 of <xref target="DMARC-Aggregate-Reporting"></xref>
@@ -1016,9 +1053,9 @@ advertise policy.  Policy discovery is accomplished via a method
 similar to the method used for SPF records.  This method, and the
 important differences between DMARC and SPF mechanisms, are discussed
 below.</t>
-<t>To balance the conflicting requirements of supporting wildcarding,
-allowing subdomain policy overrides, and limiting DNS query load, the
-following DNS lookup scheme is employed:</t>
+<t>To balance the conflicting requirements of supporting wildcarding and
+allowing subdomain policy overrides, the following DNS lookup scheme
+is employed:</t>
 
 <ol>
 <li><t>Mail Receivers MUST query the DNS for a DMARC TXT record at the
@@ -1028,27 +1065,32 @@ the message.  A possibly empty set of records is returned.</t>
 <li><t>Records that do not start with a &quot;v=&quot; tag that identifies the
 current version of DMARC are discarded.</t>
 </li>
-<li><t>If the set is now empty, the Mail Receiver MUST query the DNS for
-a DMARC TXT record at the DNS domain matching the Organizational
-Domain in place of the RFC5322.From domain in the message (if
-different).  This record can contain policy to be asserted for
-subdomains of the Organizational Domain.  A possibly empty set of
-records is returned.</t>
+<li><t>If the set is now empty, the Mail Receiver determines the target
+for additional queries, using steps 4 through 8 below.</t>
+</li>
+<li><t>Break the subject DNS domain name into a set of &quot;n&quot; ordered labels.
+Number these lables from right to left; e.g., for &quot;example.com&quot;,
+&quot;com&quot; would be label 1 and &quot;example&quot; would be label 2.</t>
+</li>
+<li><t>Count the number of labels found in the subject DNS domain. Let that
+number be &quot;x&quot;. If x &lt; 5, remove the left-most (highest-numbered)
+label from the subject domain. If x &gt;= 5, remove the left-most
+(highest-numbered) labels from the subject domain until 4 labels remain.
+The resulting DNS domain name is the new target for subsequent lookups.</t>
+</li>
+<li><t>The Mail Receiver MUST query the DNS for a DMARC TXT record at
+the DNS domain matching this new target in place of the RFC5322.From
+domain in the message. This record can contain policy to be asserted
+for subdomains of the target. A possibly empty set of records is
+returned.</t>
 </li>
 <li><t>Records that do not start with a &quot;v=&quot; tag that identifies the
 current version of DMARC are discarded.</t>
 </li>
-<li><t>If the set is now empty and the longest PSD <xref target="longest-psd"></xref> of the
-Organizational Domain is one that the receiver has determined is
-acceptable for PSD DMARC (based on the data in one of the DMARC
-PSD Registry Examples decribed in Appendix B of <xref target="RFC9091"></xref>)
-the Mail Receiver MUST query the DNS for a DMARC TXT record at
-the DNS domain matching the longest PSD in place of the RFC5322.From
-domain in the message (if different).  A possibly empty set of records
-is returned.</t>
-</li>
-<li><t>Records that do not start with a &quot;v=&quot; tag that identifies the
-current version of DMARC are discarded.</t>
+<li><t>If the set is now empty, the Mail Receiver determines the target
+for additional queries by removing a single label from the target
+domain as described in step 5 and repeating steps 6 and 7 until
+there are no more labels remaining.</t>
 </li>
 <li><t>If the remaining set contains multiple records or no records,
 policy discovery terminates and DMARC processing is not applied

--- a/draft-ietf-dmarc-dmarcbis.md
+++ b/draft-ietf-dmarc-dmarcbis.md
@@ -62,9 +62,9 @@ belongs to an organization expected to be known to - and presumably
 trusted by - the recipient. The Sender Policy Framework (SPF) [@!RFC7208]
 and DomainKeys Identified Mail (DKIM) [@!RFC6376] protocols provide 
 domain-level authentication but are not directly associated with the 
-RFC5322.From domain. DMARC leverages them, and provides a method for 
-Domain Owners to publish a DNS record describing the email authentication
-policies for the RFC5322.From domain and to request a specific handling
+RFC5322.From domain. DMARC leverages these two protocols, providing a method 
+for Domain Owners to publish a DNS record describing the email authentication
+policies for the RFC5322.From domain and to request specific handling
 for messages using that domain that fail authentication checks.
 
 As with SPF and DKIM, DMARC classes results as "pass" or "fail". In order
@@ -107,7 +107,8 @@ Owners can use these reports, especially the aggregate reports, to identify
 not only sources of mail attempting to fraudulently use their domain, but also
 (and perhaps more importantly) gaps in their own authentication practices. However,
 as with honoring the Domain Owner's stated mail handling preference, a mail-receiving
-organization supporting DMARC is under no obligation to send requested reports.
+organization supporting DMARC is under no obligation to send requested reports, 
+although it is recommended that they do send aggregate reports.
 
 Use of DMARC creates some interoperability challenges that require due 
 consideration before deployment, particularly with configurations that
@@ -137,6 +138,39 @@ DMARC has the following high-level goals:
 
 *  Work at Internet scale.
 
+##  Anti-Phishing {#anti-phishing}
+
+DMARC is designed to prevent bad actors from sending mail that claims
+to come from legitimate senders, particularly senders of transactional 
+email (official mail that is about business transactions).  One of the 
+primary uses of this kind of spoofed mail is phishing (enticing users 
+to provide information by pretending to be the legitimate service 
+requesting the information).  Thus, DMARC is significantly informed 
+by ongoing efforts to enact large-scale, Internet-wide anti-phishing 
+measures.
+
+Although DMARC can only be used to combat specific forms of 
+exact-domain spoofing directly, the DMARC mechanism has been found 
+to be useful in the creation of reliable and defensible message streams.
+
+DMARC does not attempt to solve all problems with spoofed or
+otherwise fraudulent email.  In particular, it does not address the
+use of visually similar domain names ("cousin domains") or abuse of
+the RFC5322.From human-readable <display-name>.
+
+##  Scalability {#scalability}
+
+Scalability is a major issue for systems that need to operate in a
+system as widely deployed as current SMTP email.  For this reason,
+DMARC seeks to avoid the need for third parties or pre-sending
+agreements between senders and receivers.  This preserves the
+positive aspects of the current email infrastructure.
+
+Although DMARC does not introduce third-party senders (namely
+external agents authorized to send on behalf of an operator) to the
+email-handling flow, it also does not preclude them.  Such third
+parties are free to provide services in conjunction with DMARC.
+
 ##  Out of Scope {#out-of-scope}
 
 Several topics and issues are specifically out of scope for this
@@ -154,46 +188,13 @@ work.  These include the following:
 *  Reporting or otherwise evaluating other than the last-hop IP
    address;
 
-*  Attacks in the From: header field, also known as "display name"
+*  Attacks in the RFC5322.From header field, also known as "display name"
    attacks;
 
 *  Authentication of entities other than domains, since DMARC is
    built upon SPF and DKIM, which authenticate domains; and
 
 *  Content analysis.
-
-##  Scalability {#scalability}
-
-Scalability is a major issue for systems that need to operate in a
-system as widely deployed as current SMTP email.  For this reason,
-DMARC seeks to avoid the need for third parties or pre-sending
-agreements between senders and receivers.  This preserves the
-positive aspects of the current email infrastructure.
-
-Although DMARC does not introduce third-party senders (namely
-external agents authorized to send on behalf of an operator) to the
-email-handling flow, it also does not preclude them.  Such third
-parties are free to provide services in conjunction with DMARC.
-
-##  Anti-Phishing {#anti-phishing}
-
-DMARC is designed to prevent bad actors from sending mail that claims
-to come from legitimate senders, particularly senders of
-transactional email (official mail that is about business
-transactions).  One of the primary uses of this kind of spoofed mail
-is phishing (enticing users to provide information by pretending to
-be the legitimate service requesting the information).  Thus, DMARC
-is significantly informed by ongoing efforts to enact large-scale,
-Internet-wide anti-phishing measures.
-
-Although DMARC can only be used to combat specific forms of exact-
-domain spoofing directly, the DMARC mechanism has been found to be
-useful in the creation of reliable and defensible message streams.
-
-DMARC does not attempt to solve all problems with spoofed or
-otherwise fraudulent email.  In particular, it does not address the
-use of visually similar domain names ("cousin domains") or abuse of
-the RFC5322.From human-readable <display-name>.
 
 #  Terminology and Definitions {#terminology}
 
@@ -228,7 +229,7 @@ for details about the supported mechanisms.
 
 ### Author Domain {#author-domain}
 
-The domain name of the apparent author, as extracted from the From: header field.
+The domain name of the apparent author, as extracted from the RFC5322.From header field.
 
 ### Domain Owner {#domain-owner}
 
@@ -245,19 +246,14 @@ their immediate management domain.
 
 ### Identifier Alignment {#identifier-alignment}
 
-When the domain in the address in the From: header field has the 
+When the domain in the address in the RFC5322.From header field has the 
 same Organizational Domain as a domain verified by an authenticated
-identifier, it has Identifier Alignment. (see below)
-
-### Longest PSD {#longest-psd}
-
-The term Longest PSD is defined in [@!RFC9091].
+identifier, it has Identifier Alignment. (see (#organizational-domain))
 
 ### Mail Receiver {#mail-receiver}
 
-The entity or organization that receives and processes email.  
-Mail Receivers operate one or more Internet-facing Mail Transport 
-Agents (MTAs).
+The entity or organization that receives and processes email. Mail 
+Receivers operate one or more Internet-facing Mail Transport Agents (MTAs).
 
 ### Non-existent Domains {#non-existent-domains}
 
@@ -311,8 +307,8 @@ PSO's DMARC policy is published and retrieved via the DNS.
 
 DMARC's verification function is based on whether the RFC5322.From 
 domain is aligned with a domain name used in a supported authentication
-mechanism. (#authentication-mechanisms) When a DMARC policy exists 
-for the domain name found in the RFC5322.From header field, and that 
+mechanism, as described in (#authentication-mechanisms). When a DMARC policy 
+exists for the domain name found in the RFC5322.From header field, and that 
 domain name is not verified through an aligned supported authentication 
 mechanism, the handling of that message can be affected based on the 
 DMARC policy when delivered to a participating receiver.
@@ -373,9 +369,9 @@ to do in this context:
    associate with that mailbox, if the end user knows that these 
    various protections have been provided.
 
-The absence of a single, properly formed RFC5322.From header field renders
-the message invalid.  Handling of such a message is outside of the
-scope of this specification.
+*  The absence of a single, properly formed RFC5322.From header field 
+   renders the message invalid. Handling of such a message is outside 
+   of the scope of this specification.
 
 Since the sorts of mail typically protected by DMARC participants
 tend to only have single Authors, DMARC participants generally
@@ -392,7 +388,7 @@ are supported in this version of DMARC:
    the "d=" tag of a verified DKIM-Signature header field.
 
 *  SPF, [@!RFC7208], which can authenticate both the domain found in 
-   an [@!RFC5321] HELO/EHLO command (the HELO identity) and the domain 
+   an SMTP [@!RFC5321] HELO/EHLO command (the HELO identity) and the domain 
    found in an SMTP MAIL command (the MAIL FROM identity). As noted earlier,
    however, DMARC relies solely on SPF authentication of the domain found in
    SMTP MAIL FROM command. Section 2.4 of [@!RFC7208] describes MAIL FROM 
@@ -452,7 +448,7 @@ found in (#domain-owner-actions) and (#mail-receiver-actions).
 ##  DNS Tree Walk {#dns-tree-walk}
 
 While the DMARC protocol defines a method for communicating information 
-through publishing records in DNS, it is not necessarily true that a 
+through the publishing of records in DNS, it is not necessarily true that a 
 DMARC policy record for a given domain will be found in DNS at the same
 level as the name label for the domain in question. Instead, some domains
 will inherit their DNS policy records from parent domains one level or more
@@ -550,8 +546,8 @@ DMARC authenticates use of the RFC5322.From domain by requiring either
 that it have the same Organizational Domain as an Authenticated Identifier
 (a condition known as "relaxed alignment") or that it be identical to the
 domain of the Authenticated Identifier (a condition known as "strict 
-alignment"). The choice of relaxed or strict alignment is left to the domain 
-owner and is expressed in the domain's DMARC policy record.  Domain names 
+alignment"). The choice of relaxed or strict alignment is left to the Domain 
+Owner and is expressed in the domain's DMARC policy record.  Domain names 
 in this context are to be compared in a case-insensitive manner, per [@!RFC4343]. 
 
 It is important to note that Identifier Alignment cannot occur with a
@@ -636,25 +632,24 @@ domain can be verified.
 
 #   Policy {#policy}
 
-DMARC policies are published by Domain Owners and PSOs and can be
-used by Mail Receivers to inform their message handling decisions.
-
 A Domain Owner or PSO advertises DMARC participation of one or more of its
 domains by adding a DNS TXT record (described in (#dmarc-policy-record)) to
 those domains.  In doing so, Domain Owners and PSOs indicate their handling
 preference regarding failed authentication for email messages making use
-of their domain in the RFC5322.From header field as well as the provision
-of feedback about those messages. Mail Receivers in turn can take into
+of their domain in the RFC5322.From header field as well as their desire
+for feedback about those messages. Mail Receivers in turn can take into
 account the Domain Owner's stated preference when making handling 
 decisions about email messages that fail DMARC authentication checks.
 
 A Domain Owner or PSO may choose not to participate in DMARC evaluation by
-Mail Receivers.  In this case, the Domain Owner simply declines to
-advertise participation in those schemes.  For example, if the
-results of path authorization checks ought not be considered as part
-of the overall DMARC result for a given Author Domain, then the
-Domain Owner does not publish an SPF policy record that can produce
-an SPF pass result.
+Mail Receivers simply by not publishing an appropriate DNS TXT record for
+its domain(s).  A Domain Owner can also choose to not have some underlying
+authentication technologies apply to DMARC evaluation of its domain(s). In
+this case, the Domain Owner simply declines to advertise participation in
+those schemes.  For example, if the results of path authorization checks
+ought not be considered as part of the overall DMARC result for a given
+Author Domain, then the Domain Owner does not publish an SPF policy record
+that can produce an SPF pass result.
 
 A Mail Receiver implementing the DMARC mechanism SHOULD make a best-effort
 attempt to adhere to the Domain Owner's or PSO's published DMARC Domain
@@ -748,29 +743,26 @@ Report generators MAY choose to adhere to the requested options.
 This tag's content MUST be ignored if a "ruf" tag (below) is not
 also specified.  Failure reporting options are shown below. The value
 of this tag is either "0", "1", or a colon-separated list of the 
-options represented by alphabetic characters.
-
-The valid values and their meanings are:
+options represented by alphabetic characters. The valid values and 
+their meanings are:
 
     0:
-    :  Generate a DMARC failure report if all underlying
-       authentication mechanisms fail to produce an aligned "pass"
-       result.
+    : Generate a DMARC failure report if all underlying authentication 
+      mechanisms fail to produce an aligned "pass" result.
 
     1:
-    :  Generate a DMARC failure report if any underlying
-       authentication mechanism produced something other than an
-       aligned "pass" result.
+    : Generate a DMARC failure report if any underlying authentication 
+      mechanism produced something other than an aligned "pass" result.
 
     d:
-    :  Generate a DKIM failure report if the message had a signature
-       that failed evaluation, regardless of its alignment.  DKIM-
-       specific reporting is described in [@!RFC6651].
+    : Generate a DKIM failure report if the message had a signature
+      that failed evaluation, regardless of its alignment. DKIM-specific 
+      reporting is described in [@!RFC6651].
 
     s:
-    :  Generate an SPF failure report if the message failed SPF
-       evaluation, regardless of its alignment.  SPF-specific
-       reporting is described in [@!RFC6652].
+    : Generate an SPF failure report if the message failed SPF
+      evaluation, regardless of its alignment. SPF-specific
+      reporting is described in [@!RFC6652].
 
 np:
 :   Domain Owner Assessment Policy for non-existent subdomains
@@ -798,99 +790,93 @@ p:
     Possible values are as follows:
 
     none: 
-    :   The Domain Owner offers no expression of preference.
+    : The Domain Owner offers no expression of preference.
 
     quarantine:
-    :   The Domain Owner considers such mail to be suspicious. It
-        is possible the mail is valid, although the failure creates
-        a significant concern.
+    : The Domain Owner considers such mail to be suspicious. It is possible 
+      the mail is valid, although the failure creates a significant concern.
 
     reject:
-    :   The Domain Owner considers all such failures to be a clear
-        indication that the use of the domain name is not valid. See
-        (#rejecting-messages) for some discussion of SMTP rejection
-        methods and their implications.
+    : The Domain Owner considers all such failures to be a clear indication 
+      that the use of the domain name is not valid. See (#rejecting-messages) 
+      for some discussion of SMTP rejection methods and their implications.
 
 psd:
 :   A flag indicating whether the domain is a PSD. (plain-text; OPTIONAL;
     default is 'n'). Possible values are:
 
     y:
-    :   Domains on the PSL that publish DMARC policy records SHOULD include 
-    this tag with a value of 'y' to indicate that the domain is a PSD. This 
-    information will be used during policy discovery to determine how to 
-    apply any DMARC policy records that are discovered during the tree walk.
+    : Domains on the PSL that publish DMARC policy records SHOULD include 
+      this tag with a value of 'y' to indicate that the domain is a PSD. This 
+      information will be used during policy discovery to determine how to 
+      apply any DMARC policy records that are discovered during the tree walk.
 
     n:
-    :   The default, indicating that the DMARC policy record is published
-    for a domain that is not a PSD.
+    : The default, indicating that the DMARC policy record is published for a 
+      domain that is not a PSD.
 
 rua:
-:   Addresses to which aggregate feedback is to be sent (comma-
-separated plain-text list of DMARC URIs; OPTIONAL).  [@!DMARC-Aggregate-Reporting]
-discusses considerations that apply when the domain name of a URI differs 
-from that of the domain advertising the policy.  See (#external-report-addresses) 
-for additional considerations.  Any valid URI can be specified.  
-A Mail Receiver MUST implement support for a "mailto:" URI, i.e., the 
-ability to send a DMARC report via electronic mail.  If not provided, 
-Mail Receivers MUST NOT generate aggregate feedback reports.  URIs 
-not supported by Mail Receivers MUST be ignored.  The aggregate 
-feedback report format is described in [@!DMARC-Aggregate-Reporting]
+:  Addresses to which aggregate feedback is to be sent (comma-separated plain-text
+   list of DMARC URIs; OPTIONAL).  [@!DMARC-Aggregate-Reporting] discusses considerations
+   that apply when the domain name of a URI differs from that of the domain advertising
+   the policy.  See (#external-report-addresses) for additional considerations. Any
+   valid URI can be specified.  A Mail Receiver MUST implement support for a "mailto:"
+   URI, i.e., the ability to send a DMARC report via electronic mail.  If the tag is not
+   provided, Mail Receivers MUST NOT generate aggregate feedback reports for the domain. 
+   URIs not supported by Mail Receivers MUST be ignored. The aggregate feedback report 
+   format is described in [@!DMARC-Aggregate-Reporting]
 
 ruf:
-:   Addresses to which message-specific failure information is to
-be reported (comma-separated plain-text list of DMARC URIs;
-OPTIONAL).  If present, the Domain Owner or PSO is requesting Mail
-Receivers to send detailed failure reports about messages that
-fail the DMARC evaluation in specific ways (see the "fo" tag
-above).  The format of the message to be generated MUST follow the
-format specified for the "rf" tag. [@!DMARC-Aggregate-Reporting] discusses
-considerations that apply when the domain name of a URI differs
-from that of the domain advertising the policy.  A Mail Receiver
-MUST implement support for a "mailto:" URI, i.e., the ability to
-send a DMARC report via electronic mail.  If not provided, Mail
-Receivers MUST NOT generate failure reports.  See (#external-report-addresses) for
-additional considerations.
+:  Addresses to which message-specific failure information is to be reported 
+   (comma-separated plain-text list of DMARC URIs; OPTIONAL).  If present, the Domain
+   Owner or PSO is requesting Mail Receivers to send detailed failure reports about
+   messages that fail the DMARC evaluation in specific ways (see the "fo" tag above). 
+   The format of the message to be generated MUST follow the format specified for the
+   "rf" tag. [@!DMARC-Aggregate-Reporting] discusses considerations that apply when
+   the domain name of a URI differs from that of the domain advertising the policy. 
+   A Mail Receiver MUST implement support for a "mailto:" URI, i.e., the ability to
+   send a DMARC report via electronic mail.  If the tag is not provided, Mail Receivers
+   MUST NOT generate failure reports for the domain. See (#external-report-addresses)
+   for additional considerations.
 
 sp:
-:   Domain Owner Assessment Policy for all subdomains (plain-text;
-OPTIONAL). Indicates the message handling preference the Domain Owner 
-or PSO has for mail using an existing subdomain of the domain queried 
-but not passing DMARC verification.  It applies only to subdomains of
-the domain queried and not to the domain itself.  Its syntax is
-identical to that of the "p" tag defined above.  If both the "sp"
-tag is absent and the "np" tag is either absent or not applicable, 
-the policy specified by the "p" tag MUST be applied for subdomains.
-Note that "sp" will be ignored for DMARC records published on
-subdomains of Organizational Domains due to the effect of the
-DMARC policy discovery mechanism described in (#dmarc-policy-discovery).
+:  Domain Owner Assessment Policy for all subdomains (plain-text;
+   OPTIONAL). Indicates the message handling preference the Domain Owner 
+   or PSO has for mail using an existing subdomain of the domain queried 
+   but not passing DMARC verification.  It applies only to subdomains of
+   the domain queried and not to the domain itself.  Its syntax is
+   identical to that of the "p" tag defined above.  If both the "sp"
+   tag is absent and the "np" tag is either absent or not applicable, 
+   the policy specified by the "p" tag MUST be applied for subdomains.
+   Note that "sp" will be ignored for DMARC records published on
+   subdomains of Organizational Domains due to the effect of the
+   DMARC policy discovery mechanism described in (#dmarc-policy-discovery).
 
 t:
-:   DMARC policy test mode (plain-text; OPTIONAL; default is 'n'). For 
-    the RFC5322.From domain to which the DMARC record applies, the "t" 
-    tag serves as a signal to the actor performing DMARC verification checks 
-    as to whether or not the domain owner wishes the assessment policy 
-    declared in the "p=", "sp=", and/or "np=" tags to actually be applied. This 
-    parameter does not affect the generation of DMARC reports.  Possible values 
-    are as follows:
+:  DMARC policy test mode (plain-text; OPTIONAL; default is 'n'). For 
+   the RFC5322.From domain to which the DMARC record applies, the "t" 
+   tag serves as a signal to the actor performing DMARC verification checks 
+   as to whether or not the domain owner wishes the assessment policy 
+   declared in the "p=", "sp=", and/or "np=" tags to actually be applied. This 
+   parameter does not affect the generation of DMARC reports.  Possible values 
+   are as follows:
 
     y:
-    :   A request that the actor performing the DMARC verification check not 
+    :  A request that the actor performing the DMARC verification check not 
     apply the policy, but instead apply any special handling rules it might have
     in place, such as rewriting the RFC5322.From header.  The domain owner is 
     currently testing its specified DMARC assessment policy.
 
     n:
-    :   The default, a request to apply the policy as specified to any
+    :  The default, a request to apply the policy as specified to any
     message that produces a DMARC "fail" result.
 
-
 v:
-:   Version (plain-text; REQUIRED).  Identifies the record retrieved
-    as a DMARC record.  It MUST have the value of "DMARC1".  The value
-    of this tag MUST match precisely; if it does not or it is absent,
-    the entire retrieved record MUST be ignored.  It MUST be the first
-    tag in the list.
+:  Version (plain-text; REQUIRED).  Identifies the record retrieved
+   as a DMARC record.  It MUST have the value of "DMARC1".  The value
+   of this tag MUST match precisely; if it does not or it is absent,
+   the entire retrieved record MUST be ignored.  It MUST be the first
+   tag in the list.
 
 A DMARC policy record MUST comply with the formal specification found
 in (#formal-definition) in that the "v" tag MUST be present and MUST
@@ -920,7 +906,7 @@ follows:
   dmarc-tag       = dmarc-request /
                     dmarc-test /
                     dmarc-psd /
-                    dmarc-srequest /
+                    dmarc-sprequest /
                     dmarc-nprequest /
                     dmarc-adkim /
                     dmarc-aspf /
@@ -942,7 +928,7 @@ follows:
 
   dmarc-psd       = "psd" *WSP "=" ( "y" / "n" )
 
-  dmarc-srequest  = "sp" *WSP "=" *WSP
+  dmarc-sprequest = "sp" *WSP "=" *WSP
                     ( "none" / "quarantine" / "reject" )
 
   dmarc-nprequest  = "np" *WSP "=" *WSP
@@ -978,10 +964,12 @@ DMARC mechanism.
 Because DMARC relies on SPF [@!RFC7208] and DKIM [@!RFC6376], in
 order to take full advantage of DMARC, a Domain Owner SHOULD first 
 ensure that SPF and DKIM authentication are properly configured. 
-The easiest first step here is to choose a domain to use as the 
-RFC5321.From domain (i.e., the Return-Path domain) for its mail,
+As a first step the Domain Owner SHOULD choose a domain to use as the 
+RFC5321.MailFrom domain (i.e., the Return-Path domain) for its mail,
 one that aligns with the Author Domain, and then publish an SPF
-policy in DNS for that domain.
+policy in DNS for that domain. The SPF record SHOULD be constructed
+at a minimum to ensure an SPF pass verdict for all known sources of
+mail for the RFC5321.MailFrom domain.
 
 ### Configure Sending System for DKIM Signing Using an Aligned Domain
 
@@ -991,7 +979,8 @@ both authentication mechanisms are in place in order to guard
 against failure of just one of them. The Domain Owner SHOULD choose
 a DKIM-Signing domain (i.e., the d= domain in the DKIM-Signature
 header) that aligns with the Author Domain and configure its system
-to sign using that domain.
+to sign using that domain, to include publishing a corresponding DKIM 
+public key in DNS.
 
 ### Setup a Mailbox to Receive Aggregate Reports
 
@@ -1004,11 +993,11 @@ on how mature the Domain Owner's DMARC rollout is, some of these
 sources could be legitimate ones that were overlooked during the 
 intial deployment of SPF and/or DKIM.
 
-Because the aggregate reports are XML documents, it is strongly
-advised that they be machine-parsed, so setting up a mailbox 
-involves more than just the physical creation of the mailbox. Many
-third-party services exist that will process DMARC aggregate reports,
-or the Domain Owner can create its own set of tools. No matter which
+Because the aggregate reports are XML documents, it is recommended
+that they be machine-parsed, so setting up a mailbox involves more 
+than just the physical creation of that mailbox. Many third-party 
+services exist that will process DMARC aggregate reports, or the 
+Domain Owner can create its own set of tools. No matter which
 method is chosen, the ability to parse these reports and consume
 the data contained in them will go a long way to ensuring a 
 successful deployment.
@@ -1017,8 +1006,8 @@ successful deployment.
 
 Once SPF, DKIM, and the aggregate reports mailbox are all in place,
 it's time to publish a DMARC record. For best results, Domain Owners
-SHOULD start with "p=none", with the rua tag containg the mailbox
-created in the previous step.
+SHOULD start with "p=none", with the rua tag containg a URI that
+references the mailbox created in the previous step.
 
 ### Collect and Analyze Reports and Adjust Authentication
 
@@ -1111,11 +1100,11 @@ The steps are as follows:
 5.  Conduct Identifier Alignment checks.  With authentication checks
     and policy discovery performed, the Mail Receiver checks to see
     if Authenticated Identifiers fall into alignment as described in
-    (#terminology).  If one or more of the Authenticated Identifiers align
-    with the RFC5322.From domain, the message is considered to pass
-    the DMARC mechanism check.  All other conditions (authentication
-    failures, identifier mismatches) are considered to be DMARC
-    mechanism check failures.
+    (#identifier-alignment-explained).  If one or more of the Authenticated 
+    Identifiers align with the RFC5322.From domain, the message is 
+    considered to pass the DMARC mechanism check.  All other conditions 
+    (authentication failures, identifier mismatches) are considered to be 
+    DMARC mechanism check failures.
 
 6.  Apply policy, if appropriate.  Emails that fail the DMARC mechanism 
     check are handled in accordance with the discovered DMARC policy of the
@@ -1178,7 +1167,7 @@ closed").
 Note: Because the PSD policy query comes after the Organizational
 Domain policy query, PSD policy is not used for Organizational
 domains that have published a DMARC policy.  Specifically, this is
-not a mechanism to provide feedback addresses (RUA/RUF) when an
+not a mechanism to provide feedback addresses (rua/ruf) when an
 Organizational Domain has declined to do so.
 
 ### Store Results of DMARC Processing {#store-results-of-dmarc-processing}
@@ -1203,8 +1192,8 @@ value signals to Mail Receivers, ones that can assist Mail Receivers
 with handling decisions for a message in ways that p= tag values of
 'none' cannot. 
 
-In order to ensure maximum usefulness for DMARC across the email
-ecosystem, then, Mail Receivers SHOULD generate and send aggregate
+Given the above, in order to ensure maximum usefulness for DMARC across 
+the email ecosystem, Mail Receivers SHOULD generate and send aggregate
 reports with a frequency of at least once every 24 hours.
 
 ##  Policy Enforcement Considerations {#policy-enforcement-considerations}
@@ -1321,7 +1310,7 @@ benefits of DNS caching.
 
 This protocol calls for rejection of a message during the SMTP
 session under certain circumstances.  This is preferable to
-generation of a Delivery Status Notification ([@RFC3464]), since
+generation of a Delivery Status Notification [@RFC3464], since
 fraudulent messages caught and rejected using DMARC would then result
 in annoying generation of such failure reports that go back to the
 RFC5321.MailFrom address.
@@ -1572,6 +1561,7 @@ various attacks, including but not limited to:
 The DMARC mechanism and its underlying technologies (SPF, DKIM)
 depend on the security of the DNS. Examples of how hostile parties can
 have an adverse impact on DNS traffic include:
+
 *  If they can snoop on DNS traffic, they can get an idea of who is 
    sending mail.
 
@@ -1672,10 +1662,9 @@ could reveal private information.
 # Technology Considerations {#technology-considerations}
 
 This section documents some design decisions that were made in the
-development of DMARC.  Specifically, addressed here are some
-suggestions that were considered but not included in the design.
-This text is included to explain why they were considered and not
-included in this version.
+development of DMARC.  Specifically addressed here are some
+suggestions that were considered but not included in the design,
+with explanatory text regarding the decision.
 
 ##  S/MIME {#s-mime}
 
@@ -1823,50 +1812,61 @@ direction of DMARC:
 
 ##  Organizational Domain Discovery Issues {#organizational-domain-discovery-issues}
 
-Although protocols like ADSP are useful for "protecting" a specific
-domain name, they are not helpful at protecting subdomains.  If one
-wished to protect "example.com" by requiring via ADSP that all mail
-bearing an RFC5322.From domain of "example.com" be signed, this would
-"protect" that domain; however, one could then craft an email whose
-RFC5322.From domain is "security.example.com", and ADSP would not
-provide any protection.  One could use a DNS wildcard, but this can
-undesirably interfere with other DNS activity; one could add ADSP
-records as fraudulent domains are discovered, but this solution does
-not scale and is a purely reactive measure against abuse.
+An earlier informational version of the DMARC protocol [@!RFC7489]
+noted that the DNS does not provide a method by which the "domain of record", 
+or the domain that was actually registered with a domain registrar, can
+be determined given an arbitrary domain name. That version further mentioned
+suggestions that have been made that attempt to glean such information from 
+SOA or NS resource records, but these too are not fully reliable, as the 
+partitioning of the DNS is not always done at administrative boundaries. 
 
-The DNS does not provide a method by which the "domain of record", or
-the domain that was actually registered with a domain registrar, can
-be determined given an arbitrary domain name.  Suggestions have been
-made that attempt to glean such information from SOA or NS resource
-records, but these too are not fully reliable, as the partitioning of
-the DNS is not always done at administrative boundaries.
+That previous version posited that one could "climb the tree" to find the
+Organizational Domain, but expressed concern that an attacker could exploit 
+this for a denial-of-service attack through sending a high number of messages 
+each with a relatively large number of nonsense labels, causing a Mail Receiver 
+to perform a large number of DNS queries in search of a policy record. This 
+version defines a method for performing a DNS Tree Walk, described in (#dns-tree-walk), 
+and further mitigates the risk of the denial-of-service attack by expressly limiting
+the number of DNS queries to execute regardless of the number of labels in the domain
+name.
 
-When seeking domain-specific policy based on an arbitrary domain
-name, one could "climb the tree", dropping labels off the left end of
-the name until the root is reached or a policy is discovered, but
-then one could craft a name that has a large number of nonsense
-labels; this would cause a Mail Receiver to attempt a large number of
-queries in search of a policy record.  Sending many such messages
-constitutes an amplified denial-of-service attack.
+As a matter of historical record, the method for finding the Organizational
+Domain described in [@!RFC7489] is preserved here:
 
-The Organizational Domain mechanism is a necessary component to the
-goals of DMARC.  The method described in (#determining-the-organizational-domain) is far from
-perfect but serves this purpose reasonably well without adding undue
-burden or semantics to the DNS.  If a method is created to do so that
-is more reliable and secure than the use of a public suffix list,
-DMARC should be amended to use that method as soon as it is generally
-available.
+   1.  Acquire a "public suffix" list (PSL), i.e., a list of DNS domain 
+       names reserved for registrations.  Some country Top-Level Domains
+       (TLDs) make specific registration requirements, e.g., the United
+       Kingdom places company registrations under ".co.uk"; other TLDs
+       such as ".com" appear in the IANA registry of top-level DNS
+       domains.  A PSL is the union of all of these. 
 
-###  Public Suffix Lists {#public-suffix-lists}
+       A PSL can be obtained from various sources. The most common one 
+       is maintained by the Mozilla Foundation and made public at
+       <http://publicsuffix.org>.  License terms governing the use of that
+       list are available at that URI.
 
-A public suffix list for the purposes of determining the
-Organizational Domain can be obtained from various sources.  The most
-common one is maintained by the Mozilla Foundation and made public at
-<http://publicsuffix.org>.  License terms governing the use of that
-list are available at that URI.
+       Note that if operators use a variety of public suffix lists,
+       interoperability will be difficult or impossible to guarantee.
+       
+   2.  Break the subject DNS domain name into a set of "n" ordered
+       labels.  Number these labels from right to left; e.g., for
+       "example.com", "com" would be label 1 and "example" would be
+       label 2.
 
-Note that if operators use a variety of public suffix lists,
-interoperability will be difficult or impossible to guarantee.
+   3.  Search the public suffix list for the name that matches the
+       largest number of labels found in the subject DNS domain.  Let
+       that number be "x".
+
+   4.  Construct a new DNS domain name using the name that matched from
+       the public suffix list and prefixing to it the "x+1"th label from
+       the subject domain.  This new name is the Organizational Domain.
+
+   Thus, since "com" is an IANA-registered TLD, a subject domain of
+   "a.b.c.d.example.com" would have an Organizational Domain of
+   "example.com".
+
+   The process of determining a suffix is currently a heuristic one.  No
+   list is guaranteed to be accurate or current.
 
 ## Removal of the "pct" Tag {#removal-of-the-pct-tag}
 
@@ -1878,16 +1878,15 @@ owners with a method to gradually change their preferred assessment policy
 by requesting the stricter treatment for just a percentage of messages
 that produced DMARC results of "fail".
 
-Operational experience and mathematics (specifically the Probability Mass
-Function as applied to Binomial Distributions) showed that the pct tag 
-was usually not accurately applied, unless the value specified was either "0"
-or "100" (the default), and the inaccuracies with other values varied widely
-from implementation to implementation. The default value was easily implemented, 
-as it required no special processing on the part of the message receiver, while 
-the value of "0" took on unintended significance as a value used by some 
-intermediaries and mailbox providers as an indicator to deviate from 
-standard handling of the message, usually by rewriting the RFC5322.From
-header in an effort to avoid DMARC failures downstream.
+Operational experience showed that the pct tag was usually not accurately 
+applied, unless the value specified was either "0" or "100" (the default), 
+and the inaccuracies with other values varied widely from implementation to 
+implementation. The default value was easily implemented, as it required no 
+special processing on the part of the message receiver, while the value 
+of "0" took on unintended significance as a value used by some intermediaries 
+and mailbox providers as an indicator to deviate from standard handling of 
+the message, usually by rewriting the RFC5322.From header in an effort to 
+avoid DMARC failures downstream.
 
 These custom actions when the pct= tag was set to "0" proved valuable to the 
 email community. In particular, header rewriting by an intermediary meant 
@@ -2087,13 +2086,13 @@ authentication failures.  In order to diagnose these intermittent
 problems, they wish to request per-message failure reports when
 authentication failures occur.
 
-Not all Receivers will honor such a request, but the Domain Owner
+Not all Mail Receivers will honor such a request, but the Domain Owner
 feels that any reports it does receive will be helpful enough to
 justify publishing this record.  The default per-message report
 format ([@!RFC6591]) meets the Domain Owner's needs in this scenario.
 
 The Domain Owner accomplishes this by adding the following to its
-policy record from (#domain-owner-example):
+policy record from (#entire-domain-monitoring-only):
 
 *  Per-message failure reports should be sent via email to the
    address "auth-reports@example.com"
@@ -2125,7 +2124,7 @@ might create an entry like the following in the appropriate zone file
 
 The Domain Owner from the previous example is maintaining the same
 policy but now wishes to have a third party receive and process the
-per-message failure reports.  Again, not all Receivers will honor
+per-message failure reports.  Again, not all Mail Receivers will honor
 this request, but those that do may implement additional checks to
 verify that the third party wishes to receive the failure reports
 for this domain.
@@ -2161,7 +2160,7 @@ might create an entry like the following in the appropriate zone file
 
 Because the address used in the "ruf" tag is outside the
 Organizational Domain in which this record is published, conforming
-Receivers will implement additional checks as described in Section 3 of
+Mail Receivers will implement additional checks as described in Section 3 of
 [@!DMARC-Aggregate-Reporting].  In order to pass these additional
 checks, the third party will need to publish an additional DNS record
 as follows:
@@ -2241,7 +2240,7 @@ line but is wrapped here for publication):
 ~~~
   % dig +short TXT _dmarc.test.example.com
   "v=DMARC1; p=quarantine; rua=mailto:dmarc-feedback@example.com,
-   mailto:tld-test@thirdparty.example.net t=y"
+   mailto:tld-test@thirdparty.example.net; t=y"
 ~~~
 
 To publish such a record, the DNS administrator for the Domain Owner
@@ -2263,7 +2262,8 @@ the subdomain is properly authenticating and passing DMARC checks, then
 the Domain Owner can update the policy record to indicate that it considers
 authentication failures to be a clear indication that use of the subdomain
 is not valid. It would do this by altering the DNS record to advise 
-receivers of its position on such messages ("p=reject").
+receivers of its position on such messages ("p=reject") and removing the
+testing flag ("t=y").
 
 After alteration, the DMARC policy record might look like this when retrieved
 using a common command-line tool (the output shown would appear on a single
@@ -2295,7 +2295,7 @@ SPF and DKIM, and possess the ability to collect relevant information
 from various email-processing stages to provide feedback to Domain
 Owners (possibly via Report Receivers).
 
-##  Processing of SMTP Time {#processing-of-smtp-time}
+###  SMTP Session Example {#smtp-session-example}
 
 An optimal DMARC-enabled Mail Receiver performs authentication and
 Identifier Alignment checking during the SMTP [@!RFC5321] conversation.
@@ -2338,12 +2338,12 @@ the "reject" policy that is requested to be applied to email that fails
 to pass the DMARC check.
 
 If no Authenticated Identifiers align with the Author Domain, then
-the Mail Receiver applies the DMARC-record-specified policy.
-However, before this action is taken, the Mail Receiver can consult
-external information to override the Domain Owner's Assessment Policy.  
-For example, if the Mail Receiver knows that this particular email
-came from a known and trusted forwarder (that happens to break both
-SPF and DKIM), then the Mail Receiver may choose to ignore the Domain
+the Mail Receiver applies the DMARC-record-specified policy. However,
+before this action is taken, the Mail Receiver can consult external
+information to override the Domain Owner's Assessment Policy. For
+example, if the Mail Receiver knows that this particular email came
+from a known and trusted forwarder (that happens to break both SPF
+and DKIM), then the Mail Receiver may choose to ignore the Domain
 Owner's policy.
 
 The Mail Receiver is now ready to reply to the DATA command.  If the
@@ -2399,162 +2399,6 @@ across uncovered email sources, if the mail that is failing the checks
 was generated by or on behalf of the Domain Owner.  Data regarding
 failing authentication checks can also allow the Domain Owner to
 come to an understanding of how its domain is being misused.
-
-(Aggregate report example should be moved to [@!DMARC-Aggregate-Reporting])
-
-# Change Log
-
-## January 5, 2021 
-
-### Ticket 80 - DMARCbis SHould Have Clear and Concise Defintion of DMARC
-* Updated text for Abstract and Introduction sections.
-* Diffs are recorded here - https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/1/files
-
-## February 4, 2021 
-
-### Ticket 1 - SPF RFC 4408 vs 7208
-* Some rearranging of text in the "SPF-Authenticated Identifiers" section
-* Clarification of the term "in alignment" in that same section
-* Diffs are here - https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/3/files
-
-## February 10, 2021
-
-### Ticket 84 - Remove Erroneous References to RFC3986
-* Several references to RFC3986 changed to RFC7208
-* Diffs are here - https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/4/files
-
-## March 1, 2021
-
-### Design Team Work Begins
-* Added change log section to document
-
-## March 8, 2021
-
-### Removed E. Gustafsson as editor
-* He withdrew as editor after a job change.
-
-### Ticket 3 - Two tiny nits
-* Changes to wording in section 6.6.2, Determine Handling Policy, steps
-  3 and 4. 
-* New text documented here - https://trac.ietf.org/trac/dmarc/ticket/3#comment:6
-* No change to section 6.6.3, Policy Discovery; ticket seems to pre-date
-  current text, which appears to have answered the concern raised.
-
-### Ticket 4 - Definition of "fo" parameter
-* Changes to wording in section 6.3, to bring clarity to use of colon-separated
-  list as possible value to "fo"
-* New text documented here - https://trac.ietf.org/trac/dmarc/ticket/4#comment:4
-
-## March 16, 2021
-
-### Ticket 7 - ABNF for dmarc-record is slightly wrong
-* New text documented here - https://trac.ietf.org/trac/dmarc/ticket/7
-
-### Ticket 26 - ABNF for pct allows "999"
-* Updated ABNF for dmarc-percent
-* New text documented here - https://trac.ietf.org/trac/dmarc/ticket/26#comment:6
-* Ticket 47, Remove pct= tag, rendered change obsolete
-
-## March 23, 2021
-
-### Ticket 75 - Using wording alternatives to 'disposition', 'dispose', and the like
-* Changed disposition/dispose to "handling"
-* Diffs documented here - https://trac.ietf.org/trac/dmarc/ticket/75#comment:3
-
-### Ticket 72 - Remove absolute requirement for p= tag in DMARC record
-* Changed from REQUIRED to RECOMMENDED, noted default with forward reference to discussion
-* Diffs documented here - https://trac.ietf.org/trac/dmarc/ticket/72#comment:3
-
-## March 29, 2021
-
-### Ticket 54 - Remove or expand limits on number of recipients per report
-* Removed limit
-* Diffs documented here - https://trac.ietf.org/trac/dmarc/ticket/54#comment:5
-
-## April 12, 2021
-### Ticket 50 - Remove ri= tag
-* Updated text to recommend against its usage, a la the ptr mechanism in RFC 7208
-* Diffs documented here - https://trac.ietf.org/trac/dmarc/ticket/50#comment:5
-
-### Ticket 66 - Define what it means to have implemented DMARC
-* Proposed new text (taken straight from https://trac.ietf.org/trac/dmarc/ticket/66
-  as replacement for current text in "Minimum Implemenatations"
-
-### Ticket 96 - Tweaks to Abstract and Introduction
-* Changed phrase in Abstract to "an email author's domain name"
-* Changed phrase in Introduction to "reports about email use of the domain name"
-
-## April 13, 2021
-### Ticket 53 - Remove reporting message size chunking
-* Proposed text to remove all references to message size chunking
-* Data demonstrating lack of use of feature entered into ticket -
-  https://trac.ietf.org/trac/dmarc/ticket/53#comment:4
-
-### Ticket 52 - Remove strict alignment (and adkim and aspf tags)
-* Proposed text to remove all references to strict alignment
-* Data demonstrating lack of use of feature entered into ticket -
-  https://trac.ietf.org/trac/dmarc/ticket/52#comment:2
-
-### Ticket 47 - Remove pct= tag
-* Proposed text to remove all references to pct and message sampling
-* Data demonstrating lack of use of feature entered into ticket - 
-  https://trac.ietf.org/trac/dmarc/ticket/47#comment:4
-
-### Ticket 2 - Flow of operations text in dmarc-base
-* Update ASCII Art
-* Proposed text to replace description of ASCII Art
-* Proposed text to update Domain Owner Actions section
-
-## April 14, 2021
-### Ticket 107 - DMARCbis should take a stand on multi-valued From fields
-* Proposed text that limits processing to only those times when all domains
-  are the same.
-
-### Ticket 82 - Deprecate rf= and maybe fo= tag
-* Proposed text to deprecate rf= tag, while leaving fo= tag as is
-
-### Ticket 85 - Proposed change to wording describing 'p' tag and values
-* The language expressing the semantics is proposed to be changed to be, 
-  in a sense, egocentric. How do I, the domain owner feel about (assess)
-  the meaning of a DMARC failure?
-
-## April 15, 2021
-### Ticket 86 - A-R results for DMARC
-* Proposed text to add for polrec.p and polrec.domain methods for registry
-  update.
-* Did not include polrec.pct due to proposal to remove pct tag (Ticket 47)
-
-### Ticket 62 - Make aggregate reporting a normative MUST
-* Proposed text to do just that in Mail Receiver Actions, section
-  titled "Send Aggregate Reports"
-
-## April 19, 2021
-### Ticket 109 - Sanity Check DMARCbis Document
-* Updated document to remove all "original text"/"proposed text" couplets
-  in favor of one (hopefully coherent) document full of proposed text
-  changes.
-* Noted which tickets were the cause of whatever rfcdiff output will show
-  in tracker
-
-## April 20, 2021
-### Ticket 108 - Changes to DMARCbis for PSD
-* Incorporating requests for changes to DMARCbis made in text of
-  "Experimental DMARC Extension for Public Suffix Domains"
-  (https://datatracker.ietf.org/doc/draft-ietf-dmarc-psd/)
-
-## April 22, 2021
-### Ticket 104 - Update the Security Considerations section 11.3 on DNS
-* Updated text. Diffs are here - https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis/pull/31/files
-
-## June 16, 2021
-### Publication of draft-ietf-dmarc-dmarcbis-02
-* Includes final resolution for tickets 4, 47, 50, 52, 53, 54, and 82
-
-## August 12, 2021
-### Publication of draft-ietf-dmarc-dmarcbis-03
-* Removal of "pct" tag
-* Addition of "t" tag
-* Rearranging of some text and formatting for better readability and consistency.
 
 {numbered="false"}
 # Acknowledgements {#acknowledgements}

--- a/draft-ietf-dmarc-dmarcbis.md
+++ b/draft-ietf-dmarc-dmarcbis.md
@@ -41,7 +41,7 @@ Reporting, and Conformance (DMARC) protocol.
 
 DMARC permits the owner of an email author's domain name to enable
 verification of the domain's use, to indicate the Domain Owner's or
-Public Suffix Operator's severity of concern regarding failed 
+Public Suffix Operator's message handling preference regarding failed 
 verification, and to request reports about use of the domain name. 
 Mail receiving organizations can use this information when evaluating 
 handling choices for incoming mail.
@@ -59,37 +59,31 @@ https://github.com/ietf-wg-dmarc/draft-ietf-dmarc-dmarcbis
 Abusive email often includes unauthorized and deceptive use of a
 domain name in the RFC5322.From header field. The domain typically
 belongs to an organization expected to be known to - and presumably
-trusted by - the recipient. The Sender Policy Framework (SPF) ([@!RFC7208])
-and DomainKeys Identified Mail (DKIM) ([@!RFC6376]) protocols provide 
+trusted by - the recipient. The Sender Policy Framework (SPF) [@!RFC7208]
+and DomainKeys Identified Mail (DKIM) [@!RFC6376] protocols provide 
 domain-level authentication but are not directly associated with the 
-RFC5322.From domain. DMARC leverages them, so that Domain Owners 
-publish a DNS record indicating their RFC5322.From field:
+RFC5322.From domain. DMARC leverages them, and provides a method for 
+Domain Owners to publish a DNS record describing the email authentication
+policies for the RFC5322.From domain and to request a specific handling
+for messages using that domain that fail authentication checks.
 
-* Email authentication policies
-* Level of concern for mail that fails authentication checks
-* Desire for reports about email use of the domain name
-
-DMARC can cover non-existent sub-domains, below the "Organizational 
-Domain", as well as domains at the top of the name hierarchy, 
-controlled by Public Suffix Operators (PSOs).
-
-As with SPF and DKIM, DMARC classes results as "pass" or "fail". A
-pass from either SPF or DKIM is required. Depending on the stated 
-DMARC policy, the passed domain must be "aligned" with the RFC5322.From 
-domain in one of two modes - "relaxed" or "strict".  Domains are said 
-to be "in relaxed alignment" if they have the same Organizational Domain, 
-which is at the top of the domain hierarchy, while having the same 
-administrative authority as the RFC5322.From domain, while domains are
-"in strict alignment" if and only if they are identical.
+As with SPF and DKIM, DMARC classes results as "pass" or "fail". In order
+to get a DMARC result of "pass", a pass from either SPF or DKIM is required. 
+In addition, the passed domain must be "aligned" with the RFC5322.From domain 
+in one of two modes - "relaxed" or "strict". The mode is expressed in the 
+domain's DMARC policy record. Domains are said to be "in relaxed alignment" 
+if they have the same "Organizational Domain", which is the domain at the 
+top of the domain hierarchy for the RFC5322.From domain while having the 
+same administrative authority as the RFC5322.From domain. Domains are "in 
+strict alignment" if and only if they are identical.
 
 A DMARC pass indicates only that the RFC5322.From domain has been
-authenticated for that message; authentication does not carry an 
+authenticated for that message. Authentication does not carry an 
 explicit or implicit value assertion about that message or about 
-the Domain Owner. Indeed, a mail-receiving organization that performs 
-DMARC verification can choose to follow the Domain Owner's requested 
-disposition for authentication failures, and to inform the Domain 
-Owner of the mail handling decision for that message. It also might 
-choose different actions.
+the Domain Owner. Furthermore, a mail-receiving organization that performs 
+DMARC verification can choose to honor the Domain Owner's requested 
+message handling for authentication failures, but it is under no
+obligation to do so; it might choose different actions entirely.
 
 For a mail-receiving organization supporting DMARC, a message that
 passes verification is part of a message stream that is reliably
@@ -100,11 +94,20 @@ in the RFC5322.From field.  A message that fails this verification
 is not necessarily associated with the Domain Owner's domain and its 
 reputation.
 
+DMARC policy records can also cover non-existent sub-domains, below the 
+"Organizational Domain", as well as domains at the top of the name hierarchy, 
+controlled by Public Suffix Operators (PSOs).
+
 DMARC, in the associated [@!DMARC-Aggregate-Reporting] and [@!DMARC-Failure-Reporting]
 documents, also specifies a reporting framework. Using it, a mail-receiving
 domain can generate regular reports about messages that claim to be from
 a domain publishing DMARC policies, sending those reports to the address(es) 
-specified by the Domain Owner.
+specified by the Domain Owner in the latter's DMARC policy record. Domain
+Owners can use these reports, especially the aggregate reports, to identify
+not only sources of mail attempting to fraudulently use their domain, but also
+(and perhaps more importantly) gaps in their own authentication practices. However,
+as with honoring the Domain Owner's stated mail handling preference, a mail-receiving
+organization supporting DMARC is under no obligation to send requested reports.
 
 Use of DMARC creates some interoperability challenges that require due 
 consideration before deployment, particularly with configurations that
@@ -120,9 +123,9 @@ documented as out of scope.
 
 DMARC has the following high-level goals:
 
-*  Allow Domain Owners and PSOs to assert their severity of concern for
-   authentication failures for messages purporting to have
-   authorship within the domain.
+*  Allow Domain Owners and PSOs to assert their desired message handling 
+   for authentication failures for messages purporting to have authorship 
+   within the domain.
 
 *  Allow Domain Owners and PSOs to verify their authentication deployment.
 
@@ -139,25 +142,25 @@ DMARC has the following high-level goals:
 Several topics and issues are specifically out of scope for this
 work.  These include the following:
 
-*  different treatment of messages that are not authenticated versus
+*  Different treatment of messages that are not authenticated versus
    those that fail authentication;
 
-*  evaluation of anything other than RFC5322.From header field;
+*  Evaluation of anything other than RFC5322.From header field;
 
-*  multiple reporting formats;
+*  Multiple reporting formats;
 
-*  publishing policy other than via the DNS;
+*  Publishing policy other than via the DNS;
 
-*  reporting or otherwise evaluating other than the last-hop IP
+*  Reporting or otherwise evaluating other than the last-hop IP
    address;
 
-*  attacks in the From: header field, also known as "display name"
+*  Attacks in the From: header field, also known as "display name"
    attacks;
 
-*  authentication of entities other than domains, since DMARC is
+*  Authentication of entities other than domains, since DMARC is
    built upon SPF and DKIM, which authenticate domains; and
 
-*  content analysis.
+*  Content analysis.
 
 ##  Scalability {#scalability}
 
@@ -200,7 +203,7 @@ This section defines terms used in the rest of the document.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 [@!RFC2119] [@RFC8174]
+document are to be interpreted as described in BCP 14 [@!RFC2119] and [@RFC8174]
 when, and only when, they appear in all capitals, as shown here.
 
 Readers are encouraged to be familiar with the contents of
@@ -213,17 +216,21 @@ another role.  This document does not address the distinctions among
 such roles; the reader is encouraged to become familiar with that
 material before continuing.
 
-## Authenticated Identifiers {#authenticated-identifiers}
+## Defintions {#definitions}
+
+The following sections define terms used in this document.
+
+### Authenticated Identifiers {#authenticated-identifiers}
 
 Domain-level identifiers that are verified using authentication technologies
 are referred to as "Authenticated Identifiers".  See (#authenication-mechanisms)
 for details about the supported mechanisms.
 
-## Author Domain {#author-domain}
+### Author Domain {#author-domain}
 
 The domain name of the apparent author, as extracted from the From: header field.
 
-## Domain Owner {#domain-owner}
+### Domain Owner {#domain-owner}
 
 An entity or organization that owns a DNS domain.  The
 term "owns" here indicates that the entity or organization being
@@ -236,60 +243,58 @@ Management Domain as defined in [@RFC5598].  It can also refer
 to delegates, such as Report Receivers, when those are outside of
 their immediate management domain.
 
-## Identifier Alignment {#identifier-alignment}
+### Identifier Alignment {#identifier-alignment}
 
 When the domain in the address in the From: header field has the 
 same Organizational Domain as a domain verified by SPF or DKIM 
 (or both), it has Identifier Alignment. (see below)
 
-## Longest PSD {#longest-psd}
+### Longest PSD {#longest-psd}
 
 The term Longest PSD is defined in [@!RFC9091].
 
-## Mail Receiver {#mail-receiver}
+### Mail Receiver {#mail-receiver}
 
 The entity or organization that receives and processes email.  
 Mail Receivers operate one or more Internet-facing Mail Transport 
 Agents (MTAs).
 
-## Non-existent Domains {#non-existent-domains}
+### Non-existent Domains {#non-existent-domains}
 
 For DMARC purposes, a non-existent domain is a domain for which there
 is an NXDOMAIN or NODATA response for A, AAAA, and MX records.  This
 is a broader definition than that in [@RFC8020].
 
-## Organizational Domain {#organizational-domain}
+### Organizational Domain {#organizational-domain}
 
-The domain that was registered with a domain name registrar.  In 
-the absence of more accurate methods, heuristics are used to determine 
-this, since it is not always the case that the registered domain name 
-is simply a top-level DNS domain plus one component (e.g., "example.com",
-where "com" is a top-level domain).  The Organizational Domain is 
-determined by applying the algorithm found in 
+The Organizational Domain is typically a domain that was registered with 
+a domain name registrar.  More formally, it is a Public Suffix Domain
+plus one label. The Organizational Domain for the domain in the 
+RFC5322.From domain is determined by applying the algorithm found in 
 (#determining-the-organizational-domain).
 
-## Public Suffix Domain (PSD) {#public-suffix-domain}
+### Public Suffix Domain (PSD) {#public-suffix-domain}
 
 The term Public Suffix Domain is defined in [@!RFC9091].
 
-## Public Suffix Operator (PSO) {#public-suffix-operator}
+### Public Suffix Operator (PSO) {#public-suffix-operator}
 
 The term Public Suffix Operator is defined in [@!RFC9091].
 
-## PSO Controlled Domain Names {#pso-controlled-domain-names}
+### PSO Controlled Domain Names {#pso-controlled-domain-names}
 
 The term PSO Controlled Domain Names is defined in [@!RFC9091].
 
-## Report Receiver {#report-receiver}
+### Report Receiver {#report-receiver}
 
-An operator that receives reports from another operator
-implementing the reporting mechanisms described in this document 
-and/or the documents [@!DMARC-Aggregate-Reporting] and [@!DMARC-Failure-Reporting].
-Such an operator might be receiving reports about messages related
-to a domain for which it is the Domain Owner or PSO, or reports about
-messages related to another operator's domain.  This term applies
-collectively to the system components that receive and process these
-reports and the organizations that operate them.
+An operator that receives reports from another operator implementing the 
+reporting mechanisms described in this document and/or the documents 
+[@!DMARC-Aggregate-Reporting] and [@!DMARC-Failure-Reporting]. Such an 
+operator might be receiving reports about messages related to a domain 
+for which it is the Domain Owner or PSO, or reports about messages related 
+to another operator's domain.  This term applies collectively to the 
+system components that receive and process these reports and the organizations 
+that operate them.
 
 ##  More on Identifier Alignment {#more-on-identifier-alignment}
 
@@ -352,9 +357,8 @@ In strict mode, this test would fail because the d= domain does not
 exactly match the RFC5322.From domain.
 
 However, a DKIM signature bearing a value of "d=com" would never allow 
-an "in alignment" result, as "com" should appear on all public suffix 
-lists (see (#public-suffix-lists)) and therefore cannot be an Organizational 
-Domain.
+an "in alignment" result, as "com" should be identified as a PSD and 
+therefore cannot be an Organizational Domain.
 
 Note that a single email can contain multiple DKIM signatures, and it
 is considered to produce a DMARC "pass" result if any DKIM signature 
@@ -602,11 +606,11 @@ used by Mail Receivers to inform their message handling decisions.
 
 A Domain Owner or PSO advertises DMARC participation of one or more of its
 domains by adding a DNS TXT record (described in (#dmarc-policy-record)) to
-those domains.  In doing so, Domain Owners and PSOs indicate their severity of
-concern regarding failed authentication for email messages making use
+those domains.  In doing so, Domain Owners and PSOs indicate their handling
+preference regarding failed authentication for email messages making use
 of their domain in the RFC5322.From header field as well as the provision
 of feedback about those messages. Mail Receivers in turn can take into
-account the Domain Owner's severity of concern when making handling 
+account the Domain Owner's stated preference when making handling 
 decisions about email messages that fail DMARC authentication checks.
 
 A Domain Owner or PSO may choose not to participate in DMARC evaluation by
@@ -735,9 +739,9 @@ The valid values and their meanings are:
 
 np:
 :   Domain Owner Assessment Policy for non-existent subdomains
-    (plain-text; OPTIONAL).  Indicates the severity of concern the 
-    Domain Owner or PSO has for mail using non-existent subdomains of the
-    domain queried. It applies only to non-existent subdomains of
+    (plain-text; OPTIONAL).  Indicates the message handling preference 
+    that the Domain Owner or PSO has for mail using non-existent subdomains 
+    of the domain queried. It applies only to non-existent subdomains of
     the domain queried and not to either existing subdomains or 
     the domain itself.  Its syntax is identical to that of the "p" 
     tag defined below.  If the "np" tag is absent, the policy 
@@ -750,8 +754,8 @@ np:
 
 p: 
 :   Domain Owner Assessment Policy (plain-text; RECOMMENDED for policy
-    records). Indicates the severity of concern the Domain Owner or PSO
-    has for mail using its domain but not passing DMARC verification.
+    records). Indicates the message handling preference the Domain Owner or 
+    PSO has for mail using its domain but not passing DMARC verification.
     Policy applies to the domain queried and to subdomains, unless
     subdomain policy is explicitly described using the "sp" or "np" tags.
     This tag is mandatory for policy records only, but not for third-party
@@ -815,9 +819,9 @@ additional considerations.
 
 sp:
 :   Domain Owner Assessment Policy for all subdomains (plain-text;
-OPTIONAL). Indicates the severity of concern the Domain Owner or PSO has
-for mail using an existing subdomain of the domain queried but not
-passing DMARC verification.  It applies only to subdomains of
+OPTIONAL). Indicates the message handling preference the Domain Owner 
+or PSO has for mail using an existing subdomain of the domain queried 
+but not passing DMARC verification.  It applies only to subdomains of
 the domain queried and not to the domain itself.  Its syntax is
 identical to that of the "p" tag defined above.  If both the "sp"
 tag is absent and the "np" tag is either absent or not applicable, 
@@ -1196,8 +1200,8 @@ mailstreams making use of its domain in email, to include not only
 illegitimate uses but also, and perhaps more importantly, all 
 legitimate uses. Domain Owners can use aggregate reports to ensure
 that all legitimate uses of their domain for sending email are 
-properly authenticated, and once they are, increase the severity of
-concern expressed in the p= tag in their DMARC policy records from
+properly authenticated, and once they are, express a stricter message
+handling preference in the p= tag in their DMARC policy records from
 none to quarantine to reject, if appropriate. In turn, DMARC policy
 records with p= tag values of 'quarantine' or 'reject' are higher
 value signals to Mail Receivers, ones that can assist Mail Receivers
@@ -2198,7 +2202,7 @@ for the full details of this mechanism.
 
 The Domain Owner has implemented SPF and DKIM in a subdomain used for
 pre-production testing of messaging services.  It now wishes to express
-a severity of concern for messages from this subdomain that fail to 
+a handling preference for messages from this subdomain that fail to 
 authenticate to indicate to participating receivers that use of this
 domain is not valid.
 

--- a/draft-ietf-dmarc-dmarcbis.md
+++ b/draft-ietf-dmarc-dmarcbis.md
@@ -1235,54 +1235,6 @@ domains is desirable and useful, just as it is for org-level DMARC
 operators.  See Section 4 of [@!RFC9091] for discussion of
 Privacy Considerations for PSD DMARC
 
-#  Minimum Implementations
-
-Domain owners, mediators, and mail receivers can all claim to
-implement DMARC, but what that means will depend on their role in the
-transmission of mail. To remove any ambiguity from the claims, this
-document specifies the following minimum criteria that must be met
-for each agent to rightly claim to be "implementing DMARC".
-
-Domain Owner: To implement DMARC, a Domain Owner MUST configure its
-domain to convey its concern that unauthenticated mail be rejected 
-or at least treated with suspicion. Furthermore, the Domain Owner MUST
-actively solicit aggregate feedback reports regarding mail using its
-domain. This means that it MUST publish a policy record that:
-
-* Has a p tag with a value of 'quarantine' or 'reject'
-* Has a rua tag with at least one valid URI
-* If applicable, has an sp tag with a value of 'quarantine' or
-  'reject'
-* If desired, has an np tag with a value of 'quarantine' or
-  'reject'
-
-While 'none' is a syntactically valid value for both p, sp, and np
-tags, the practical value of any of those tags being 'none' means 
-that the Domain Owner is still gathering information about mail 
-flows for the domain or sub-domains. It is not yet ready to commit
-to conveying a severity of concern for unauthenticated email using
-its domain.
-
-Mediator: To implement DMARC, a mediator MUST do the following before 
-passing the message to the next hop or rejecting it as appropriate:
-
-* Perform DMARC verification checks on inbound mail
-* Perform verification on any authentication checks recorded by
-  previous mediators.
-* Record the results of its authentication checks in message 
-  headers for consumption by later hosts.
-
-Mail Receiver: To implement DMARC, a mail receiver MUST do the
-following:
-
-* Perform DMARC verification checks on inbound mail
-* Perform verification checks on any authentication check results 
-  recorded by mediators that handled the message prior to its
-  reaching the Mail Receiver.
-* Send aggregate reports to Domain Owners at least every 24 hours
-  when a minimum of 100 messages with that domain in the RFC5322.From
-  header field have been seen during the reporting period
-
 #   Other Topics {#other-topics}
 
 This section discusses some topics regarding choices made in the


### PR DESCRIPTION
Here is a summary of the major differences between this revision and draft-ietf-dmarc-dmarcbis-03:

- A 'psd' tag is proposed, with values of 'y' or 'n' (default is 'n'). The purpose of this tag is for Public Suffix Domains to announce themselves as PSDs in their DMARC record, an idea that was discussed on-list in the thread with the subject "Organizational Alignment Options". Thread starts here - https://mailarchive.ietf.org/arch/msg/dmarc/W07Sqvw6fm1VWD4VnNyJOK9GlGY/ - and it's option four in the list in that message.
- The DNS Tree Walk is introduced, using text proposed by Scott Kitterman here - https://mailarchive.ietf.org/arch/msg/dmarc/iOuQzCPlD99dxqt8_q-9C1gl24o/ - and the tree walk is recommended as the method to be used both for policy discovery and for identifying the Organizational Domain. The old method for discovering the Org Domain is preserved in Appendix A.
- Several existing sections have been re-worked, shifting the order of paragraphs to make the document flow better in my opinion, and/or altering the hierarchy of sections, making some sub-sections of others where previously they were peers, and/or wordsmithing here and there. There was no intent to change the meaning of the text in question; these changes were made in the interests of improved clarity and consistency of phrasing.
- The change log (Appendix C) has been removed, because even though there are only two new ideas introduced, there is enough shifting of text to make this revision effectively a reboot. 

The point here is that I think this is a good baseline rev to use to re-focus on-list discussion and move forward with our core work to update the DMARC protocol. 
