### PR TITLE
More fixes to ABNF and a few typos

### DIFF
--- a/draft-ietf-dmarc-dmarcbis.md
+++ b/draft-ietf-dmarc-dmarcbis.md
@@ -957,7 +957,7 @@ The generic steps for a DNS Tree Walk are as follows:
 2. Records that do not start with a "v" tag that identifies the current
    version of DMARC are discarded. If multiple DMARC Policy Records are 
    returned, they are all discarded. If a single record remains and it 
-   contains a "psd=n" tag or "psd=y" tag, stop.
+   contains a "psd=n" or "psd=y" tag, stop.
 
 3. Break the subject DNS domain name into a set of ordered labels. Assign
    the count of labels to "x", and number the labels from right to left; e.g.,

--- a/draft-ietf-dmarc-dmarcbis.md
+++ b/draft-ietf-dmarc-dmarcbis.md
@@ -1764,7 +1764,7 @@ sending aggregate reports and failure reports are addressed in
 Aggregate reports may, particularly for small organizations, provide some
 limited insight into email sending patterns.  As an example, in a small
 organization, an aggregate report from a particular domain may be sufficient
-to make the report receiver aware of sensitive personal or business
+to make the Report Consumer aware of sensitive personal or business
 information.  If setting an "rua" tag in a DMARC Policy Record, the reporting
 address needs controls appropriate to the organizational requirements to
 mitigate any risk associated with receiving and handling reports.

--- a/draft-ietf-dmarc-dmarcbis.md
+++ b/draft-ietf-dmarc-dmarcbis.md
@@ -820,19 +820,12 @@ and [@!RFC7405], is as follows:
 
   dmarc-urilist = dmarc-uri *(*WSP "," *WSP dmarc-uri)
 
-  dmarc-fo      = "0" / "0:d" / "0:d:s"
-                      / "0:s" / "0:s:d"
-                / "1" / "1:d" / "1:d:s"
-                      / "1:s" / "1:s:d"
-                / "d" / "d:0" / "d:0:s"
-                      / "d:1" / "d:1:s"
-                      / "d:s" / "d:s:0"
-                              / "d:s:1"
-                / "s" / "s:0" / "s:0:d"
-                      / "s:1" / "s:1:d"
-                      / "s:d" / "s:d:0"
-                              / "s:d:1"
+  dmarc-fo      = ("0" / "1") *(":" dmarc-afrf)
+                / dmarc-afrf [":" ("0" / "1")] [":" dmarc-afrf]
+                / *(dmarc-afrf ":") ("0" / "1")
 
+  dmarc-afrf    = "d" / "s"
+                ; each may appear at most once in dmarc-fo
 ~~~
 
 In each dmarc-tag, the dmarc-value has a syntax that depends on the tag name.

--- a/draft-ietf-dmarc-dmarcbis.md
+++ b/draft-ietf-dmarc-dmarcbis.md
@@ -820,7 +820,9 @@ and [@!RFC7405], is as follows:
 
   dmarc-urilist = dmarc-uri *(*WSP "," *WSP dmarc-uri)
 
-  dmarc-fo      = "0" / "1" / "d" / "s" / "d:s" / "s:d" / "0:d" / "0:s" / "0:s:d" / "0:d:s" / "1:d" / "1:s" / "1:s:d" / "1:d:s" 
+  dmarc-fo      = "0" / "1" / "d" / "s" / "d:s" / "s:d"
+                / "0:d" / "0:s" / "0:d:s" / "0:s:d"
+                / "1:d" / "1:s" / "1:d:s" / "1:s:d"
 
 ~~~
 

--- a/draft-ietf-dmarc-dmarcbis.md
+++ b/draft-ietf-dmarc-dmarcbis.md
@@ -820,9 +820,18 @@ and [@!RFC7405], is as follows:
 
   dmarc-urilist = dmarc-uri *(*WSP "," *WSP dmarc-uri)
 
-  dmarc-fo      = "0" / "1" / "d" / "s" / "d:s" / "s:d"
-                / "0:d" / "0:s" / "0:d:s" / "0:s:d"
-                / "1:d" / "1:s" / "1:d:s" / "1:s:d"
+  dmarc-fo      = "0" / "0:d" / "0:d:s"
+                      / "0:s" / "0:s:d"
+                / "1" / "1:d" / "1:d:s"
+                      / "1:s" / "1:s:d"
+                / "d" / "d:0" / "d:0:s"
+                      / "d:1" / "d:1:s"
+                      / "d:s" / "d:s:0"
+                              / "d:s:1"
+                / "s" / "s:0" / "s:0:d"
+                      / "s:1" / "s:1:d"
+                      / "s:d" / "s:d:0"
+                              / "s:d:1"
 
 ~~~
 

--- a/draft-ietf-dmarc-dmarcbis.md
+++ b/draft-ietf-dmarc-dmarcbis.md
@@ -796,6 +796,10 @@ and [@!RFC7405], is as follows:
                 ; points (ASCII 0x21) MUST be 
                 ; encoded
 
+  obs-dmarc-uri = dmarc-uri "!" 1*DIGIT [ "k" / "m" / "g" / "t" ]
+                ; Obsolete syntax, reporters should ignore the
+                ; size if it is found in a DMARC Policy Record.
+
   dmarc-sep     = *WSP ";" *WSP
 
   equals        = *WSP "=" *WSP
@@ -818,7 +822,8 @@ and [@!RFC7405], is as follows:
 
   dmarc-rors    = "r" / "s"
 
-  dmarc-urilist = dmarc-uri *(*WSP "," *WSP dmarc-uri)
+  dmarc-urilist = ( dmarc-uri *(*WSP "," *WSP dmarc-uri) )
+                / ( obs-dmarc-uri *(*WSP "," *WSP obs-dmarc-uri) )
 
   dmarc-fo      = ("0" / "1") *(":" dmarc-afrf)
                 / dmarc-afrf [":" ("0" / "1")] [":" dmarc-afrf]

--- a/draft-ietf-dmarc-dmarcbis.md
+++ b/draft-ietf-dmarc-dmarcbis.md
@@ -2835,7 +2835,7 @@ The DNS Tree Walk also incorporates PSD policy discovery, which was introduced i
 that the RFC was not implemented as written. Instead, this document redefines the 
 algorithm for PSD policy discovery, and thus obsoletes [@RFC9091]. Specifically, the 
 DNS Tree Walk defined in this document obviates the need for a PSD DMARC registry,
-and that PSD DMARC regisry is what made RFC 9091 and Experimental RFC.
+and that PSD DMARC registry is what made RFC 9091 an Experimental RFC.
 
 These algorithm changes introduce the possibility of interoperability issues where a
 Domain Owner expects a DMARC Policy Record or an Organizational Domain to be identified by

--- a/draft-ietf-dmarc-dmarcbis.md
+++ b/draft-ietf-dmarc-dmarcbis.md
@@ -622,7 +622,6 @@ also specified. This tag can include one or more of the values shown here,
 with the exception that "0" and "1" are mutually exclusive. If more than one
 value is assigned to the tag, the list of values should be separated by colons 
 (e.g., fo=0:d), and the values may appear in the list in any order.
-
 The valid values and their meanings are:
 
     0:


### PR DESCRIPTION
Changes to ABNF for dmarc-fo and dmarc-urilist, adding the new obs-dmarc-uri
dmarc-fo going through a few iterations before arriving at the final result.
Remove an empty line to help definitions render properly, as well as some typos.